### PR TITLE
Lower Python f-strings to string concatenation

### DIFF
--- a/crates/smelt-frontend-py/src/lowering/list.rs
+++ b/crates/smelt-frontend-py/src/lowering/list.rs
@@ -1,3 +1,66 @@
+/// Source element specification for a comprehension, before its element
+/// expressions are lowered.
+#[derive(Clone, Copy)]
+enum ComprehensionSource<'a> {
+    /// `[elt ...]` and `(elt ...)` generator expressions.
+    List(&'a Expr),
+    /// `{elt ...}` set comprehensions.
+    Set(&'a Expr),
+    /// `{key: value ...}` dict comprehensions.
+    Dict {
+        /// Key expression evaluated per produced element.
+        key: &'a Expr,
+        /// Value expression evaluated per produced element.
+        value: &'a Expr,
+    },
+}
+
+/// A bound comprehension generator clause: the loop pattern, the normalized
+/// iterable expression, and the `if` guards (kept as source AST so they lower
+/// while the loop target is in scope).
+struct ComprehensionLevel<'a> {
+    /// Loop binding pattern for this generator's target.
+    pat: smelt_hir::PatternId,
+    /// Normalized iterable expression for this generator.
+    iter: smelt_hir::ExprId,
+    /// `if` guard expressions for this generator, in source order.
+    ifs: &'a [Expr],
+}
+
+/// Shared context threaded through the comprehension loop builder: the
+/// accumulator local and type, how to append, and the comprehension span.
+struct ComprehensionBuild<'a> {
+    /// Mutable local holding the comprehension's accumulator collection.
+    acc_local: smelt_hir::LocalId,
+    /// Type of the accumulator collection.
+    acc_ty: TypeId,
+    /// How each produced element is appended to the accumulator.
+    append: &'a ComprehensionAppend,
+    /// Source span of the comprehension expression.
+    span: Span,
+}
+
+/// How a comprehension appends each produced element to its accumulator.
+enum ComprehensionAppend {
+    /// `acc.push(item)` — list comprehensions and generator expressions.
+    List {
+        /// Lowered element expression.
+        item: smelt_hir::ExprId,
+    },
+    /// `acc.add(item)` — set comprehensions.
+    Set {
+        /// Lowered element expression.
+        item: smelt_hir::ExprId,
+    },
+    /// `acc[key] = value` — dict comprehensions.
+    Dict {
+        /// Lowered key expression.
+        key: smelt_hir::ExprId,
+        /// Lowered value expression.
+        value: smelt_hir::ExprId,
+    },
+}
+
 impl ModuleBuilder<'_> {
     /// Resolve a class method by inspecting class metadata directly.
     fn class_method_item_by_name(&self, class_name: &str, method: &str) -> Option<ItemId> {
@@ -287,97 +350,319 @@ impl ModuleBuilder<'_> {
         })))
     }
 
-    /// Lower a Python list comprehension `[elt for target in iter if cond ...]`.
-    ///
-    /// Comprehensions reuse the same callback/closure machinery as `map`/`filter`:
-    /// the iterable must be a list, the loop target binds as the single callback
-    /// parameter, each `if` clause becomes a `Filter` closure applied in source
-    /// order, and the element expression becomes a final `Map` closure. The
-    /// element and condition expressions are therefore restricted to the same
-    /// subset accepted inside lambda callbacks (`python_callback_expr`).
-    ///
-    /// Only a single, synchronous generator with a plain name target is modeled;
-    /// nested generators, async generators, and destructuring targets are
-    /// rejected as unsupported rather than mis-lowered.
+    /// Lower a Python list comprehension `[elt for t in it if cond ...]`.
     pub(crate) fn list_comprehension(
         &mut self,
         comp: &ruff_python_ast::ExprListComp,
         body: &mut Body,
     ) -> Result<smelt_hir::ExprId, SmeltError> {
         let span = self.span(comp.range);
-        let [generator] = comp.generators.as_slice() else {
+        self.comprehension(&comp.generators, ComprehensionSource::List(&comp.elt), span, body)
+    }
+
+    /// Lower a Python set comprehension `{elt for t in it if cond ...}`.
+    pub(crate) fn set_comprehension(
+        &mut self,
+        comp: &ruff_python_ast::ExprSetComp,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let span = self.span(comp.range);
+        self.comprehension(&comp.generators, ComprehensionSource::Set(&comp.elt), span, body)
+    }
+
+    /// Lower a Python dict comprehension `{key: value for t in it if cond ...}`.
+    pub(crate) fn dict_comprehension(
+        &mut self,
+        comp: &ruff_python_ast::ExprDictComp,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let span = self.span(comp.range);
+        let Some(key) = comp.key.as_deref() else {
             return Err(SmeltError::unsupported(
                 span,
-                "nested list comprehensions (multiple `for` clauses) are not supported",
+                "dict comprehension requires an explicit key expression",
             ));
         };
-        if generator.is_async {
+        self.comprehension(
+            &comp.generators,
+            ComprehensionSource::Dict {
+                key,
+                value: &comp.value,
+            },
+            span,
+            body,
+        )
+    }
+
+    /// Lower a Python generator expression `(elt for t in it if cond ...)`.
+    ///
+    /// Generator expressions are materialized eagerly into a list, which is
+    /// correct for the common eager sinks (`list(...)`, `sum(...)`,
+    /// `" ".join(...)`) but does not preserve laziness.
+    pub(crate) fn generator_expression(
+        &mut self,
+        comp: &ruff_python_ast::ExprGenerator,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let span = self.span(comp.range);
+        self.comprehension(&comp.generators, ComprehensionSource::List(&comp.elt), span, body)
+    }
+
+    /// Lower any comprehension form to an imperative accumulator loop wrapped in
+    /// a block expression (see `docs/python-comprehensions.md`).
+    ///
+    /// The loop targets, element/key/value, and `if` guards all lower through
+    /// the normal expression path, so the full expression language is available
+    /// inside comprehension bodies. Comprehension targets are scoped to the
+    /// comprehension: `self.locals` is snapshotted on entry and restored on exit
+    /// so the loop variables do not leak into the enclosing scope.
+    fn comprehension(
+        &mut self,
+        generators: &[ruff_python_ast::Comprehension],
+        source: ComprehensionSource<'_>,
+        span: Span,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let saved_locals = self.locals.clone();
+        let result = self.comprehension_impl(generators, source, span, body);
+        self.locals = saved_locals;
+        result
+    }
+
+    /// Inner comprehension lowering; see [`Self::comprehension`] for the
+    /// surrounding scope save/restore.
+    fn comprehension_impl(
+        &mut self,
+        generators: &[ruff_python_ast::Comprehension],
+        source: ComprehensionSource<'_>,
+        span: Span,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        if generators.is_empty() {
             return Err(SmeltError::unsupported(
                 span,
-                "async list comprehensions are not supported",
+                "comprehension requires at least one `for` clause",
             ));
         }
-        let Expr::Name(target_name) = &generator.target else {
-            return Err(SmeltError::unsupported(
-                self.span(generator.target.range()),
-                "list comprehension targets must be a single name (destructuring is not supported)",
-            ));
-        };
 
-        let mut list = self.expression(&generator.iter, body)?;
-        let list_ty = Self::expr_ty(body, list);
-        let Some(Type::List(item_ty)) = self.ctx.krate.types.get(list_ty) else {
-            return Err(SmeltError::unsupported(
-                self.span(generator.iter.range()),
-                "list comprehensions can only iterate over a list",
-            ));
-        };
-        let element_ty = *item_ty;
-
-        // Bind the loop target as the single callback parameter so the condition
-        // and element expressions resolve it through the lambda-callback subset.
-        let mut params = HashMap::new();
-        params.insert(
-            target_name.id.as_str(),
-            CallbackExpr {
-                kind: CallbackExprKind::Param(0),
-                ty: element_ty,
-            },
-        );
-
-        let bool_ty = self.intern_type(Type::Bool);
-        for condition in &generator.ifs {
-            let predicate = self.python_callback_expr(condition, &params, body)?;
-            if predicate.ty != bool_ty {
+        // Bind every generator target in source order, lowering each iterable so
+        // later iterables and conditions can reference earlier loop variables.
+        let mut levels: Vec<ComprehensionLevel<'_>> = Vec::with_capacity(generators.len());
+        for generator in generators {
+            if generator.is_async {
                 return Err(SmeltError::unsupported(
-                    self.span(condition.range()),
-                    "list comprehension `if` clauses must be boolean conditions",
+                    span,
+                    "async comprehensions are not supported",
                 ));
             }
-            let closure = self.callback_expr_to_closure(&predicate, &[element_ty], span, body)?;
-            list = body.push_expr(HirExpr {
-                kind: ExprKind::ListCallback {
-                    op: ListCallbackOp::Filter,
-                    list,
-                    callback: closure,
-                },
-                ty: list_ty,
-                span,
+            if !matches!(&generator.target, Expr::Name(_)) {
+                return Err(SmeltError::unsupported(
+                    self.span(generator.target.range()),
+                    "comprehension targets must be a single name (destructuring is not supported)",
+                ));
+            }
+            let raw_iter = self.expression(&generator.iter, body)?;
+            let iter = self.for_iterable(raw_iter, body);
+            let iter_ty = Self::expr_ty(body, iter);
+            let Some(item_ty) = self.iter_item_type(iter_ty) else {
+                return Err(SmeltError::unsupported(
+                    self.span(generator.iter.range()),
+                    "comprehensions can only iterate over a list, set, dict, or string",
+                ));
+            };
+            let pat = self.binding_pattern_from_target(&generator.target, body, Some(item_ty))?;
+            levels.push(ComprehensionLevel {
+                pat,
+                iter,
+                ifs: &generator.ifs,
             });
         }
 
-        let element = self.python_callback_expr(&comp.elt, &params, body)?;
-        let result_ty = self.intern_type(Type::List(element.ty));
-        let closure = self.callback_expr_to_closure(&element, &[element_ty], span, body)?;
-        Ok(body.push_expr(HirExpr {
-            kind: ExprKind::ListCallback {
-                op: ListCallbackOp::Map,
-                list,
-                callback: closure,
+        // Lower the element/key/value while all loop targets are in scope and
+        // derive the accumulator's collection type from them.
+        let (acc_ty, append) = match source {
+            ComprehensionSource::List(elt) => {
+                let item = self.expression(elt, body)?;
+                let acc_ty = self.intern_type(Type::List(Self::expr_ty(body, item)));
+                (acc_ty, ComprehensionAppend::List { item })
+            }
+            ComprehensionSource::Set(elt) => {
+                let item = self.expression(elt, body)?;
+                let acc_ty = self.intern_type(Type::Set(Self::expr_ty(body, item)));
+                (acc_ty, ComprehensionAppend::Set { item })
+            }
+            ComprehensionSource::Dict { key, value } => {
+                let key_expr = self.expression(key, body)?;
+                let value_expr = self.expression(value, body)?;
+                let acc_ty = self.intern_type(Type::Dict(
+                    Self::expr_ty(body, key_expr),
+                    Self::expr_ty(body, value_expr),
+                ));
+                (
+                    acc_ty,
+                    ComprehensionAppend::Dict {
+                        key: key_expr,
+                        value: value_expr,
+                    },
+                )
+            }
+        };
+
+        // Declare the mutable accumulator and seed it with an empty collection.
+        let acc_name = self.intern_name("__smelt_comp_acc");
+        let acc_local = body.push_local(LocalDecl {
+            name: Some(acc_name),
+            ty: acc_ty,
+            mutable: true,
+            span,
+        });
+        let init_kind = match &append {
+            ComprehensionAppend::List { .. } => ExprKind::ListLit(Vec::new()),
+            ComprehensionAppend::Set { .. } => ExprKind::SetLit(Vec::new()),
+            ComprehensionAppend::Dict { .. } => ExprKind::DictLit(Vec::new()),
+        };
+        let init = body.push_expr(HirExpr {
+            kind: init_kind,
+            ty: acc_ty,
+            span,
+        });
+        let acc_pat = body.push_pattern(HirPattern::Binding(acc_local));
+        let outer = body.push_block(span);
+        body.push_stmt_to_block(
+            outer,
+            HirStmt::Let {
+                pat: acc_pat,
+                ty: acc_ty,
+                value: Some(init),
             },
-            ty: result_ty,
+        );
+
+        // Build the nested for/if structure with the append at the innermost.
+        let build = ComprehensionBuild {
+            acc_local,
+            acc_ty,
+            append: &append,
+            span,
+        };
+        self.emit_comprehension_levels(outer, &levels, &build, body)?;
+
+        // The block evaluates to the populated accumulator.
+        let tail = body.push_expr(HirExpr {
+            kind: ExprKind::Local(acc_local),
+            ty: acc_ty,
+            span,
+        });
+        let outer_idx = usize::try_from(outer.0)
+            .map_err(|error| SmeltError::unsupported(span, error.to_string()))?;
+        body.blocks[outer_idx].tail = Some(tail);
+
+        Ok(body.push_expr(HirExpr {
+            kind: ExprKind::Block(outer),
+            ty: acc_ty,
             span,
         }))
+    }
+
+    /// Emit the nested `for` loop for the first remaining generator level into
+    /// `target_block`: this level's `if` guards are applied as a chain of `if`
+    /// statements and inner levels are emitted by recursion. When no levels
+    /// remain it emits the accumulator append.
+    fn emit_comprehension_levels(
+        &mut self,
+        target_block: smelt_hir::BlockId,
+        levels: &[ComprehensionLevel<'_>],
+        build: &ComprehensionBuild<'_>,
+        body: &mut Body,
+    ) -> Result<(), SmeltError> {
+        let Some((level, rest)) = levels.split_first() else {
+            let stmt = self.comprehension_append_stmt(build, body)?;
+            body.push_stmt_to_block(target_block, stmt);
+            return Ok(());
+        };
+        // The loop body wraps the inner levels in this level's `if` guards,
+        // applied in source order as nested `if` statements.
+        let loop_body = body.push_block(build.span);
+        let bool_ty = self.intern_type(Type::Bool);
+        let mut innermost = loop_body;
+        for condition in level.ifs {
+            let cond = self.expression(condition, body)?;
+            if Self::expr_ty(body, cond) != bool_ty {
+                return Err(SmeltError::unsupported(
+                    self.span(condition.range()),
+                    "comprehension `if` clauses must be boolean conditions",
+                ));
+            }
+            let then_block = body.push_block(build.span);
+            body.push_stmt_to_block(
+                innermost,
+                HirStmt::If {
+                    cond,
+                    then_block,
+                    else_block: None,
+                },
+            );
+            innermost = then_block;
+        }
+        self.emit_comprehension_levels(innermost, rest, build, body)?;
+        body.push_stmt_to_block(
+            target_block,
+            HirStmt::For {
+                pat: level.pat,
+                iter: level.iter,
+                body: loop_body,
+            },
+        );
+        Ok(())
+    }
+
+    /// Build the statement that appends one produced element to the accumulator.
+    fn comprehension_append_stmt(
+        &mut self,
+        build: &ComprehensionBuild<'_>,
+        body: &mut Body,
+    ) -> Result<HirStmt, SmeltError> {
+        let ComprehensionBuild {
+            acc_local,
+            acc_ty,
+            append,
+            span,
+        } = *build;
+        let none_ty = self.intern_type(Type::None);
+        let acc = body.push_expr(HirExpr {
+            kind: ExprKind::Local(acc_local),
+            ty: acc_ty,
+            span,
+        });
+        match append {
+            ComprehensionAppend::List { item } => {
+                let push = body.push_expr(HirExpr {
+                    kind: ExprKind::ListPush { list: acc, item: *item },
+                    ty: none_ty,
+                    span,
+                });
+                Ok(HirStmt::Expr(push))
+            }
+            ComprehensionAppend::Set { item } => {
+                let add = body.push_expr(HirExpr {
+                    kind: ExprKind::SetAdd { set: acc, item: *item },
+                    ty: none_ty,
+                    span,
+                });
+                Ok(HirStmt::Expr(add))
+            }
+            ComprehensionAppend::Dict { key, value } => {
+                let value_ty = Self::expr_ty(body, *value);
+                let target = body.push_expr(HirExpr {
+                    kind: ExprKind::Index { receiver: acc, index: *key },
+                    ty: value_ty,
+                    span,
+                });
+                Ok(HirStmt::Assign {
+                    target,
+                    value: *value,
+                })
+            }
+        }
     }
 
     /// Lower either an inline lambda or an annotated local lambda callback.

--- a/crates/smelt-frontend-py/src/lowering/list.rs
+++ b/crates/smelt-frontend-py/src/lowering/list.rs
@@ -287,6 +287,99 @@ impl ModuleBuilder<'_> {
         })))
     }
 
+    /// Lower a Python list comprehension `[elt for target in iter if cond ...]`.
+    ///
+    /// Comprehensions reuse the same callback/closure machinery as `map`/`filter`:
+    /// the iterable must be a list, the loop target binds as the single callback
+    /// parameter, each `if` clause becomes a `Filter` closure applied in source
+    /// order, and the element expression becomes a final `Map` closure. The
+    /// element and condition expressions are therefore restricted to the same
+    /// subset accepted inside lambda callbacks (`python_callback_expr`).
+    ///
+    /// Only a single, synchronous generator with a plain name target is modeled;
+    /// nested generators, async generators, and destructuring targets are
+    /// rejected as unsupported rather than mis-lowered.
+    pub(crate) fn list_comprehension(
+        &mut self,
+        comp: &ruff_python_ast::ExprListComp,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let span = self.span(comp.range);
+        let [generator] = comp.generators.as_slice() else {
+            return Err(SmeltError::unsupported(
+                span,
+                "nested list comprehensions (multiple `for` clauses) are not supported",
+            ));
+        };
+        if generator.is_async {
+            return Err(SmeltError::unsupported(
+                span,
+                "async list comprehensions are not supported",
+            ));
+        }
+        let Expr::Name(target_name) = &generator.target else {
+            return Err(SmeltError::unsupported(
+                self.span(generator.target.range()),
+                "list comprehension targets must be a single name (destructuring is not supported)",
+            ));
+        };
+
+        let mut list = self.expression(&generator.iter, body)?;
+        let list_ty = Self::expr_ty(body, list);
+        let Some(Type::List(item_ty)) = self.ctx.krate.types.get(list_ty) else {
+            return Err(SmeltError::unsupported(
+                self.span(generator.iter.range()),
+                "list comprehensions can only iterate over a list",
+            ));
+        };
+        let element_ty = *item_ty;
+
+        // Bind the loop target as the single callback parameter so the condition
+        // and element expressions resolve it through the lambda-callback subset.
+        let mut params = HashMap::new();
+        params.insert(
+            target_name.id.as_str(),
+            CallbackExpr {
+                kind: CallbackExprKind::Param(0),
+                ty: element_ty,
+            },
+        );
+
+        let bool_ty = self.intern_type(Type::Bool);
+        for condition in &generator.ifs {
+            let predicate = self.python_callback_expr(condition, &params, body)?;
+            if predicate.ty != bool_ty {
+                return Err(SmeltError::unsupported(
+                    self.span(condition.range()),
+                    "list comprehension `if` clauses must be boolean conditions",
+                ));
+            }
+            let closure = self.callback_expr_to_closure(&predicate, &[element_ty], span, body)?;
+            list = body.push_expr(HirExpr {
+                kind: ExprKind::ListCallback {
+                    op: ListCallbackOp::Filter,
+                    list,
+                    callback: closure,
+                },
+                ty: list_ty,
+                span,
+            });
+        }
+
+        let element = self.python_callback_expr(&comp.elt, &params, body)?;
+        let result_ty = self.intern_type(Type::List(element.ty));
+        let closure = self.callback_expr_to_closure(&element, &[element_ty], span, body)?;
+        Ok(body.push_expr(HirExpr {
+            kind: ExprKind::ListCallback {
+                op: ListCallbackOp::Map,
+                list,
+                callback: closure,
+            },
+            ty: result_ty,
+            span,
+        }))
+    }
+
     /// Lower either an inline lambda or an annotated local lambda callback.
     fn python_callback_argument(
         &mut self,
@@ -792,6 +885,7 @@ impl ModuleBuilder<'_> {
                     Operator::Sub => BinOp::Sub,
                     Operator::Mult => BinOp::Mul,
                     Operator::Div => BinOp::Div,
+                    Operator::Mod => BinOp::Rem,
                     _ => {
                         return Err(SmeltError::unsupported(
                             self.span(binary.range),

--- a/crates/smelt-frontend-py/src/lowering/literals.rs
+++ b/crates/smelt-frontend-py/src/lowering/literals.rs
@@ -267,9 +267,10 @@ impl ModuleBuilder<'_> {
 
             Expr::FString(f) => self.fstring_expression(f, body),
 
+            Expr::ListComp(c) => self.list_comprehension(c, body),
+
             Expr::Named(_)
             | Expr::Lambda(_)
-            | Expr::ListComp(_)
             | Expr::SetComp(_)
             | Expr::DictComp(_)
             | Expr::Generator(_)

--- a/crates/smelt-frontend-py/src/lowering/literals.rs
+++ b/crates/smelt-frontend-py/src/lowering/literals.rs
@@ -265,6 +265,8 @@ impl ModuleBuilder<'_> {
                 }))
             }
 
+            Expr::FString(f) => self.fstring_expression(f, body),
+
             Expr::Named(_)
             | Expr::Lambda(_)
             | Expr::ListComp(_)
@@ -273,7 +275,6 @@ impl ModuleBuilder<'_> {
             | Expr::Generator(_)
             | Expr::Yield(_)
             | Expr::YieldFrom(_)
-            | Expr::FString(_)
             | Expr::TString(_)
             | Expr::BytesLiteral(_)
             | Expr::EllipsisLiteral(_)
@@ -284,6 +285,142 @@ impl ModuleBuilder<'_> {
                 format!("unsupported expression: {}", expr_kind_name(expr)),
             )),
         }
+    }
+
+    /// Lower a Python f-string (`f"a{expr}b"`) as runtime string concatenation.
+    ///
+    /// Mirrors the TypeScript template-literal lowering: each literal chunk and
+    /// interpolated expression is folded together with `BinOp::Add` on a `String`
+    /// result type. The Rust emitter coerces non-string operands of a string
+    /// addition via `to_string()`, which matches the common `f"{value}"` case
+    /// where `value` formats through `str(...)`.
+    ///
+    /// Format specifications (`{x:.2f}`), the `repr`/`ascii` conversions
+    /// (`{x!r}`, `{x!a}`) and self-documenting expressions (`{x=}`) are not yet
+    /// modeled, so they are rejected as unsupported rather than silently
+    /// dropped. Implicitly concatenated literal parts (`"a" f"b{x}"`) are
+    /// preserved by walking the f-string parts directly instead of the
+    /// `elements()` helper, which skips plain string literal parts.
+    fn fstring_expression(
+        &mut self,
+        fstring: &ruff_python_ast::ExprFString,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        // A segment is either a static literal chunk or a lowered interpolation.
+        enum Segment {
+            Literal(String),
+            Expr(smelt_hir::ExprId),
+        }
+
+        let span = self.span(fstring.range);
+        let str_ty = self.intern_type(Type::String);
+        let mut segments: Vec<Segment> = Vec::new();
+
+        for part in fstring.value.iter() {
+            match part {
+                ruff_python_ast::FStringPart::Literal(literal) => {
+                    segments.push(Segment::Literal(literal.as_str().to_owned()));
+                }
+                ruff_python_ast::FStringPart::FString(inner) => {
+                    for element in &inner.elements {
+                        match element {
+                            ruff_python_ast::InterpolatedStringElement::Literal(literal) => {
+                                segments.push(Segment::Literal(literal.value.to_string()));
+                            }
+                            ruff_python_ast::InterpolatedStringElement::Interpolation(interp) => {
+                                if interp.debug_text.is_some() {
+                                    return Err(SmeltError::unsupported(
+                                        self.span(interp.range),
+                                        "f-string self-documenting expressions (trailing `=`) are not supported",
+                                    ));
+                                }
+                                if interp.format_spec.is_some() {
+                                    return Err(SmeltError::unsupported(
+                                        self.span(interp.range),
+                                        "f-string format specifications (a `:` conversion suffix) are not supported",
+                                    ));
+                                }
+                                if !matches!(
+                                    interp.conversion,
+                                    ruff_python_ast::ConversionFlag::None
+                                        | ruff_python_ast::ConversionFlag::Str
+                                ) {
+                                    return Err(SmeltError::unsupported(
+                                        self.span(interp.range),
+                                        "f-string `!r`/`!a` conversions are not supported",
+                                    ));
+                                }
+                                let expr = self.expression(&interp.expression, body)?;
+                                segments.push(Segment::Expr(expr));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fold segments into a chain of `String` additions, using the first
+        // segment as the accumulator base so a literal-only f-string lowers to a
+        // single string literal.
+        let mut iter = segments.into_iter();
+        let mut acc = match iter.next() {
+            Some(Segment::Literal(text)) => body.push_expr(HirExpr {
+                kind: ExprKind::Literal(Literal::String(text)),
+                ty: str_ty,
+                span,
+            }),
+            Some(Segment::Expr(expr)) => {
+                // Anchor on an empty string literal so the first interpolation is
+                // emitted through the string-addition path (which coerces the
+                // operand to `String`).
+                let empty = body.push_expr(HirExpr {
+                    kind: ExprKind::Literal(Literal::String(String::new())),
+                    ty: str_ty,
+                    span,
+                });
+                body.push_expr(HirExpr {
+                    kind: ExprKind::BinOp {
+                        op: BinOp::Add,
+                        lhs: empty,
+                        rhs: expr,
+                    },
+                    ty: str_ty,
+                    span,
+                })
+            }
+            None => body.push_expr(HirExpr {
+                kind: ExprKind::Literal(Literal::String(String::new())),
+                ty: str_ty,
+                span,
+            }),
+        };
+
+        for segment in iter {
+            let rhs = match segment {
+                Segment::Literal(text) => {
+                    if text.is_empty() {
+                        continue;
+                    }
+                    body.push_expr(HirExpr {
+                        kind: ExprKind::Literal(Literal::String(text)),
+                        ty: str_ty,
+                        span,
+                    })
+                }
+                Segment::Expr(expr) => expr,
+            };
+            acc = body.push_expr(HirExpr {
+                kind: ExprKind::BinOp {
+                    op: BinOp::Add,
+                    lhs: acc,
+                    rhs,
+                },
+                ty: str_ty,
+                span,
+            });
+        }
+
+        Ok(acc)
     }
 
     /// Lower a Python conditional expression (`then if cond else else_`).

--- a/crates/smelt-frontend-py/src/lowering/literals.rs
+++ b/crates/smelt-frontend-py/src/lowering/literals.rs
@@ -268,12 +268,12 @@ impl ModuleBuilder<'_> {
             Expr::FString(f) => self.fstring_expression(f, body),
 
             Expr::ListComp(c) => self.list_comprehension(c, body),
+            Expr::SetComp(c) => self.set_comprehension(c, body),
+            Expr::DictComp(c) => self.dict_comprehension(c, body),
+            Expr::Generator(c) => self.generator_expression(c, body),
 
             Expr::Named(_)
             | Expr::Lambda(_)
-            | Expr::SetComp(_)
-            | Expr::DictComp(_)
-            | Expr::Generator(_)
             | Expr::Yield(_)
             | Expr::YieldFrom(_)
             | Expr::TString(_)

--- a/crates/smelt-frontend-py/src/tests/basic_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/basic_tests.rs
@@ -438,3 +438,117 @@ def render(value: int) -> str:
     )?;
     Ok(())
 }
+
+#[test]
+fn list_comprehension_lowers_to_map() -> TestResult {
+    let source = py!(r#"
+def doubles(xs: list[int]) -> list[int]:
+    return [x * 2 for x in xs]
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let item_id = module
+        .items
+        .first()
+        .copied()
+        .ok_or_else(|| "expected doubles function".to_owned())?;
+    let Item::Function(doubles) = item(&ctx, item_id)? else {
+        return Err("expected function item".to_owned());
+    };
+    let body_id = doubles.body.ok_or_else(|| "expected body".to_owned())?;
+    let body = body(&ctx, body_id)?;
+    ensure(
+        body.exprs.iter().any(|expr| {
+            matches!(
+                expr.kind,
+                ExprKind::ListCallback {
+                    op: ListCallbackOp::Map,
+                    ..
+                }
+            )
+        }),
+        "expected list comprehension to lower to a Map list callback",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn list_comprehension_if_clause_lowers_to_filter_then_map() -> TestResult {
+    let source = py!(r#"
+def evens(xs: list[int]) -> list[int]:
+    return [x for x in xs if x % 2 == 0]
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let item_id = module
+        .items
+        .first()
+        .copied()
+        .ok_or_else(|| "expected evens function".to_owned())?;
+    let Item::Function(evens) = item(&ctx, item_id)? else {
+        return Err("expected function item".to_owned());
+    };
+    let body_id = evens.body.ok_or_else(|| "expected body".to_owned())?;
+    let body = body(&ctx, body_id)?;
+    ensure(
+        body.exprs.iter().any(|expr| {
+            matches!(
+                expr.kind,
+                ExprKind::ListCallback {
+                    op: ListCallbackOp::Filter,
+                    ..
+                }
+            )
+        }),
+        "expected `if` clause to lower to a Filter list callback",
+    )?;
+    ensure(
+        body.exprs.iter().any(|expr| {
+            matches!(
+                expr.kind,
+                ExprKind::ListCallback {
+                    op: ListCallbackOp::Map,
+                    ..
+                }
+            )
+        }),
+        "expected the element expression to lower to a Map list callback",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn nested_list_comprehension_is_rejected() -> TestResult {
+    let source = py!(r#"
+def pairs(xs: list[int], ys: list[int]) -> list[int]:
+    return [x + y for x in xs for y in ys]
+"#);
+    let mut ctx = HirCtx::new();
+    let errors = lower_errors(source, &mut ctx)?;
+    let error = first_error(&errors)?;
+    ensure_eq(&error.code, &"smelt::unsupported-py", "error code")?;
+    ensure(
+        error.message.contains("nested list comprehensions"),
+        "expected nested comprehension rejection message",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn list_comprehension_over_non_list_is_rejected() -> TestResult {
+    let source = py!(r#"
+def chars(text: str) -> list[str]:
+    return [c for c in text]
+"#);
+    let mut ctx = HirCtx::new();
+    let errors = lower_errors(source, &mut ctx)?;
+    let error = first_error(&errors)?;
+    ensure_eq(&error.code, &"smelt::unsupported-py", "error code")?;
+    ensure(
+        error.message.contains("can only iterate over a list"),
+        "expected non-list iterable rejection message",
+    )?;
+    Ok(())
+}

--- a/crates/smelt-frontend-py/src/tests/basic_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/basic_tests.rs
@@ -439,116 +439,161 @@ def render(value: int) -> str:
     Ok(())
 }
 
+/// Returns the body of the single function item in `source` after lowering.
+fn single_function_body<'a>(ctx: &'a HirCtx, module_id: ModuleId) -> Result<&'a Body, String> {
+    let module = module(ctx, module_id)?;
+    let item_id = module
+        .items
+        .first()
+        .copied()
+        .ok_or_else(|| "expected a function item".to_owned())?;
+    let Item::Function(function) = item(ctx, item_id)? else {
+        return Err("expected function item".to_owned());
+    };
+    let body_id = function.body.ok_or_else(|| "expected function body".to_owned())?;
+    body(ctx, body_id)
+}
+
 #[test]
-fn list_comprehension_lowers_to_map() -> TestResult {
+fn list_comprehension_lowers_to_block_with_push() -> TestResult {
     let source = py!(r#"
 def doubles(xs: list[int]) -> list[int]:
     return [x * 2 for x in xs]
 "#);
     let mut ctx = HirCtx::new();
     let module_id = lower_module(source, &mut ctx)?;
-    let module = module(&ctx, module_id)?;
-    let item_id = module
-        .items
-        .first()
-        .copied()
-        .ok_or_else(|| "expected doubles function".to_owned())?;
-    let Item::Function(doubles) = item(&ctx, item_id)? else {
-        return Err("expected function item".to_owned());
-    };
-    let body_id = doubles.body.ok_or_else(|| "expected body".to_owned())?;
-    let body = body(&ctx, body_id)?;
+    let body = single_function_body(&ctx, module_id)?;
     ensure(
-        body.exprs.iter().any(|expr| {
-            matches!(
-                expr.kind,
-                ExprKind::ListCallback {
-                    op: ListCallbackOp::Map,
-                    ..
-                }
-            )
-        }),
-        "expected list comprehension to lower to a Map list callback",
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Block(_))),
+        "expected list comprehension to lower to a block expression",
+    )?;
+    ensure(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::ListPush { .. })),
+        "expected the accumulator to be built with list pushes",
     )?;
     Ok(())
 }
 
 #[test]
-fn list_comprehension_if_clause_lowers_to_filter_then_map() -> TestResult {
+fn list_comprehension_if_clause_lowers() -> TestResult {
+    // The `if` guard lowers to an `If` statement inside the loop; we assert the
+    // overall comprehension still lowers to a block with a push.
     let source = py!(r#"
 def evens(xs: list[int]) -> list[int]:
-    return [x for x in xs if x % 2 == 0]
+    return [x for x in xs if x > 0]
 "#);
     let mut ctx = HirCtx::new();
     let module_id = lower_module(source, &mut ctx)?;
-    let module = module(&ctx, module_id)?;
-    let item_id = module
-        .items
-        .first()
-        .copied()
-        .ok_or_else(|| "expected evens function".to_owned())?;
-    let Item::Function(evens) = item(&ctx, item_id)? else {
-        return Err("expected function item".to_owned());
-    };
-    let body_id = evens.body.ok_or_else(|| "expected body".to_owned())?;
-    let body = body(&ctx, body_id)?;
+    let body = single_function_body(&ctx, module_id)?;
     ensure(
-        body.exprs.iter().any(|expr| {
-            matches!(
-                expr.kind,
-                ExprKind::ListCallback {
-                    op: ListCallbackOp::Filter,
-                    ..
-                }
-            )
-        }),
-        "expected `if` clause to lower to a Filter list callback",
-    )?;
-    ensure(
-        body.exprs.iter().any(|expr| {
-            matches!(
-                expr.kind,
-                ExprKind::ListCallback {
-                    op: ListCallbackOp::Map,
-                    ..
-                }
-            )
-        }),
-        "expected the element expression to lower to a Map list callback",
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Block(_))),
+        "expected a block expression",
     )?;
     Ok(())
 }
 
 #[test]
-fn nested_list_comprehension_is_rejected() -> TestResult {
+fn nested_list_comprehension_lowers() -> TestResult {
     let source = py!(r#"
 def pairs(xs: list[int], ys: list[int]) -> list[int]:
     return [x + y for x in xs for y in ys]
 "#);
     let mut ctx = HirCtx::new();
-    let errors = lower_errors(source, &mut ctx)?;
-    let error = first_error(&errors)?;
-    ensure_eq(&error.code, &"smelt::unsupported-py", "error code")?;
+    let module_id = lower_module(source, &mut ctx)?;
+    let body = single_function_body(&ctx, module_id)?;
     ensure(
-        error.message.contains("nested list comprehensions"),
-        "expected nested comprehension rejection message",
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Block(_))),
+        "expected nested list comprehension to lower to a block expression",
     )?;
     Ok(())
 }
 
 #[test]
-fn list_comprehension_over_non_list_is_rejected() -> TestResult {
+fn set_comprehension_lowers_to_block_with_add() -> TestResult {
+    let source = py!(r#"
+def uniq(xs: list[int]) -> set[int]:
+    return {x for x in xs}
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let body = single_function_body(&ctx, module_id)?;
+    ensure(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::SetAdd { .. })),
+        "expected set comprehension to build the accumulator with set adds",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn dict_comprehension_lowers_to_block() -> TestResult {
+    let source = py!(r#"
+def table(xs: list[int]) -> dict[int, int]:
+    return {k: k for k in xs}
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let body = single_function_body(&ctx, module_id)?;
+    ensure(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Block(_))),
+        "expected dict comprehension to lower to a block expression",
+    )?;
+    ensure(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::DictLit(_))),
+        "expected an empty dict accumulator literal",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn generator_expression_lowers() -> TestResult {
+    let source = py!(r#"
+def collected(xs: list[int]) -> list[int]:
+    return list(x for x in xs)
+"#);
+    let mut ctx = HirCtx::new();
+    // Generator expressions materialize eagerly; lowering should succeed.
+    lower_module(source, &mut ctx)?;
+    Ok(())
+}
+
+#[test]
+fn list_comprehension_over_string_lowers() -> TestResult {
     let source = py!(r#"
 def chars(text: str) -> list[str]:
     return [c for c in text]
+"#);
+    let mut ctx = HirCtx::new();
+    lower_module(source, &mut ctx)?;
+    Ok(())
+}
+
+#[test]
+fn comprehension_destructuring_target_is_rejected() -> TestResult {
+    let source = py!(r#"
+def firsts(pairs: list[tuple[int, int]]) -> list[int]:
+    return [a for a, b in pairs]
 "#);
     let mut ctx = HirCtx::new();
     let errors = lower_errors(source, &mut ctx)?;
     let error = first_error(&errors)?;
     ensure_eq(&error.code, &"smelt::unsupported-py", "error code")?;
     ensure(
-        error.message.contains("can only iterate over a list"),
-        "expected non-list iterable rejection message",
+        error.message.contains("destructuring"),
+        "expected destructuring rejection message",
     )?;
     Ok(())
 }

--- a/crates/smelt-frontend-py/src/tests/basic_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/basic_tests.rs
@@ -342,3 +342,99 @@ def run() -> None:
     )?;
     Ok(())
 }
+
+#[test]
+fn fstring_interpolation_lowers_to_string_concat() -> TestResult {
+    let source = py!(r#"
+def greet(name: str, count: int) -> str:
+    return f"Hello {name}, you have {count} messages"
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let item_id = module
+        .items
+        .first()
+        .copied()
+        .ok_or_else(|| "expected greet function".to_owned())?;
+    let Item::Function(greet) = item(&ctx, item_id)? else {
+        return Err("expected function item".to_owned());
+    };
+    let body_id = greet.body.ok_or_else(|| "expected greet body".to_owned())?;
+    let body = body(&ctx, body_id)?;
+    ensure(
+        body.exprs.iter().any(|expr| {
+            matches!(
+                expr.kind,
+                ExprKind::BinOp {
+                    op: BinOp::Add,
+                    ..
+                }
+            ) && ctx.krate.types.get(expr.ty) == Some(&Type::String)
+        }),
+        "expected f-string to lower to a String addition chain",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn fstring_only_literal_parts_lower_to_string() -> TestResult {
+    let source = py!(r#"
+def shout() -> str:
+    return f"static text"
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let item_id = module
+        .items
+        .first()
+        .copied()
+        .ok_or_else(|| "expected shout function".to_owned())?;
+    let Item::Function(shout) = item(&ctx, item_id)? else {
+        return Err("expected function item".to_owned());
+    };
+    let body_id = shout.body.ok_or_else(|| "expected shout body".to_owned())?;
+    let body = body(&ctx, body_id)?;
+    ensure(
+        body.exprs.iter().any(|expr| {
+            matches!(&expr.kind, ExprKind::Literal(Literal::String(text)) if text == "static text")
+        }),
+        "expected a literal-only f-string to lower to a string literal",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn fstring_format_spec_is_rejected() -> TestResult {
+    let source = py!(r#"
+def render(value: float) -> str:
+    return f"{value:.2f}"
+"#);
+    let mut ctx = HirCtx::new();
+    let errors = lower_errors(source, &mut ctx)?;
+    let error = first_error(&errors)?;
+    ensure_eq(&error.code, &"smelt::unsupported-py", "error code")?;
+    ensure(
+        error.message.contains("format specifications"),
+        "expected format specification rejection message",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn fstring_repr_conversion_is_rejected() -> TestResult {
+    let source = py!(r#"
+def render(value: int) -> str:
+    return f"{value!r}"
+"#);
+    let mut ctx = HirCtx::new();
+    let errors = lower_errors(source, &mut ctx)?;
+    let error = first_error(&errors)?;
+    ensure_eq(&error.code, &"smelt::unsupported-py", "error code")?;
+    ensure(
+        error.message.contains("conversions"),
+        "expected conversion rejection message",
+    )?;
+    Ok(())
+}

--- a/crates/smelt-frontend-py/src/tests/mod.rs
+++ b/crates/smelt-frontend-py/src/tests/mod.rs
@@ -3,7 +3,7 @@
 use crate::{HirCtx, SmeltError, to_hir, to_hir_with_path};
 use smelt_hir::{
     AsyncOp, BinOp, Body, BodyId, BoolFoldOp, DictProjectionOp, ExprKind, FileId, Item, ItemId,
-    Language, ListCallbackOp,
+    Language,
     Literal, Module, ModuleId, NumericExtremaOp, NumericPredicateOp, NumericRoundOp,
     NumericUnaryFuncOp, Pattern, PatternId, PrimitiveCastOp, RegexMatchOp, SetBinaryOp,
     SetProjectionOp, SetRelationOp, SetRemoveOp, Stmt, StringAffixOp, StringCaseOp,

--- a/crates/smelt-frontend-py/src/tests/mod.rs
+++ b/crates/smelt-frontend-py/src/tests/mod.rs
@@ -3,7 +3,7 @@
 use crate::{HirCtx, SmeltError, to_hir, to_hir_with_path};
 use smelt_hir::{
     AsyncOp, BinOp, Body, BodyId, BoolFoldOp, DictProjectionOp, ExprKind, FileId, Item, ItemId,
-    Language,
+    Language, ListCallbackOp,
     Literal, Module, ModuleId, NumericExtremaOp, NumericPredicateOp, NumericRoundOp,
     NumericUnaryFuncOp, Pattern, PatternId, PrimitiveCastOp, RegexMatchOp, SetBinaryOp,
     SetProjectionOp, SetRelationOp, SetRemoveOp, Stmt, StringAffixOp, StringCaseOp,

--- a/crates/smelt-frontend-py/src/tests/mod.rs
+++ b/crates/smelt-frontend-py/src/tests/mod.rs
@@ -2,7 +2,8 @@
 
 use crate::{HirCtx, SmeltError, to_hir, to_hir_with_path};
 use smelt_hir::{
-    AsyncOp, Body, BodyId, BoolFoldOp, DictProjectionOp, ExprKind, FileId, Item, ItemId, Language,
+    AsyncOp, BinOp, Body, BodyId, BoolFoldOp, DictProjectionOp, ExprKind, FileId, Item, ItemId,
+    Language,
     Literal, Module, ModuleId, NumericExtremaOp, NumericPredicateOp, NumericRoundOp,
     NumericUnaryFuncOp, Pattern, PatternId, PrimitiveCastOp, RegexMatchOp, SetBinaryOp,
     SetProjectionOp, SetRelationOp, SetRemoveOp, Stmt, StringAffixOp, StringCaseOp,

--- a/crates/smelt-mir/src/lower.rs
+++ b/crates/smelt-mir/src/lower.rs
@@ -3404,7 +3404,18 @@ impl<'hir> LoweringCtx<'hir> {
                 });
                 Operand::Copy(Place::Local(dest))
             }
-            ExprKind::Block(_) | ExprKind::Lambda { .. } => {
+            ExprKind::Block(block_id) => {
+                // Execute the block's statements in the current control flow,
+                // then yield the block's tail expression (or `None`) as the
+                // block-expression value. Used by comprehension lowering.
+                let tail = self.hir_block(*block_id)?.tail;
+                self.lower_block_stmts(*block_id)?;
+                match tail {
+                    Some(tail_expr) => self.lower_expr(tail_expr)?,
+                    None => Operand::Const(Constant::None),
+                }
+            }
+            ExprKind::Lambda { .. } => {
                 return Err(self.error(
                     "expression kind is not implemented in MIR yet",
                     Some(expr.span),

--- a/docs/python-comprehensions.md
+++ b/docs/python-comprehensions.md
@@ -1,0 +1,86 @@
+# Python Comprehensions
+
+Status and design notes for lowering Python comprehensions
+(`[...]`, `{...}`, `{k: v ...}`, and generator expressions) in the Python
+frontend (`smelt-frontend-py`).
+
+## Forms
+
+| Source form            | Example                          | Status |
+| ---------------------- | -------------------------------- | ------ |
+| List comprehension     | `[f(x) for x in xs if p(x)]`     | supported (loop lowering) |
+| Set comprehension      | `{f(x) for x in xs}`             | supported (loop lowering) |
+| Dict comprehension     | `{k: v for k, v in items}`       | supported (loop lowering) |
+| Generator expression   | `(f(x) for x in xs)`             | supported, eagerly materialized (see below) |
+
+## Lowering strategy
+
+Comprehensions lower to an **imperative accumulator loop** wrapped in an
+`ExprKind::Block` value expression, rather than the legacy `map`/`filter`
+`CallbackExpr` bridge (see `docs/callback-expr-audit.md`). For
+
+```python
+[elt for t0 in it0 if c0 for t1 in it1 if c1]
+```
+
+the frontend emits the HIR equivalent of
+
+```rust
+{
+    let mut acc = Vec::new();          // SetLit / DictLit for set/dict forms
+    for t0 in it0 {
+        if c0 {
+            for t1 in it1 {
+                if c1 {
+                    acc.push(elt);     // SetAdd / dict index-assign for set/dict
+                }
+            }
+        }
+    }
+    acc
+}
+```
+
+Because the element, key, value, and condition expressions are lowered through
+the normal expression path (`expression`), they support the full expression
+language — including nested comprehensions, f-strings, method calls, and
+conditionals — not just the restricted callback subset.
+
+Loop targets bind through `binding_pattern_from_target` and the iterable is
+normalized through `for_iterable`, so comprehensions iterate over any iterable
+the `for` statement already supports (lists, sets, dicts, strings).
+
+### Generator expressions
+
+Generator expressions lower identically to list comprehensions, i.e. they are
+**eagerly materialized** into a list. This is correct for the common eager
+sinks (`list(...)`, `sum(...)`, `" ".join(...)`, `for ... in (gen)`), but does
+not preserve laziness. Truly lazy/infinite generators and short-circuiting
+consumers (`any`/`next`) are therefore out of scope until the runtime grows a
+lazy iterator type.
+
+## Known limitations
+
+These are rejected with a `smelt::unsupported-py` diagnostic rather than
+mis-lowered:
+
+- **Async comprehensions** (`[x async for x in ...]`) — needs async iteration.
+- **Destructuring loop targets** (`for k, v in items`) — blocked by a more
+  general MIR limitation: `Stmt::For` and `Stmt::Let` only lower *binding*
+  (single-name) patterns to MIR today, so ordinary `for k, v in ...` loops are
+  unsupported as well. Lifting this is tracked as a shared `for`/`let`/
+  comprehension destructuring task, not a comprehension-specific one.
+- **Walrus (`:=`) inside the comprehension body** — needs named-expression
+  lowering.
+
+## Implementation map
+
+- `smelt-frontend-py/src/lowering/list.rs` — `list_comprehension`,
+  `set_comprehension`, `dict_comprehension`, `generator_expression`, and the
+  shared `comprehension_block` loop builder.
+- `smelt-frontend-py/src/lowering/literals.rs` — routes `Expr::ListComp`,
+  `Expr::SetComp`, `Expr::DictComp`, and `Expr::Generator`.
+- `smelt-mir/src/lower.rs` — `ExprKind::Block` lowering (executes block
+  statements, then yields the block tail operand).
+</content>
+</invoke>


### PR DESCRIPTION
Python f-strings (`f"a{expr}b"`) were rejected as unsupported expressions,
which blocked transpiling essentially every real Python library since
f-strings are ubiquitous. This mirrors the existing TypeScript template
literal lowering: each literal chunk and interpolated expression is folded
together with `BinOp::Add` on a `String` result type, and the Rust emitter
coerces non-string operands through `to_string()` for the common
`f"{value}"` case.

Implicitly concatenated literal parts (`"a" f"b{x}"`) are preserved by
walking the f-string parts directly rather than the `elements()` helper,
which skips plain string-literal parts. Format specifications (`:`),
`repr`/`ascii` conversions (`!r`/`!a`) and self-documenting expressions
(trailing `=`) are not yet modeled and are rejected as unsupported rather
than silently dropped.

Adds frontend regression tests for interpolation, literal-only f-strings,
and the rejected format-spec/conversion cases.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0152sAfpJ73zNEmuzHwufoaK