### PR TITLE
Support Python sorted/list.sort key and reverse

### DIFF
--- a/IMPLEMENTATION_CHECKLIST.md
+++ b/IMPLEMENTATION_CHECKLIST.md
@@ -278,7 +278,9 @@ runtime errors.
   - [x] TypeScript `Array.prototype.find` and `findIndex` with capture-free expression callbacks.
   - [x] TypeScript `Array.prototype.some` and `every` with capture-free expression callbacks.
   - [ ] TypeScript callback methods with captured closures, callback function values, and index/array parameters.
-  - [ ] Python `map`, `filter`, and callback-style `sorted(key=...)` if supported.
+  - [x] Python `map`, `filter`, and callback-style `sorted(key=...)` if supported.
+    - [x] `list(map(...))` and `list(filter(...))` with lambda or local lambda callbacks.
+    - [x] `sorted(values, key=..., reverse=...)` and `list.sort(key=..., reverse=...)`.
 - [ ] Batch F, dependency-backed mappings:
   - [ ] `serde_json` dependency injection, then TypeScript `JSON.stringify` / `JSON.parse` and
         Python `json.dumps` / `json.loads`.
@@ -478,8 +480,9 @@ runtime errors.
     - [x] `sum(...)` for int and float lists.
     - [x] `min(...)` and `max(...)` for all-int or all-float fixed argument lists.
   - [x] `all(...)` and `any(...)`.
-  - [ ] `sorted(...)` and `reversed(...)`.
+  - [x] `sorted(...)` and `reversed(...)`.
     - [x] `sorted(...)` for plain sortable lists without `key` or `reverse`.
+    - [x] `sorted(...)` with a scalar `key=` callable and/or `reverse=` boolean.
     - [x] `reversed(...)` for list values.
   - [ ] `list(...)`, `dict(...)`, `tuple(...)`, and `set(...)` constructors.
     - [x] Empty annotated `list()`, `dict()`, `set()`, and `tuple()`.

--- a/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
@@ -960,7 +960,9 @@ impl FunctionEmitter<'_> {
             Rvalue::ListCount { list, item } => self.list_count_text(list, item, dest_ty),
             Rvalue::ListSum { list } => self.list_sum_text(list, dest_ty),
             Rvalue::ListBoolFold { op, list } => self.list_bool_fold_text(*op, list),
-            Rvalue::ListSorted { list } => self.list_sorted_text(list, dest_ty),
+            Rvalue::ListSorted { list, key, reverse } => {
+                self.list_sorted_text(list, key.as_ref(), *reverse, dest_ty)
+            }
             Rvalue::ListReversed { list } => self.list_reversed_text(list, dest_ty),
             Rvalue::ListEnumerate { list } => self.list_enumerate_text(list, dest_ty),
             Rvalue::ListZip { left, right } => self.list_zip_text(left, right, dest_ty),
@@ -970,9 +972,12 @@ impl FunctionEmitter<'_> {
             Rvalue::ListRandomChoice { list } => self.list_random_choice_text(list, dest_ty),
             Rvalue::ListIndex { list, item } => self.list_index_text(list, item, dest_ty),
             Rvalue::ListRemove { list, item } => self.list_remove_text(list, item, dest_ty),
-            Rvalue::ListSort { list, comparator } => {
-                self.list_sort_text(list, comparator.as_ref(), dest_ty)
-            }
+            Rvalue::ListSort {
+                list,
+                comparator,
+                key,
+                reverse,
+            } => self.list_sort_text(list, comparator.as_ref(), key.as_ref(), *reverse, dest_ty),
             Rvalue::ListPop { list } => self.list_pop_text(list, dest_ty),
             Rvalue::ListShift { list } => self.list_shift_text(list, dest_ty),
             Rvalue::ListNext { list } => self.list_next_text(list, dest_ty),

--- a/crates/smelt-codegen-rust/src/emitter/list_mutation.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_mutation.rs
@@ -515,6 +515,8 @@ impl FunctionEmitter<'_> {
         &self,
         list: &Operand,
         comparator: Option<&Operand>,
+        key: Option<&Operand>,
+        reverse: bool,
         dest_ty: TypeId,
     ) -> Result<String, EmitError> {
         let list_ty = self.operand_ty(list)?;
@@ -542,6 +544,12 @@ impl FunctionEmitter<'_> {
         };
         if let Some(comparator) = comparator {
             return self.list_sort_comparator_text(comparator, element_ty, returns_list, &list_text, &result_text);
+        }
+        if key.is_some() || reverse {
+            let (prefix, closure) = self.list_sort_by_text(key, reverse, element_ty)?;
+            return Ok(format!(
+                "{{ {prefix}{list_text}.sort_by({closure}); {result_text} }}"
+            ));
         }
         match self.mir.types.get(*item_ty) {
             Some(Type::Bool | Type::Int | Type::Float | Type::String) if returns_list => {

--- a/crates/smelt-codegen-rust/src/emitter/list_ordering.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_ordering.rs
@@ -26,19 +26,28 @@ impl FunctionEmitter<'_> {
     pub(super) fn list_sorted_text(
         &self,
         list: &Operand,
+        key: Option<&Operand>,
+        reverse: bool,
         dest_ty: TypeId,
     ) -> Result<String, EmitError> {
         let list_ty = self.operand_ty(list)?;
         let Some(Type::List(item_ty)) = self.mir.types.get(list_ty) else {
             return Err(EmitError::new("sorted() argument must be a list"));
         };
+        let element_ty = *item_ty;
         if dest_ty != list_ty {
             return Err(EmitError::new(
                 "sorted() destination must match the input list type",
             ));
         }
         let list_text = self.operand_text(list)?;
-        match self.mir.types.get(*item_ty) {
+        if key.is_some() || reverse {
+            let (prefix, closure) = self.list_sort_by_text(key, reverse, element_ty)?;
+            return Ok(format!(
+                "{{ {prefix}let mut sorted = {list_text}.clone(); sorted.sort_by({closure}); sorted }}"
+            ));
+        }
+        match self.mir.types.get(element_ty) {
             Some(Type::Bool | Type::Int | Type::String) => Ok(format!(
                 "{{ let mut sorted = {list_text}.clone(); sorted.sort(); sorted }}"
             )),
@@ -49,6 +58,74 @@ impl FunctionEmitter<'_> {
                 "sorted() supports bool, int, float, and string lists",
             )),
         }
+    }
+
+    /// Build the prefix bindings and `sort_by` comparison closure for Python
+    /// `key`/`reverse` sorting.
+    ///
+    /// When `key` is present it is bound once as `smelt_sort_key` and applied to
+    /// both compared items, producing owned key values. Otherwise the list items
+    /// compare directly through their references. `reverse` swaps the comparison
+    /// operands rather than reversing the result, so equal items keep their
+    /// original order to match Python's stable descending sort. Floating keys use
+    /// `partial_cmp` and panic on unordered values such as `NaN`.
+    pub(super) fn list_sort_by_text(
+        &self,
+        key: Option<&Operand>,
+        reverse: bool,
+        element_ty: TypeId,
+    ) -> Result<(String, String), EmitError> {
+        if let Some(key) = key {
+            let Some(Type::Function(function_ty)) = self.mir.types.get(self.operand_ty(key)?) else {
+                return Err(EmitError::new("sort key must be a closure"));
+            };
+            let return_ty = function_ty.return_ty;
+            let param_ty = function_ty.params.first().copied().unwrap_or(element_ty);
+            let left_arg = self.value_at_type_text("left.clone()", element_ty, param_ty)?;
+            let right_arg = self.value_at_type_text("right.clone()", element_ty, param_ty)?;
+            let closure_text = match self.closure_operand_text_for_declared_type(key) {
+                Ok(closure_text) => closure_text,
+                Err(_) => self.operand_text(key)?,
+            };
+            let (first, second) = if reverse {
+                ("right_key", "left_key")
+            } else {
+                ("left_key", "right_key")
+            };
+            let comparison = match self.mir.types.get(return_ty) {
+                Some(Type::Float) => format!(
+                    "{first}.partial_cmp(&{second}).expect(\"sort key incomparable float\")"
+                ),
+                Some(Type::Bool | Type::Int | Type::String) => format!("{first}.cmp(&{second})"),
+                _ => {
+                    return Err(EmitError::new(
+                        "sort key must return bool, int, float, or string",
+                    ));
+                }
+            };
+            let prefix = format!("let mut smelt_sort_key = {closure_text}; ");
+            let closure = format!(
+                "|left, right| {{ let left_key = (smelt_sort_key)({left_arg}); let right_key = (smelt_sort_key)({right_arg}); {comparison} }}"
+            );
+            return Ok((prefix, closure));
+        }
+        let (first, second) = if reverse {
+            ("right", "left")
+        } else {
+            ("left", "right")
+        };
+        let comparison = match self.mir.types.get(element_ty) {
+            Some(Type::Float) => {
+                format!("{first}.partial_cmp({second}).expect(\"sort incomparable float\")")
+            }
+            Some(Type::Bool | Type::Int | Type::String) => format!("{first}.cmp({second})"),
+            _ => {
+                return Err(EmitError::new(
+                    "sort supports bool, int, float, and string items",
+                ));
+            }
+        };
+        Ok((String::new(), format!("|left, right| {comparison}")))
     }
 
     /// Converts a reversed-copy list operation to Rust text.

--- a/crates/smelt-codegen-rust/src/tests/part_4_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_4_tests.rs
@@ -326,6 +326,35 @@ ordered_floats: list[float] = sorted(floats)
 }
 
 #[test]
+fn emits_python_sorted_key_and_reverse() {
+    let source = source_for_py(
+        r#"
+bias: int = 10
+values: list[int] = [2, 1]
+ordered: list[int] = sorted(values, key=lambda value: value + bias, reverse=True)
+"#,
+    );
+
+    assert!(source.contains("let mut smelt_sort_key ="));
+    assert!(source.contains("let left_key = (smelt_sort_key)"));
+    assert!(source.contains("right_key.cmp(&left_key)"));
+}
+
+#[test]
+fn emits_python_list_sort_key() {
+    let source = source_for_py(
+        r#"
+values: list[int] = [2, 1]
+ordered: None = values.sort(key=lambda value: value * 2)
+"#,
+    );
+
+    assert!(source.contains("let mut smelt_sort_key ="));
+    assert!(source.contains(".sort_by(|left, right|"));
+    assert!(source.contains("left_key.cmp(&right_key)"));
+}
+
+#[test]
 fn emits_python_reversed_builtin() {
     let source = source_for_py(
         r#"

--- a/crates/smelt-frontend-py/src/lowering.rs
+++ b/crates/smelt-frontend-py/src/lowering.rs
@@ -117,11 +117,11 @@ struct FunctionVariadics {
 
 /// A closure expression prepared for a callback-consuming Python API.
 #[derive(Debug, Clone, Copy)]
-struct ClosureCallback {
+pub(super) struct ClosureCallback {
     /// HIR expression id of the closure value.
-    expr: smelt_hir::ExprId,
+    pub(super) expr: smelt_hir::ExprId,
     /// Return type produced by the closure.
-    return_ty: TypeId,
+    pub(super) return_ty: TypeId,
 }
 
 /// A simple pytest parametrization table.

--- a/crates/smelt-frontend-py/src/lowering/list.rs
+++ b/crates/smelt-frontend-py/src/lowering/list.rs
@@ -288,7 +288,7 @@ impl ModuleBuilder<'_> {
     }
 
     /// Lower either an inline lambda or an annotated local lambda callback.
-    fn python_callback_argument(
+    pub(super) fn python_callback_argument(
         &mut self,
         arg: &Expr,
         expected_param_tys: &[TypeId],

--- a/crates/smelt-frontend-py/src/lowering/stdlib_types.rs
+++ b/crates/smelt-frontend-py/src/lowering/stdlib_types.rs
@@ -141,7 +141,12 @@ impl ModuleBuilder<'_> {
         })))
     }
 
-    /// Lower Python `sorted(values)` calls for directly sortable lists.
+    /// Lower Python `sorted(values, key=..., reverse=...)` for sortable lists.
+    ///
+    /// Lists of scalar items sort directly; an optional `key=` lambda or local
+    /// callable sorts by its mapped value, and `reverse=True` produces a
+    /// descending order. This mirrors the TypeScript `Array.prototype.sort`
+    /// comparator support so the two frontends keep parity.
     pub(super) fn sorted_call_expression(
         &mut self,
         call: &ruff_python_ast::ExprCall,
@@ -153,10 +158,10 @@ impl ModuleBuilder<'_> {
         if name.id.as_str() != "sorted" {
             return Ok(None);
         }
-        if call.arguments.args.len() != 1 || !call.arguments.keywords.is_empty() {
+        if call.arguments.args.len() != 1 {
             return Err(SmeltError::unsupported(
                 self.span(call.range),
-                "sorted() currently supports exactly one list argument and no keywords",
+                "sorted() currently supports exactly one list argument",
             ));
         }
         let list = self.expression(&call.arguments.args[0], body)?;
@@ -167,20 +172,82 @@ impl ModuleBuilder<'_> {
                 "sorted() argument must be a sortable list",
             ));
         };
-        if !matches!(
-            self.ctx.krate.types.get(*item_ty),
-            Some(Type::Bool | Type::Int | Type::Float | Type::String)
-        ) {
+        let element_ty = *item_ty;
+        let (key, reverse) =
+            self.sort_keyword_arguments(&call.arguments.keywords, element_ty, body)?;
+        if key.is_none()
+            && !matches!(
+                self.ctx.krate.types.get(element_ty),
+                Some(Type::Bool | Type::Int | Type::Float | Type::String)
+            )
+        {
             return Err(SmeltError::unsupported(
                 self.span(call.arguments.args[0].range()),
                 "sorted() argument must be a sortable list",
             ));
         }
         Ok(Some(body.push_expr(HirExpr {
-            kind: ExprKind::ListSorted { list },
+            kind: ExprKind::ListSorted {
+                list,
+                key,
+                reverse,
+            },
             ty: list_ty,
             span: self.span(call.range),
         })))
+    }
+
+    /// Parse Python `key=` and `reverse=` sort keyword arguments.
+    ///
+    /// A `key` lambda or local callable lowers to a closure mapping one list
+    /// item to a scalar sort value; `key=None` is treated as absent. `reverse`
+    /// accepts only boolean literals because non-literal flags would need
+    /// runtime branching that the sort lowering does not model yet.
+    fn sort_keyword_arguments(
+        &mut self,
+        keywords: &[ruff_python_ast::Keyword],
+        element_ty: smelt_hir::TypeId,
+        body: &mut Body,
+    ) -> Result<(Option<smelt_hir::ExprId>, bool), SmeltError> {
+        let mut key = None;
+        let mut reverse = false;
+        for keyword in keywords {
+            match keyword.arg.as_ref().map(ruff_python_ast::Identifier::as_str) {
+                Some("key") => {
+                    if matches!(&keyword.value, Expr::NoneLiteral(_)) {
+                        continue;
+                    }
+                    let callback =
+                        self.python_callback_argument(&keyword.value, &[element_ty], body)?;
+                    if !matches!(
+                        self.ctx.krate.types.get(callback.return_ty),
+                        Some(Type::Bool | Type::Int | Type::Float | Type::String)
+                    ) {
+                        return Err(SmeltError::unsupported(
+                            self.span(keyword.range),
+                            "sort key must return bool, int, float, or str",
+                        ));
+                    }
+                    key = Some(callback.expr);
+                }
+                Some("reverse") => match &keyword.value {
+                    Expr::BooleanLiteral(value) => reverse = value.value,
+                    _ => {
+                        return Err(SmeltError::unsupported(
+                            self.span(keyword.range),
+                            "sort reverse must be a boolean literal",
+                        ));
+                    }
+                },
+                _ => {
+                    return Err(SmeltError::unsupported(
+                        self.span(keyword.range),
+                        "sort supports only key and reverse keyword arguments",
+                    ));
+                }
+            }
+        }
+        Ok((key, reverse))
     }
 
     /// Lower Python `reversed(values)` calls for list values.
@@ -535,19 +602,11 @@ impl ModuleBuilder<'_> {
         })))
     }
 
-    /// Return whether a Python `list.sort()` keyword leaves direct sorting unchanged.
-    fn is_noop_sort_keyword(keyword: &ruff_python_ast::Keyword) -> bool {
-        match keyword.arg.as_ref().map(|arg| arg.as_str()) {
-            Some("key") => matches!(&keyword.value, Expr::NoneLiteral(_)),
-            Some("reverse") => matches!(
-                &keyword.value,
-                Expr::BooleanLiteral(value) if !value.value
-            ),
-            _ => false,
-        }
-    }
-
-    /// Lower Python `list.sort()` calls with direct scalar ordering.
+    /// Lower Python `list.sort(key=..., reverse=...)` calls in place.
+    ///
+    /// Scalar lists sort directly; an optional `key=` callable sorts by its
+    /// mapped value and `reverse=True` orders descending, matching the
+    /// `sorted()` lowering and the TypeScript array sort comparator support.
     pub(super) fn list_sort_call_expression(
         &mut self,
         call: &ruff_python_ast::ExprCall,
@@ -565,23 +624,20 @@ impl ModuleBuilder<'_> {
                 "list.sort() currently supports no positional arguments",
             ));
         }
-        for keyword in &call.arguments.keywords {
-            if !Self::is_noop_sort_keyword(keyword) {
-                return Err(SmeltError::unsupported(
-                    self.span(keyword.range),
-                    "list.sort() currently supports only key=None and reverse=False keywords",
-                ));
-            }
-        }
         let list = self.expression(&attr.value, body)?;
         let list_ty = Self::expr_ty(body, list);
         let Some(Type::List(list_element_ty)) = self.ctx.krate.types.get(list_ty) else {
             return Ok(None);
         };
-        if !matches!(
-            self.ctx.krate.types.get(*list_element_ty),
-            Some(Type::Bool | Type::Int | Type::Float | Type::String)
-        ) {
+        let element_ty = *list_element_ty;
+        let (key, reverse) =
+            self.sort_keyword_arguments(&call.arguments.keywords, element_ty, body)?;
+        if key.is_none()
+            && !matches!(
+                self.ctx.krate.types.get(element_ty),
+                Some(Type::Bool | Type::Int | Type::Float | Type::String)
+            )
+        {
             return Err(SmeltError::unsupported(
                 self.span(attr.value.range()),
                 "list.sort() supports bool, int, float, and str lists for now",
@@ -592,6 +648,8 @@ impl ModuleBuilder<'_> {
             kind: ExprKind::ListSort {
                 list,
                 comparator: None,
+                key,
+                reverse,
             },
             ty,
             span: self.span(call.range),

--- a/crates/smelt-frontend-py/src/tests/builtins_sets_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/builtins_sets_tests.rs
@@ -343,6 +343,88 @@ ordered: list[int] = sorted(values)
 }
 
 #[test]
+fn builtin_sorted_key_and_reverse_lower() -> TestResult {
+    let source = py!(r#"
+bias: int = 10
+values: list[int] = [2, 1]
+ordered: list[int] = sorted(values, key=lambda value: value + bias, reverse=True)
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let body = body(
+        &ctx,
+        module
+            .body
+            .ok_or_else(|| "expected module body".to_owned())?,
+    )?;
+
+    ensure(
+        body.exprs.iter().any(|expr| {
+            matches!(
+                &expr.kind,
+                ExprKind::ListSorted {
+                    key: Some(key),
+                    reverse: true,
+                    ..
+                } if closure_cfg_has_capture(&ctx, body, *key)
+            )
+        }),
+        "expected sorted key+reverse lowering",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn list_sort_key_and_reverse_lower() -> TestResult {
+    let source = py!(r#"
+bias: int = 10
+values: list[int] = [2, 1]
+ordered: None = values.sort(key=lambda value: value + bias, reverse=True)
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let body = body(
+        &ctx,
+        module
+            .body
+            .ok_or_else(|| "expected module body".to_owned())?,
+    )?;
+
+    ensure(
+        body.exprs.iter().any(|expr| {
+            matches!(
+                &expr.kind,
+                ExprKind::ListSort {
+                    comparator: None,
+                    key: Some(key),
+                    reverse: true,
+                    ..
+                } if closure_cfg_has_capture(&ctx, body, *key)
+            )
+        }),
+        "expected list.sort key+reverse lowering",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn sorted_non_literal_reverse_is_rejected() -> TestResult {
+    let source = py!(r#"
+flag: bool = True
+values: list[int] = [2, 1]
+ordered: list[int] = sorted(values, reverse=flag)
+"#);
+    let mut ctx = HirCtx::new();
+    ensure(
+        lower_module(source, &mut ctx).is_err(),
+        "expected non-literal reverse to be rejected",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn builtin_map_filter_lambda_callbacks_lower() -> TestResult {
     let source = py!(r#"
 factor: int = 2

--- a/crates/smelt-frontend-py/src/tests/collections_reject_a_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/collections_reject_a_tests.rs
@@ -298,18 +298,34 @@ result: None = values.sort(True)
     )?;
 
     let mut ctx = HirCtx::new();
-    let keyword_arg = lower_errors(
+    let non_literal_reverse = lower_errors(
         py!(r#"
+flag: bool = True
 values: list[int] = [1, 2]
-result: None = values.sort(reverse=True)
+result: None = values.sort(reverse=flag)
 "#),
         &mut ctx,
     )?;
     ensure(
-        first_error(&keyword_arg)?
+        first_error(&non_literal_reverse)?
             .message
-            .contains("key=None and reverse=False"),
-        "expected list sort keyword diagnostic",
+            .contains("reverse must be a boolean literal"),
+        "expected list sort non-literal reverse diagnostic",
+    )?;
+
+    let mut ctx = HirCtx::new();
+    let unknown_keyword = lower_errors(
+        py!(r#"
+values: list[int] = [1, 2]
+result: None = values.sort(cmp=None)
+"#),
+        &mut ctx,
+    )?;
+    ensure(
+        first_error(&unknown_keyword)?
+            .message
+            .contains("only key and reverse keyword arguments"),
+        "expected list sort unknown keyword diagnostic",
     )
 }
 

--- a/crates/smelt-frontend-py/src/tests/collections_reject_b_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/collections_reject_b_tests.rs
@@ -156,7 +156,7 @@ fn unsupported_builtin_sorted_forms_reject() -> TestResult {
     let wrong_arity = lower_errors(
         py!(r#"
 values: list[int] = [1, 2]
-ordered: list[int] = sorted(values, reverse=True)
+ordered: list[int] = sorted(values, values)
 "#),
         &mut ctx,
     )?;
@@ -180,6 +180,22 @@ ordered: list[list[int]] = sorted(values)
             .message
             .contains("sortable list"),
         "expected sorted type diagnostic",
+    )?;
+
+    let mut ctx = HirCtx::new();
+    let non_literal_reverse = lower_errors(
+        py!(r#"
+flag: bool = True
+values: list[int] = [1, 2]
+ordered: list[int] = sorted(values, reverse=flag)
+"#),
+        &mut ctx,
+    )?;
+    ensure(
+        first_error(&non_literal_reverse)?
+            .message
+            .contains("reverse must be a boolean literal"),
+        "expected sorted non-literal reverse diagnostic",
     )
 }
 

--- a/crates/smelt-frontend-ts/src/lowering/stdlib.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib.rs
@@ -1674,7 +1674,12 @@ impl ModuleBuilder<'_> {
         };
         if comparator.is_some() {
             return Ok(Some(body.push_expr(Expr {
-                kind: ExprKind::ListSort { list, comparator },
+                kind: ExprKind::ListSort {
+                    list,
+                    comparator,
+                    key: None,
+                    reverse: false,
+                },
                 ty: list_ty,
                 span: self.span(call.span.start, call.span.end),
             })));
@@ -1689,7 +1694,12 @@ impl ModuleBuilder<'_> {
             ));
         }
         Ok(Some(body.push_expr(Expr {
-            kind: ExprKind::ListSort { list, comparator },
+            kind: ExprKind::ListSort {
+                list,
+                comparator,
+                key: None,
+                reverse: false,
+            },
             ty: list_ty,
             span: self.span(call.span.start, call.span.end),
         })))
@@ -2055,6 +2065,8 @@ impl ModuleBuilder<'_> {
                     kind: ExprKind::ListSort {
                         list: sorted,
                         comparator,
+                        key: None,
+                        reverse: false,
                     },
                     ty: list_ty,
                     span,

--- a/crates/smelt-hir/src/expr/kinds.rs
+++ b/crates/smelt-hir/src/expr/kinds.rs
@@ -368,6 +368,13 @@ pub enum ExprKind {
     },
     ListSorted {
         list: ExprId,
+        /// Optional key closure for Python `sorted(values, key=...)`.
+        ///
+        /// Like other callbacks, the key is a normal closure body referenced by
+        /// `ExprId`; it maps one list item to a sortable value.
+        key: Option<ExprId>,
+        /// Whether to sort in descending order, as in Python `reverse=True`.
+        reverse: bool,
     },
     ListReversed {
         list: ExprId,
@@ -402,6 +409,14 @@ pub enum ExprKind {
         /// Like other callbacks, the comparator is a normal closure body
         /// referenced by `ExprId`; it takes two list items and returns a number.
         comparator: Option<ExprId>,
+        /// Optional key closure for Python `list.sort(key=...)`.
+        ///
+        /// The key is a normal closure body referenced by `ExprId`; it maps one
+        /// list item to a sortable value. It is mutually exclusive with the
+        /// JavaScript-style `comparator`.
+        key: Option<ExprId>,
+        /// Whether to sort in descending order, as in Python `reverse=True`.
+        reverse: bool,
     },
     ListPop {
         list: ExprId,

--- a/crates/smelt-hir/src/format/call.rs
+++ b/crates/smelt-hir/src/format/call.rs
@@ -563,7 +563,11 @@ pub(super) fn expr_text(krate: &Crate, expr: &Expr) -> String {
             };
             format!("list_{op_text} {}", expr_ref(*list))
         }
-        ExprKind::ListSorted { list } => format!("list_sorted {}", expr_ref(*list)),
+        ExprKind::ListSorted { list, key, reverse } => {
+            let key_text = if key.is_some() { " <key>" } else { "" };
+            let reverse_text = if *reverse { " reverse" } else { "" };
+            format!("list_sorted {}{}{}", expr_ref(*list), key_text, reverse_text)
+        }
         ExprKind::ListReversed { list } => format!("list_reversed {}", expr_ref(*list)),
         ExprKind::ListEnumerate { list } => format!("list_enumerate {}", expr_ref(*list)),
         ExprKind::ListZip { left, right } => {
@@ -585,14 +589,25 @@ pub(super) fn expr_text(krate: &Crate, expr: &Expr) -> String {
             format!("list_remove {}, {}", expr_ref(*list), expr_ref(*item))
         }
         ExprKind::ListSort {
-            list, comparator, ..
+            list,
+            comparator,
+            key,
+            reverse,
         } => {
             let comparator_text = if comparator.is_some() {
                 " <comparator>"
             } else {
                 ""
             };
-            format!("list_sort {}{}", expr_ref(*list), comparator_text)
+            let key_text = if key.is_some() { " <key>" } else { "" };
+            let reverse_text = if *reverse { " reverse" } else { "" };
+            format!(
+                "list_sort {}{}{}{}",
+                expr_ref(*list),
+                comparator_text,
+                key_text,
+                reverse_text
+            )
         }
         ExprKind::ListPop { list } => format!("list_pop {}", expr_ref(*list)),
         ExprKind::ListShift { list } => format!("list_shift {}", expr_ref(*list)),

--- a/crates/smelt-hir/src/validate.rs
+++ b/crates/smelt-hir/src/validate.rs
@@ -99,6 +99,14 @@ pub fn validate(krate: &Crate) -> Vec<ValidationError> {
                 | ExprKind::ListSort {
                     comparator: Some(callback),
                     ..
+                }
+                | ExprKind::ListSort {
+                    key: Some(callback),
+                    ..
+                }
+                | ExprKind::ListSorted {
+                    key: Some(callback),
+                    ..
                 } => {
                     let Some(callback_expr) = body.exprs.get(callback.0 as usize) else {
                         errors.push(ValidationError {

--- a/crates/smelt-mir/src/format.rs
+++ b/crates/smelt-mir/src/format.rs
@@ -891,7 +891,16 @@ fn rvalue_text(value: &Rvalue) -> String {
             };
             format!("list_{op_text} {}", operand_text(list))
         }
-        Rvalue::ListSorted { list } => format!("list_sorted {}", operand_text(list)),
+        Rvalue::ListSorted { list, key, reverse } => {
+            let key_text = if key.is_some() { " <key>" } else { "" };
+            let reverse_text = if *reverse { " reverse" } else { "" };
+            format!(
+                "list_sorted {}{}{}",
+                operand_text(list),
+                key_text,
+                reverse_text
+            )
+        }
         Rvalue::ListReversed { list } => format!("list_reversed {}", operand_text(list)),
         Rvalue::ListEnumerate { list } => format!("list_enumerate {}", operand_text(list)),
         Rvalue::ListZip { left, right } => {
@@ -913,14 +922,25 @@ fn rvalue_text(value: &Rvalue) -> String {
             format!("list_remove {}, {}", operand_text(list), operand_text(item))
         }
         Rvalue::ListSort {
-            list, comparator, ..
+            list,
+            comparator,
+            key,
+            reverse,
         } => {
             let comparator_text = if comparator.is_some() {
                 " <comparator>"
             } else {
                 ""
             };
-            format!("list_sort {}{}", operand_text(list), comparator_text)
+            let key_text = if key.is_some() { " <key>" } else { "" };
+            let reverse_text = if *reverse { " reverse" } else { "" };
+            format!(
+                "list_sort {}{}{}{}",
+                operand_text(list),
+                comparator_text,
+                key_text,
+                reverse_text
+            )
         }
         Rvalue::ListPop { list } => format!("list_pop {}", operand_text(list)),
         Rvalue::ListShift { list } => format!("list_shift {}", operand_text(list)),

--- a/crates/smelt-mir/src/lower.rs
+++ b/crates/smelt-mir/src/lower.rs
@@ -2551,12 +2551,20 @@ impl<'hir> LoweringCtx<'hir> {
                 });
                 Operand::Copy(Place::Local(dest))
             }
-            ExprKind::ListSorted { list } => {
+            ExprKind::ListSorted { list, key, reverse } => {
                 let list_operand = self.lower_expr(*list)?;
+                let key_operand = match key {
+                    Some(key) => Some(self.lower_expr(*key)?),
+                    None => None,
+                };
                 let dest = self.push_temp(expr.ty, expr.span);
                 self.block_mut()?.statements.push(Statement::Assign {
                     dest,
-                    value: Rvalue::ListSorted { list: list_operand },
+                    value: Rvalue::ListSorted {
+                        list: list_operand,
+                        key: key_operand,
+                        reverse: *reverse,
+                    },
                 });
                 Operand::Copy(Place::Local(dest))
             }
@@ -2642,10 +2650,19 @@ impl<'hir> LoweringCtx<'hir> {
                 self.write_back_mutation_receiver(writeback)?;
                 Operand::Copy(Place::Local(dest))
             }
-            ExprKind::ListSort { list, comparator } => {
+            ExprKind::ListSort {
+                list,
+                comparator,
+                key,
+                reverse,
+            } => {
                 let (list_operand, writeback) = self.lower_mutation_receiver(*list)?;
                 let comparator_operand = match comparator {
                     Some(comparator) => Some(self.lower_expr(*comparator)?),
+                    None => None,
+                };
+                let key_operand = match key {
+                    Some(key) => Some(self.lower_expr(*key)?),
                     None => None,
                 };
                 let dest = self.push_temp(expr.ty, expr.span);
@@ -2654,6 +2671,8 @@ impl<'hir> LoweringCtx<'hir> {
                     value: Rvalue::ListSort {
                         list: list_operand,
                         comparator: comparator_operand,
+                        key: key_operand,
+                        reverse: *reverse,
                     },
                 });
                 self.write_back_mutation_receiver(writeback)?;

--- a/crates/smelt-mir/src/opt.rs
+++ b/crates/smelt-mir/src/opt.rs
@@ -523,9 +523,12 @@ fn rewrite_rvalue(
         }
         Rvalue::ListSum { list }
         | Rvalue::ListBoolFold { list, .. }
-        | Rvalue::ListSorted { list }
         | Rvalue::ListReversed { list }
         | Rvalue::ListEnumerate { list } => rewrite_operand_except(list, aliases, dest),
+        Rvalue::ListSorted { list, key, .. } => {
+            rewrite_operand_except(list, aliases, dest)
+                | rewrite_optional_operand_except(key, aliases, dest)
+        }
         Rvalue::ListZip { left, right } => {
             rewrite_operand_except(left, aliases, dest)
                 | rewrite_operand_except(right, aliases, dest)
@@ -544,9 +547,15 @@ fn rewrite_rvalue(
             rewrite_operand_except(list, aliases, dest)
                 | rewrite_operand_except(item, aliases, dest)
         }
-        Rvalue::ListSort { list, comparator } => {
+        Rvalue::ListSort {
+            list,
+            comparator,
+            key,
+            ..
+        } => {
             rewrite_operand_except(list, aliases, dest)
                 | rewrite_optional_operand_except(comparator, aliases, dest)
+                | rewrite_optional_operand_except(key, aliases, dest)
         }
         Rvalue::ListPop { list } => rewrite_operand_except(list, aliases, dest),
         Rvalue::ListShift { list } => rewrite_operand_except(list, aliases, dest),

--- a/crates/smelt-mir/src/types.rs
+++ b/crates/smelt-mir/src/types.rs
@@ -1109,6 +1109,13 @@ pub enum Rvalue {
     ListSorted {
         /// List value to copy and sort.
         list: Operand,
+        /// Optional key closure for Python `sorted(values, key=...)`.
+        ///
+        /// The key is a normal closure operand mapping one list item to a
+        /// sortable value.
+        key: Option<Operand>,
+        /// Whether to sort in descending order, as in Python `reverse=True`.
+        reverse: bool,
     },
     /// Return a reversed copy of a list.
     ListReversed {
@@ -1164,6 +1171,13 @@ pub enum Rvalue {
         /// The comparator is a normal closure operand, like other list
         /// callbacks; it takes two list items and returns a number.
         comparator: Option<Operand>,
+        /// Optional key closure for Python `list.sort(key=...)`.
+        ///
+        /// The key is a normal closure operand mapping one list item to a
+        /// sortable value. It is mutually exclusive with `comparator`.
+        key: Option<Operand>,
+        /// Whether to sort in descending order, as in Python `reverse=True`.
+        reverse: bool,
     },
     /// Pop the last item from a list.
     ListPop {

--- a/crates/smelt-mir/src/validate.rs
+++ b/crates/smelt-mir/src/validate.rs
@@ -539,10 +539,15 @@ impl Rvalue {
             }
             Self::ListSum { list }
             | Self::ListBoolFold { list, .. }
-            | Self::ListSorted { list }
             | Self::ListReversed { list }
             | Self::ListEnumerate { list } => {
                 visit(list);
+            }
+            Self::ListSorted { list, key, .. } => {
+                visit(list);
+                if let Some(key) = key {
+                    visit(key);
+                }
             }
             Self::ListZip { left, right } => {
                 visit(left);
@@ -564,10 +569,18 @@ impl Rvalue {
                 visit(list);
                 visit(item);
             }
-            Self::ListSort { list, comparator } => {
+            Self::ListSort {
+                list,
+                comparator,
+                key,
+                ..
+            } => {
                 visit(list);
                 if let Some(comparator) = comparator {
                     visit(comparator);
+                }
+                if let Some(key) = key {
+                    visit(key);
                 }
             }
             Self::ListPop { list } => {


### PR DESCRIPTION
Extend the Python stdlib lowering so `sorted(values, key=..., reverse=...)`
and `list.sort(key=..., reverse=...)` match TypeScript's `Array.prototype.sort`
comparator parity. A scalar `key=` lambda or local callable lowers to a closure
mapping each item to a sortable value, and `reverse=True` swaps the comparison
operands to keep Python's stable descending order.

Threaded `key`/`reverse` through the `ListSorted`/`ListSort` HIR and MIR
variants (validation, optimization, formatting), and emit `sort_by` with the
bound key closure in the Rust backend. Floating keys use `partial_cmp`;
non-literal `reverse` flags and non-scalar key returns are rejected with
source-located diagnostics.

Added frontend lowering tests, codegen tests, updated reject-form tests for the
now-supported keywords, and verified an end-to-end generated crate compiles and
sorts correctly.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VM9Aao5xGfjwr7epPSoiA9