### PR TITLE
Add daily dev-log routine for honest X posts

### DIFF
--- a/devlog/NOTES.md
+++ b/devlog/NOTES.md
@@ -1,0 +1,14 @@
+# Dev-log notes inbox
+
+Jot anything you want in the next dev log here — a gripe, a thought, something
+that annoyed you, a thing you're proud of. One line each is fine. The `/devlog`
+routine reads this, weaves it in, and moves consumed lines to `## Archived`.
+
+This is the highest-signal input to the post. Git history says *what* changed;
+this says how you actually feel about it.
+
+## Pending
+
+- (write here)
+
+## Archived

--- a/devlog/README.md
+++ b/devlog/README.md
@@ -14,11 +14,16 @@ The `/devlog` skill (`skills/devlog/SKILL.md`) does the writing. Each run it:
 1. Looks at git history since the last log (`state.json` tracks the cutoff).
 2. Scans `blocker-logs/`, `Test-TODO.md`, and `IMPLEMENTATION_CHECKLIST.md` for
    real, current gripes.
-3. Folds in whatever you wrote in [`NOTES.md`](./NOTES.md) — the highest-signal
-   input.
-4. Drafts a single ≤280-char post (or offers a short thread), writes it to
-   `posts/YYYY-MM-DD.md`, and shows it to you to copy-paste.
-5. Advances `state.json` so tomorrow's window starts where today's ended.
+3. Folds in whatever you wrote in [`NOTES.md`](./NOTES.md).
+4. **Interviews you** — asks a few open questions (what'd you work on, what
+   pissed you off, what are you proud of, the AI-code angle, the vibe). You write
+   the raw material in your own words; the routine just makes it read well. (On
+   an unattended scheduled run with nobody to answer, it falls back to NOTES.md +
+   git history.)
+5. Drafts a single ≤280-char post in a slangy, honest dev voice (or offers a
+   short thread), writes it to `posts/YYYY-MM-DD.md`, and shows it to you to
+   copy-paste. Iterates if you want changes — it's your voice.
+6. Advances `state.json` so tomorrow's window starts where today's ended.
 
 ## Running it
 

--- a/devlog/README.md
+++ b/devlog/README.md
@@ -51,5 +51,9 @@ post.
 
 ## Notes on X limits
 
-Drafts target the free-tier 280-character limit. If you have X Premium and want
-longer posts or threads by default, say so and the skill can be relaxed.
+Drafts target the free-tier 280-character limit.
+
+The repo link never goes in the main post — X demotes posts with external links,
+and a link costs ~23 chars. When a post is worth linking, the draft includes a
+`reply:` line: post the main tweet, then reply to it with that link. Pure-gripe
+days skip the link entirely.

--- a/devlog/README.md
+++ b/devlog/README.md
@@ -1,0 +1,55 @@
+# Smelt dev log
+
+A once-a-day, honest dev-log routine for posting about Smelt on X (Twitter).
+It is deliberately **not** a promo machine: it puts gripes next to wins and is
+fine saying that a lot of the code is AI-generated.
+
+Nothing here posts to X automatically. Every run produces a **draft you read
+and post by hand**, so you stay in control of what ships.
+
+## How it works
+
+The `/devlog` skill (`skills/devlog/SKILL.md`) does the writing. Each run it:
+
+1. Looks at git history since the last log (`state.json` tracks the cutoff).
+2. Scans `blocker-logs/`, `Test-TODO.md`, and `IMPLEMENTATION_CHECKLIST.md` for
+   real, current gripes.
+3. Folds in whatever you wrote in [`NOTES.md`](./NOTES.md) — the highest-signal
+   input.
+4. Drafts a single ≤280-char post (or offers a short thread), writes it to
+   `posts/YYYY-MM-DD.md`, and shows it to you to copy-paste.
+5. Advances `state.json` so tomorrow's window starts where today's ended.
+
+## Running it
+
+**Manually:** open a session in this repo and run `/devlog`. Read the draft,
+tweak if you want, paste it to X.
+
+**Once a day (scheduled web session):** set up a scheduled session in Claude
+Code on the web (https://claude.ai/code → the repo's environment → schedule a
+recurring session). Use this as the session prompt:
+
+```
+Run the /devlog routine for Smelt. Draft today's dev-log post following
+skills/devlog/SKILL.md, show me the draft, and commit the draft + state update
+to the devlog branch. Do not post to X.
+```
+
+Set it to run once a day at whatever time you like. When it fires, the draft
+will be waiting in `devlog/posts/` and in the session transcript for you to
+post.
+
+> Why a session and not a cron/bash script: a templated script writes robotic
+> tweets. Letting the model read the actual project state each day is what makes
+> the log read like a person wrote it — gripes and all.
+
+## Files
+
+- `NOTES.md` — your freeform inbox for the next post. Write here between runs.
+- `posts/` — dated drafts. History of what the log said.
+- `state.json` — `last_commit` / `last_run`; the cutoff for "what changed".
+
+## Notes on X limits
+
+Drafts target the free-tier 280-character limit. If you have X Premium and want
+longer posts or threads by default, say so and the skill can be relaxed.

--- a/devlog/posts/2026-06-22-2.md
+++ b/devlog/posts/2026-06-22-2.md
@@ -1,0 +1,10 @@
+smelt dev log: Object prototypes now dispatch by runtime kind via sentinels. ngl at this point the job isnt writing code, its auditing whatever the agents shoved into my lowering pass. somehow the generated remeda suite is at 1714 passing real Rust tests tho. we move i guess.
+
+reply: code's here if you wanna point and laugh: https://github.com/Bombatomica64/smelt
+
+---
+
+- chars: 276 / 280
+- interview: worked on = Object prototypes via sentinels; gripe = auditing AI code is the real job; proud = 1714 passing real Rust tests; vibe = neutral / just vibing
+- supporting: commit 1fd7520 (Object prototypes by runtime kind via sentinels); blocker-logs/remeda-full-current-2026-06-22.md (1714 passed / 75 failed)
+- status: DRAFT — not posted. Copy-paste to X if you like it.

--- a/devlog/posts/2026-06-22.md
+++ b/devlog/posts/2026-06-22.md
@@ -1,5 +1,7 @@
 smelt dev log: generated remeda suite is at 1714/1789 passing as real Rust tests. today: fixed shuffle/omit/intersection/splitAt codegen. still 75 failing — evolve & when keep beating me. most of this is AI-written, so half the job is auditing what an agent did to my lowering.
 
+reply: code's here if you want to point and laugh: https://github.com/Bombatomica64/smelt
+
 ---
 
 - chars: 279 / 280

--- a/devlog/posts/2026-06-22.md
+++ b/devlog/posts/2026-06-22.md
@@ -1,0 +1,10 @@
+smelt dev log: generated remeda suite is at 1714/1789 passing as real Rust tests. today: fixed shuffle/omit/intersection/splitAt codegen. still 75 failing — evolve & when keep beating me. most of this is AI-written, so half the job is auditing what an agent did to my lowering.
+
+---
+
+- chars: 279 / 280
+- window: recent-history fallback (first run; state initialized at HEAD 4672b60)
+- wins: be50fb6 (shuffle/intersection/omit/splitAt/splitWhen/mergeAll/reduce codegen), 1fd7520 (Object prototypes via sentinels)
+- gripe: blocker-logs/remeda-full-current-2026-06-22.md — 1714 passed / 75 failed; largest groups evolve (6), when (6), isDeepEqual (5)
+- notes: NOTES.md pending was empty this run
+- status: DRAFT — not posted. Copy-paste to X if you like it.

--- a/devlog/state.json
+++ b/devlog/state.json
@@ -1,0 +1,4 @@
+{
+  "last_commit": "4672b60363c0556ae79f4bab748c9cdb8e8cd0a4",
+  "last_run": "2026-06-22"
+}

--- a/devlog/tracker.html
+++ b/devlog/tracker.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>smelt devlog · engagement tracker</title>
+<style>
+  :root {
+    --bg: #0f1115;
+    --panel: #171a21;
+    --panel-2: #1d212b;
+    --line: #272c38;
+    --text: #e7eaf0;
+    --muted: #8b93a7;
+    --accent: #5b9dff;
+    --accent-2: #f0883e;
+    --good: #4ec47a;
+    --bad: #e5586e;
+    --radius: 12px;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 1040px; margin: 0 auto; padding: 28px 20px 80px; }
+  header h1 { margin: 0 0 4px; font-size: 22px; letter-spacing: -0.01em; }
+  header p { margin: 0; color: var(--muted); font-size: 13px; }
+  .grid { display: grid; gap: 16px; }
+  .panel {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 18px;
+  }
+  .row { display: flex; gap: 12px; flex-wrap: wrap; align-items: flex-end; }
+  label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 5px; }
+  input, select, textarea {
+    background: var(--panel-2);
+    border: 1px solid var(--line);
+    color: var(--text);
+    border-radius: 8px;
+    padding: 8px 10px;
+    font: inherit;
+    width: 100%;
+  }
+  textarea { resize: vertical; min-height: 38px; }
+  input:focus, select:focus, textarea:focus { outline: none; border-color: var(--accent); }
+  .field { flex: 1 1 110px; min-width: 90px; }
+  .field.sm { flex: 0 1 130px; }
+  button {
+    background: var(--accent);
+    color: #0a0d12;
+    border: 0;
+    border-radius: 8px;
+    padding: 9px 16px;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  button:hover { filter: brightness(1.08); }
+  button.ghost { background: transparent; color: var(--muted); border: 1px solid var(--line); font-weight: 500; }
+  button.ghost:hover { color: var(--text); border-color: var(--muted); }
+  button.danger { background: transparent; color: var(--bad); border: 1px solid transparent; padding: 4px 8px; font-size: 12px; }
+  button.danger:hover { background: rgba(229,88,110,0.12); }
+  .toolbar { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+  .toolbar .spacer { flex: 1; }
+  h2 { font-size: 14px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted); margin: 0 0 14px; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 10px; }
+  .card { background: var(--panel-2); border: 1px solid var(--line); border-radius: 10px; padding: 12px 14px; }
+  .card .k { font-size: 11px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.05em; }
+  .card .v { font-size: 24px; font-weight: 700; margin-top: 3px; letter-spacing: -0.02em; }
+  .card .d { font-size: 12px; margin-top: 2px; color: var(--muted); }
+  .chip { display: inline-flex; gap: 6px; align-items: center; padding: 5px 10px; border-radius: 999px; border: 1px solid var(--line); background: var(--panel-2); cursor: pointer; font-size: 12px; color: var(--muted); }
+  .chip.active { color: var(--text); border-color: var(--accent); background: rgba(91,157,255,0.12); }
+  .chip .dot { width: 9px; height: 9px; border-radius: 50%; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  th, td { text-align: right; padding: 8px 10px; border-bottom: 1px solid var(--line); white-space: nowrap; }
+  th:first-child, td:first-child { text-align: left; }
+  th { color: var(--muted); font-weight: 500; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
+  tbody tr:hover { background: var(--panel-2); }
+  .muted { color: var(--muted); }
+  .empty { color: var(--muted); text-align: center; padding: 30px; font-size: 14px; }
+  svg text { fill: var(--muted); font-size: 11px; }
+  .legend { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 10px; }
+  .legend span { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--muted); }
+  .legend i { width: 12px; height: 3px; border-radius: 2px; display: inline-block; }
+  .note { font-size: 12px; color: var(--muted); margin-top: 10px; line-height: 1.6; }
+  .note a { color: var(--accent); }
+  @media (max-width: 560px) { .field.sm { flex: 1 1 45%; } }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <h1>smelt devlog · engagement tracker</h1>
+    <p>Glance at X post analytics, log a snapshot, watch the trend build over the months. Data lives in this browser — export regularly.</p>
+  </header>
+
+  <div class="grid" style="margin-top:22px;">
+
+    <!-- POST SELECTOR -->
+    <div class="panel">
+      <h2>Post</h2>
+      <div class="row">
+        <div class="field" style="flex:2 1 280px;">
+          <label for="postSelect">Tracked post</label>
+          <select id="postSelect"></select>
+        </div>
+        <div class="field" style="flex:0 0 auto;">
+          <label>&nbsp;</label>
+          <button class="ghost" id="newPostBtn">+ New post</button>
+        </div>
+        <div class="field" style="flex:0 0 auto;">
+          <label>&nbsp;</label>
+          <button class="danger" id="delPostBtn">Delete post</button>
+        </div>
+      </div>
+      <div class="row" style="margin-top:12px;">
+        <div class="field" style="flex:1 1 100%;">
+          <label for="postLabel">Label / note (e.g. the post text or date)</label>
+          <textarea id="postLabel" placeholder="smelt dev log: Object prototypes now dispatch by runtime kind…"></textarea>
+        </div>
+      </div>
+      <div class="row" style="margin-top:10px;">
+        <div class="field" style="flex:1 1 100%;">
+          <label for="postUrl">Post URL (optional)</label>
+          <input id="postUrl" type="url" placeholder="https://x.com/you/status/…" />
+        </div>
+      </div>
+    </div>
+
+    <!-- ADD SNAPSHOT -->
+    <div class="panel">
+      <h2>Log a snapshot</h2>
+      <div class="row">
+        <div class="field sm"><label for="fDate">Date</label><input id="fDate" type="date" /></div>
+        <div class="field sm"><label for="fViews">Impressions</label><input id="fViews" type="number" min="0" placeholder="0" /></div>
+        <div class="field sm"><label for="fLikes">Likes</label><input id="fLikes" type="number" min="0" placeholder="0" /></div>
+        <div class="field sm"><label for="fReposts">Reposts</label><input id="fReposts" type="number" min="0" placeholder="0" /></div>
+        <div class="field sm"><label for="fReplies">Replies</label><input id="fReplies" type="number" min="0" placeholder="0" /></div>
+        <div class="field sm"><label for="fBookmarks">Bookmarks</label><input id="fBookmarks" type="number" min="0" placeholder="0" /></div>
+        <div class="field" style="flex:0 0 auto;"><label>&nbsp;</label><button id="addBtn">Save snapshot</button></div>
+      </div>
+      <p class="note">Tip: open your post on X → <em>View post analytics</em> → copy the totals here. Logging once a day gives you a clean day-to-day curve.</p>
+    </div>
+
+    <!-- SUMMARY CARDS -->
+    <div class="panel">
+      <h2>Latest totals</h2>
+      <div class="cards" id="cards"></div>
+    </div>
+
+    <!-- CHART -->
+    <div class="panel">
+      <div class="toolbar" style="margin-bottom:14px;">
+        <h2 style="margin:0;">Trend</h2>
+        <div class="spacer"></div>
+        <span class="chip" data-mode="cumulative" id="modeCum">Totals</span>
+        <span class="chip" data-mode="daily" id="modeDaily">Day-to-day</span>
+      </div>
+      <div id="metricChips" style="display:flex; gap:8px; flex-wrap:wrap; margin-bottom:14px;"></div>
+      <div id="chart"></div>
+      <div class="legend" id="legend"></div>
+    </div>
+
+    <!-- TABLE -->
+    <div class="panel">
+      <div class="toolbar" style="margin-bottom:14px;">
+        <h2 style="margin:0;">Snapshots</h2>
+        <div class="spacer"></div>
+        <button class="ghost" id="exportBtn">Export JSON</button>
+        <button class="ghost" id="importBtn">Import JSON</button>
+        <input id="importFile" type="file" accept="application/json" style="display:none;" />
+      </div>
+      <div id="tableWrap"></div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+"use strict";
+
+/* ----- storage model -----
+   db = { posts: [ { id, label, url, snaps: [ {date, views, likes, reposts, replies, bookmarks} ] } ], current }
+*/
+const KEY = "smelt-devlog-tracker-v1";
+const METRICS = [
+  { k: "views",     label: "Impressions", color: "#5b9dff" },
+  { k: "likes",     label: "Likes",       color: "#4ec47a" },
+  { k: "reposts",   label: "Reposts",     color: "#f0883e" },
+  { k: "replies",   label: "Replies",     color: "#c77dff" },
+  { k: "bookmarks", label: "Bookmarks",   color: "#e5586e" },
+];
+
+let db = load();
+let mode = "cumulative";              // or "daily"
+let active = new Set(["views", "likes"]);
+
+function load() {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (raw) return JSON.parse(raw);
+  } catch (e) {}
+  const id = uid();
+  return { posts: [{ id, label: "", url: "", snaps: [] }], current: id };
+}
+function save() { localStorage.setItem(KEY, JSON.stringify(db)); }
+function uid() { return Math.random().toString(36).slice(2, 9); }
+function fmt(n) { return (n == null || isNaN(n)) ? "—" : Number(n).toLocaleString(); }
+function currentPost() { return db.posts.find(p => p.id === db.current) || db.posts[0]; }
+function sortedSnaps() {
+  return [...currentPost().snaps].sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/* ----- post selector ----- */
+const postSelect = document.getElementById("postSelect");
+const postLabel = document.getElementById("postLabel");
+const postUrl = document.getElementById("postUrl");
+
+function renderPostSelect() {
+  postSelect.innerHTML = "";
+  db.posts.forEach((p, i) => {
+    const o = document.createElement("option");
+    o.value = p.id;
+    const txt = (p.label || "").trim();
+    o.textContent = (txt ? txt.slice(0, 50) : `Post ${i + 1}`) + (txt.length > 50 ? "…" : "");
+    if (p.id === db.current) o.selected = true;
+    postSelect.appendChild(o);
+  });
+  const p = currentPost();
+  postLabel.value = p.label || "";
+  postUrl.value = p.url || "";
+}
+postSelect.onchange = () => { db.current = postSelect.value; save(); renderAll(); };
+postLabel.oninput = () => { currentPost().label = postLabel.value; save(); renderPostSelect(); };
+postUrl.oninput = () => { currentPost().url = postUrl.value; save(); };
+document.getElementById("newPostBtn").onclick = () => {
+  const id = uid();
+  db.posts.push({ id, label: "", url: "", snaps: [] });
+  db.current = id; save(); renderAll();
+  postLabel.focus();
+};
+document.getElementById("delPostBtn").onclick = () => {
+  if (db.posts.length === 1) { alert("Keep at least one post."); return; }
+  if (!confirm("Delete this post and its snapshots?")) return;
+  db.posts = db.posts.filter(p => p.id !== db.current);
+  db.current = db.posts[0].id; save(); renderAll();
+};
+
+/* ----- add snapshot ----- */
+const fDate = document.getElementById("fDate");
+fDate.value = new Date().toISOString().slice(0, 10);
+document.getElementById("addBtn").onclick = () => {
+  const date = fDate.value;
+  if (!date) { alert("Pick a date."); return; }
+  const get = id => { const v = document.getElementById(id).value; return v === "" ? 0 : Math.max(0, Number(v)); };
+  const snap = {
+    date,
+    views: get("fViews"), likes: get("fLikes"), reposts: get("fReposts"),
+    replies: get("fReplies"), bookmarks: get("fBookmarks"),
+  };
+  const snaps = currentPost().snaps;
+  const existing = snaps.findIndex(s => s.date === date);
+  if (existing >= 0) {
+    if (!confirm("A snapshot for that date exists. Overwrite it?")) return;
+    snaps[existing] = snap;
+  } else {
+    snaps.push(snap);
+  }
+  save();
+  ["fViews","fLikes","fReposts","fReplies","fBookmarks"].forEach(id => document.getElementById(id).value = "");
+  renderAll();
+};
+
+/* ----- summary cards ----- */
+function renderCards() {
+  const snaps = sortedSnaps();
+  const last = snaps[snaps.length - 1];
+  const prev = snaps[snaps.length - 2];
+  const wrap = document.getElementById("cards");
+  wrap.innerHTML = "";
+  METRICS.forEach(m => {
+    const v = last ? last[m.k] : null;
+    let delta = "";
+    if (last && prev) {
+      const d = last[m.k] - prev[m.k];
+      const sign = d > 0 ? "+" : "";
+      const col = d > 0 ? "var(--good)" : d < 0 ? "var(--bad)" : "var(--muted)";
+      delta = `<div class="d" style="color:${col}">${sign}${fmt(d)} since prev</div>`;
+    }
+    const el = document.createElement("div");
+    el.className = "card";
+    el.innerHTML = `<div class="k" style="color:${m.color}">${m.label}</div><div class="v">${fmt(v)}</div>${delta}`;
+    wrap.appendChild(el);
+  });
+}
+
+/* ----- metric chips + mode ----- */
+function renderChips() {
+  const wrap = document.getElementById("metricChips");
+  wrap.innerHTML = "";
+  METRICS.forEach(m => {
+    const c = document.createElement("span");
+    c.className = "chip" + (active.has(m.k) ? " active" : "");
+    c.innerHTML = `<i class="dot" style="background:${m.color}"></i>${m.label}`;
+    c.onclick = () => {
+      if (active.has(m.k)) { if (active.size > 1) active.delete(m.k); }
+      else active.add(m.k);
+      renderChips(); renderChart();
+    };
+    wrap.appendChild(c);
+  });
+  document.getElementById("modeCum").classList.toggle("active", mode === "cumulative");
+  document.getElementById("modeDaily").classList.toggle("active", mode === "daily");
+}
+document.getElementById("modeCum").onclick = () => { mode = "cumulative"; renderChips(); renderChart(); };
+document.getElementById("modeDaily").onclick = () => { mode = "daily"; renderChips(); renderChart(); };
+
+/* ----- chart (hand-rolled SVG, zero deps) ----- */
+function seriesFor(metricKey) {
+  const snaps = sortedSnaps();
+  if (mode === "cumulative") {
+    return snaps.map(s => ({ date: s.date, y: s[metricKey] }));
+  }
+  // day-to-day: delta vs previous snapshot, normalized per day so uneven gaps stay fair
+  const out = [];
+  for (let i = 1; i < snaps.length; i++) {
+    const days = Math.max(1, daysBetween(snaps[i - 1].date, snaps[i].date));
+    out.push({ date: snaps[i].date, y: (snaps[i][metricKey] - snaps[i - 1][metricKey]) / days });
+  }
+  return out;
+}
+function daysBetween(a, b) {
+  return Math.round((new Date(b) - new Date(a)) / 86400000);
+}
+function renderChart() {
+  const host = document.getElementById("chart");
+  const snaps = sortedSnaps();
+  const need = mode === "daily" ? 3 : 2;
+  if (snaps.length < need) {
+    host.innerHTML = `<div class="empty">Log at least ${need} snapshots to draw the ${mode === "daily" ? "day-to-day" : ""} trend.</div>`;
+    document.getElementById("legend").innerHTML = "";
+    return;
+  }
+  const W = 980, H = 320, pad = { l: 52, r: 16, t: 16, b: 34 };
+  const keys = METRICS.filter(m => active.has(m.k)).map(m => m.k);
+  const seriesMap = {};
+  let maxY = 0, minY = 0;
+  const datesSet = new Set();
+  keys.forEach(k => {
+    const s = seriesFor(k);
+    seriesMap[k] = s;
+    s.forEach(pt => { datesSet.add(pt.date); maxY = Math.max(maxY, pt.y); minY = Math.min(minY, pt.y); });
+  });
+  const dates = [...datesSet].sort();
+  if (maxY === minY) maxY = minY + 1;
+  // pad headroom
+  maxY = maxY + (maxY - minY) * 0.08;
+
+  const x = i => pad.l + (dates.length === 1 ? 0 : (W - pad.l - pad.r) * i / (dates.length - 1));
+  const y = v => pad.t + (H - pad.t - pad.b) * (1 - (v - minY) / (maxY - minY));
+  const dateIndex = {}; dates.forEach((d, i) => dateIndex[d] = i);
+
+  let svg = `<svg viewBox="0 0 ${W} ${H}" width="100%" preserveAspectRatio="xMidYMid meet" role="img">`;
+  // gridlines + y labels
+  const ticks = 4;
+  for (let t = 0; t <= ticks; t++) {
+    const val = minY + (maxY - minY) * t / ticks;
+    const yy = y(val);
+    svg += `<line x1="${pad.l}" y1="${yy}" x2="${W - pad.r}" y2="${yy}" stroke="#272c38" stroke-width="1"/>`;
+    svg += `<text x="${pad.l - 8}" y="${yy + 4}" text-anchor="end">${fmt(Math.round(val))}</text>`;
+  }
+  // x labels (thin out if many)
+  const step = Math.ceil(dates.length / 8);
+  dates.forEach((d, i) => {
+    if (i % step !== 0 && i !== dates.length - 1) return;
+    svg += `<text x="${x(i)}" y="${H - 12}" text-anchor="middle">${d.slice(5)}</text>`;
+  });
+  // lines
+  keys.forEach(k => {
+    const m = METRICS.find(mm => mm.k === k);
+    const pts = seriesMap[k];
+    if (!pts.length) return;
+    const path = pts.map((pt, j) => `${j === 0 ? "M" : "L"} ${x(dateIndex[pt.date])} ${y(pt.y)}`).join(" ");
+    svg += `<path d="${path}" fill="none" stroke="${m.color}" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>`;
+    pts.forEach(pt => {
+      svg += `<circle cx="${x(dateIndex[pt.date])}" cy="${y(pt.y)}" r="3.2" fill="${m.color}"><title>${pt.date} · ${m.label}: ${fmt(Math.round(pt.y))}</title></circle>`;
+    });
+  });
+  svg += `</svg>`;
+  host.innerHTML = svg;
+
+  document.getElementById("legend").innerHTML = keys.map(k => {
+    const m = METRICS.find(mm => mm.k === k);
+    return `<span><i style="background:${m.color}"></i>${m.label}${mode === "daily" ? " / day" : ""}</span>`;
+  }).join("");
+}
+
+/* ----- table ----- */
+function renderTable() {
+  const snaps = sortedSnaps();
+  const wrap = document.getElementById("tableWrap");
+  if (!snaps.length) { wrap.innerHTML = `<div class="empty">No snapshots yet. Log one above.</div>`; return; }
+  let html = `<table><thead><tr><th>Date</th>${METRICS.map(m => `<th>${m.label}</th>`).join("")}<th></th></tr></thead><tbody>`;
+  snaps.forEach(s => {
+    html += `<tr><td>${s.date}</td>${METRICS.map(m => `<td>${fmt(s[m.k])}</td>`).join("")}<td><button class="danger" data-del="${s.date}">delete</button></td></tr>`;
+  });
+  html += `</tbody></table>`;
+  wrap.innerHTML = html;
+  wrap.querySelectorAll("[data-del]").forEach(b => {
+    b.onclick = () => {
+      const d = b.getAttribute("data-del");
+      currentPost().snaps = currentPost().snaps.filter(s => s.date !== d);
+      save(); renderAll();
+    };
+  });
+}
+
+/* ----- export / import ----- */
+document.getElementById("exportBtn").onclick = () => {
+  const blob = new Blob([JSON.stringify(db, null, 2)], { type: "application/json" });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = `smelt-engagement-${new Date().toISOString().slice(0,10)}.json`;
+  a.click();
+  URL.revokeObjectURL(a.href);
+};
+document.getElementById("importBtn").onclick = () => document.getElementById("importFile").click();
+document.getElementById("importFile").onchange = (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const data = JSON.parse(reader.result);
+      if (!data.posts || !Array.isArray(data.posts)) throw new Error("bad shape");
+      db = data;
+      if (!db.current || !db.posts.find(p => p.id === db.current)) db.current = db.posts[0].id;
+      save(); renderAll();
+    } catch (err) { alert("Couldn't import that file: " + err.message); }
+  };
+  reader.readAsText(file);
+  e.target.value = "";
+};
+
+/* ----- render all ----- */
+function renderAll() {
+  renderPostSelect();
+  renderCards();
+  renderChips();
+  renderChart();
+  renderTable();
+}
+renderAll();
+</script>
+</body>
+</html>

--- a/skills/devlog/SKILL.md
+++ b/skills/devlog/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: devlog
+description: Draft an honest, once-a-day X (Twitter) dev-log post about Smelt. Use when the user wants their daily dev log, runs /devlog, or a scheduled web session fires the daily devlog routine. Reads git history since the last log, scans blockers/TODOs for gripes, folds in the user's freeform notes, and writes a draft post for manual review — it NEVER posts anything itself.
+---
+
+# Daily Dev Log (X / Twitter)
+
+Draft one honest dev-log post about Smelt, written the way the maintainer
+actually talks about the project — wins next to gripes, no marketing voice.
+The output is a **draft for the user to read and post manually**. This routine
+must never publish to X, never call an external API, and never pretend a post
+was sent.
+
+## Voice
+
+This is a personal dev log, not an announcement. Match these rules:
+
+- **Honest over hype.** Lead with what actually happened, including what broke
+  or annoyed you. A good post can be mostly a gripe.
+- **No promo language.** Never "excited to announce", "🚀", "game-changer",
+  "the future of", call-to-action, or hashtag spam. At most one tag if it's
+  genuinely relevant.
+- **AI-generated code is not a secret.** A lot of Smelt's code is AI-generated
+  and the user is fine saying so. When it's relevant (a bug an agent caused, a
+  refactor an agent did, trusting/distrusting generated output), say it plainly.
+  Don't force it into every post.
+- **First person, lowercase-friendly, terse.** Sound like a tired-but-curious
+  engineer, not a brand. Dry humor is welcome.
+- **Concrete.** Name the actual thing — `date-fns` slice, clippy warnings,
+  HIR/MIR lowering, a specific commit — not "made great progress."
+
+## Length
+
+- Default to a **single post ≤ 280 characters** (assume free-tier X limits).
+- If there's genuinely too much for one post, offer a **2–3 post thread** as an
+  alternative, but still give the single-post version first.
+- Never pad to fill space. A 120-character post is fine.
+
+## Procedure
+
+1. **Find the window.** Read `devlog/state.json` for `last_commit`. The window
+   is `git log <last_commit>..HEAD`. If the file is missing or the commit is
+   unknown, fall back to the last 24h: `git log --since="1 day ago"`.
+
+2. **Gather wins (git history).**
+   - `git log <last_commit>..HEAD --oneline`
+   - For anything ambiguous, `git show --stat <sha>` to see what really changed.
+   - Ignore pure noise commits (`chore(ci): update coverage report`, golden
+     output refreshes) unless that IS the story.
+
+3. **Gather gripes.** Skim for current pain, don't deep-read everything:
+   - `blocker-logs/` — newest files (`ls -t blocker-logs | head`); these are the
+     active failures and frustrations.
+   - `Test-TODO.md` and `IMPLEMENTATION_CHECKLIST.md` — unchecked / open items
+     near recently touched areas.
+   - Optionally `cargo test`/`cargo clippy` state if a gripe needs a live number,
+     but don't run a full suite just to write a tweet — cite what the logs say.
+
+4. **Fold in the user's notes.** Read `devlog/NOTES.md`. Anything the user jotted
+   there since the last run is the highest-signal input — weave it in and then
+   clear the consumed lines (move them under a `## Archived` heading, don't
+   delete, so there's a record).
+
+5. **Draft the post.** One honest paragraph or a few short lines. Include at least
+   one real gripe unless the day was genuinely clean. Keep it ≤ 280 chars.
+
+6. **Write the draft to a file**, do not post it:
+   - Path: `devlog/posts/YYYY-MM-DD.md` (today's UTC date).
+   - Contents: the post text, then a `---` and a short "sources" note listing the
+     commits / blockers / notes you drew from, and the character count.
+   - If the file already exists for today, write `YYYY-MM-DD-2.md` etc.
+
+7. **Show the draft in chat** verbatim, with the character count, and tell the
+   user it's ready to copy-paste. Offer the thread version only if step 5 hit the
+   length limit with leftover material.
+
+8. **Update state.** Set `last_commit` in `devlog/state.json` to current `HEAD`
+   and `last_run` to today's UTC date. This advances the window even if the user
+   chooses not to post — a skipped day just means tomorrow's window is larger.
+
+## Hard rules
+
+- Never post to X or any network. Draft only.
+- Never invent progress. If the window is empty or boring, say so in the draft
+  ("quiet day, mostly CI noise") rather than manufacturing a milestone.
+- Keep `git status` clean-ish: the only files this routine writes are under
+  `devlog/`.
+- Don't regenerate or touch generated Rust files (see AGENTS.md).

--- a/skills/devlog/SKILL.md
+++ b/skills/devlog/SKILL.md
@@ -13,21 +13,30 @@ was sent.
 
 ## Voice
 
-This is a personal dev log, not an announcement. Match these rules:
+This is a personal dev log, not an announcement. The user writes the raw
+material; you make it read well. Match these rules:
 
 - **Honest over hype.** Lead with what actually happened, including what broke
   or annoyed you. A good post can be mostly a gripe.
 - **No promo language.** Never "excited to announce", "🚀", "game-changer",
   "the future of", call-to-action, or hashtag spam. At most one tag if it's
   genuinely relevant.
+- **Slangy and online.** Sound like a dev posting at 1am, not a brand. Lean into
+  dev/online slang where it fits — e.g. "ngl", "tbh", "lowkey/highkey", "cooked",
+  "this is held together with vibes", "yak-shaving", "skill issue", "it's so
+  over / we're so back", "ship it", "jank", "fighting for my life in the borrow
+  checker". One or two slang beats per post — don't force it into every line or
+  it reads try-hard. Match the user's own phrasing from the interview when they
+  give it.
 - **AI-generated code is not a secret.** A lot of Smelt's code is AI-generated
   and the user is fine saying so. When it's relevant (a bug an agent caused, a
   refactor an agent did, trusting/distrusting generated output), say it plainly.
   Don't force it into every post.
-- **First person, lowercase-friendly, terse.** Sound like a tired-but-curious
-  engineer, not a brand. Dry humor is welcome.
+- **First person, lowercase-friendly, terse.** Dry humor welcome.
 - **Concrete.** Name the actual thing — `date-fns` slice, clippy warnings,
   HIR/MIR lowering, a specific commit — not "made great progress."
+- **Keep it the user's, not yours.** You're polishing their take, not replacing
+  it. Don't invent opinions or details they didn't give.
 
 ## Length
 
@@ -68,26 +77,49 @@ This is a personal dev log, not an announcement. Match these rules:
      but don't run a full suite just to write a tweet — cite what the logs say.
 
 4. **Fold in the user's notes.** Read `devlog/NOTES.md`. Anything the user jotted
-   there since the last run is the highest-signal input — weave it in and then
-   clear the consumed lines (move them under a `## Archived` heading, don't
-   delete, so there's a record).
+   there since the last run is high-signal input — weave it in and then clear the
+   consumed lines (move them under a `## Archived` heading, don't delete, so
+   there's a record).
 
-5. **Draft the post.** One honest paragraph or a few short lines. Include at least
-   one real gripe unless the day was genuinely clean. Keep it ≤ 280 chars.
+5. **Interview the user (interactive runs).** This is the main input — the user
+   writes most of the content, you make it good. Use the `AskUserQuestion` tool
+   to ask several open questions in one batch so they can answer in their own
+   words (they answer via the free-text "Other" field, or just reply in chat).
+   Ground the questions in what you found in steps 2–3 so they're not generic.
+   Ask roughly these, adapted to the day:
+   - **What'd you actually work on today?** (offer the commits you found as a
+     jog, but let them rewrite it)
+   - **What pissed you off / what's janky right now?** (the gripe — the heart of
+     the post)
+   - **Anything you're lowkey proud of?**
+   - **Anything to say about the AI-written side today?** (optional)
+   - **Vibe for today — we so back, or it's so over?**
 
-6. **Write the draft to a file**, do not post it:
+   Their raw answers are the primary material. If they hand you a full sentence,
+   keep their words and just tighten. If they give fragments, you assemble.
+
+   **Unattended / scheduled runs:** if no user is there to answer (e.g. a
+   scheduled web session running solo), skip the interview and draft from
+   `NOTES.md` + git history instead, then leave the draft for review.
+
+6. **Draft the post.** Shape the interview answers into one honest, slangy post.
+   Include at least one real gripe unless the day was genuinely clean. Keep their
+   voice; don't add opinions they didn't give. Keep it ≤ 280 chars.
+
+7. **Write the draft to a file**, do not post it:
    - Path: `devlog/posts/YYYY-MM-DD.md` (today's UTC date).
    - Contents: the post text; then, if the post warrants a link, a `reply:` line
      with the suggested first-reply (repo link); then a `---` and a short
-     "sources" note listing the commits / blockers / notes you drew from, and the
-     character count.
+     "sources" note listing the commits / blockers / notes / interview answers
+     you drew from, and the character count.
    - If the file already exists for today, write `YYYY-MM-DD-2.md` etc.
 
-7. **Show the draft in chat** verbatim, with the character count, and tell the
-   user it's ready to copy-paste. Offer the thread version only if step 5 hit the
-   length limit with leftover material.
+8. **Show the draft in chat** verbatim, with the character count, and tell the
+   user it's ready to copy-paste. If they want changes, iterate — it's their
+   voice. Offer the thread version only if step 6 hit the length limit with
+   leftover material.
 
-8. **Update state.** Set `last_commit` in `devlog/state.json` to current `HEAD`
+9. **Update state.** Set `last_commit` in `devlog/state.json` to current `HEAD`
    and `last_run` to today's UTC date. This advances the window even if the user
    chooses not to post — a skipped day just means tomorrow's window is larger.
 

--- a/skills/devlog/SKILL.md
+++ b/skills/devlog/SKILL.md
@@ -36,6 +36,17 @@ This is a personal dev log, not an announcement. Match these rules:
   alternative, but still give the single-post version first.
 - Never pad to fill space. A 120-character post is fine.
 
+## Links
+
+- **Never put the repo link in the main post.** X demotes posts with external
+  links, and a link burns ~23 chars of the 280 budget. The main post is content
+  only.
+- When the post points at something worth clicking, put the repo link in a
+  suggested **first reply** instead (added to the draft file under a `reply:`
+  line). The user posts the main tweet, then replies to it with the link.
+- On a pure-gripe / nothing-to-click day, skip the reply entirely — don't link
+  reflexively. Repo: https://github.com/Bombatomica64/smelt
+
 ## Procedure
 
 1. **Find the window.** Read `devlog/state.json` for `last_commit`. The window
@@ -66,8 +77,10 @@ This is a personal dev log, not an announcement. Match these rules:
 
 6. **Write the draft to a file**, do not post it:
    - Path: `devlog/posts/YYYY-MM-DD.md` (today's UTC date).
-   - Contents: the post text, then a `---` and a short "sources" note listing the
-     commits / blockers / notes you drew from, and the character count.
+   - Contents: the post text; then, if the post warrants a link, a `reply:` line
+     with the suggested first-reply (repo link); then a `---` and a short
+     "sources" note listing the commits / blockers / notes you drew from, and the
+     character count.
    - If the file already exists for today, write `YYYY-MM-DD-2.md` etc.
 
 7. **Show the draft in chat** verbatim, with the character count, and tell the


### PR DESCRIPTION
A /devlog skill that drafts a once-a-day, honest dev-log post about
Smelt for manual posting to X. Reads git history since the last log,
scans blocker-logs/TODOs for real gripes, folds in a freeform NOTES.md
inbox, and writes a draft to devlog/posts/ — it never posts itself.

Includes setup docs for running it as a scheduled Claude Code web
session, plus today's first draft.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VzPuYyTgVy88eBytrzMJdu