### PR TITLE
Add bug-library transpile probes + daily Library Probes CI

### DIFF
--- a/.github/compat/README.md
+++ b/.github/compat/README.md
@@ -5,9 +5,15 @@ TypeScript or Python library's source root + test glob. They are used to probe
 how far Smelt can transpile real-world "bug libraries".
 
 `remeda/` is the curated, passing compat target wired into the
-`Compatibility` GitHub Actions workflow. The others are exploratory probes;
-the most recent results are written up in
-[`blocker-logs/bug-library-probes-2026-06-24.md`](../../blocker-logs/bug-library-probes-2026-06-24.md).
+`Compatibility` GitHub Actions workflow. The others are exploratory probes run
+daily by the [`Library Probes`](../workflows/library-probes.yml) workflow, which
+refreshes the report at
+[`blocker-logs/library-probes.md`](../../blocker-logs/library-probes.md).
+
+The probe set, pinned refs, and per-library source roots live in
+[`libraries.json`](./libraries.json); the driver is
+[`scripts/probe_libraries.py`](../../scripts/probe_libraries.py). Bump a `ref`
+deliberately to re-baseline a probe against a newer library version.
 
 ## Probed libraries
 
@@ -46,4 +52,17 @@ cargo run --bin smelt -- rust-test-report \
 # 4b. If the build aborts at the first unsupported file, enumerate every
 #     blocker class across the whole library:
 SMELT_ROOT=$PWD python3 scripts/probe_blocker_scan.py lib ts src
+```
+
+## Reproducing the whole report locally
+
+```bash
+cargo build --bin smelt
+mkdir -p target/library-probes
+# clone each library at its pinned ref into target/library-probes/<name>, then:
+python3 scripts/probe_libraries.py \
+  --config .github/compat/libraries.json \
+  --fixtures .github/compat \
+  --work-dir target/library-probes \
+  --output blocker-logs/library-probes.md
 ```

--- a/.github/compat/README.md
+++ b/.github/compat/README.md
@@ -1,0 +1,49 @@
+# Compatibility probe fixtures
+
+Each subdirectory holds a `Smelt.toml` that points Smelt at a third-party
+TypeScript or Python library's source root + test glob. They are used to probe
+how far Smelt can transpile real-world "bug libraries".
+
+`remeda/` is the curated, passing compat target wired into the
+`Compatibility` GitHub Actions workflow. The others are exploratory probes;
+the most recent results are written up in
+[`blocker-logs/bug-library-probes-2026-06-24.md`](../../blocker-logs/bug-library-probes-2026-06-24.md).
+
+## Probed libraries
+
+| Dir | Source repo | Language |
+| --- | --- | --- |
+| `remeda` | `remeda/remeda` | TS (reference, passes) |
+| `es-toolkit` | `toss/es-toolkit` | TS |
+| `radash` | `sodiray/radash` | TS |
+| `ts-pattern` | `gvergnaud/ts-pattern` | TS |
+| `valibot` | `fabian-hiller/valibot` | TS |
+| `neverthrow` | `supermacro/neverthrow` | TS |
+| `returns` | `dry-python/returns` | Py |
+| `result` | `rustedpy/result` | Py |
+| `more-itertools` | `more-itertools/more-itertools` | Py |
+| `funcy` | `Suor/funcy` | Py |
+| `toolz` | `pytoolz/toolz` | Py |
+
+## Reproducing a probe
+
+```bash
+# 1. Fetch the library source (default branch) next to Smelt.
+curl -L -o lib.tar.gz https://codeload.github.com/<org>/<repo>/tar.gz/refs/heads/main
+mkdir lib && tar -xzf lib.tar.gz -C lib --strip-components=1
+
+# 2. Drop the fixture manifest into the library root.
+cp .github/compat/<name>/Smelt.toml lib/Smelt.toml
+
+# 3. Try a whole-crate transpile.
+cargo run --bin smelt -- build --manifest-path lib/Smelt.toml
+
+# 4a. If it transpiles, run the generated tests.
+cargo run --bin smelt -- rust-test-report \
+  --build-manifest lib/Smelt.toml \
+  --cargo-manifest lib/dist-smelt/Cargo.toml --full --output report.md
+
+# 4b. If the build aborts at the first unsupported file, enumerate every
+#     blocker class across the whole library:
+SMELT_ROOT=$PWD python3 scripts/probe_blocker_scan.py lib ts src
+```

--- a/.github/compat/es-toolkit/Smelt.toml
+++ b/.github/compat/es-toolkit/Smelt.toml
@@ -1,0 +1,24 @@
+[project]
+name = "es-toolkit"
+version = "0.0.0"
+description = "es-toolkit Smelt probe"
+
+[sources]
+roots = ["src"]
+test-prefix = ["array/**/*.spec.ts", "function/**/*.spec.ts", "math/**/*.spec.ts", "object/**/*.spec.ts", "predicate/**/*.spec.ts", "promise/**/*.spec.ts", "string/**/*.spec.ts", "util/**/*.spec.ts", "error/**/*.spec.ts"]
+entries = ["src/index.ts"]
+
+[output]
+target = "./dist-smelt"
+crate-name = "es_toolkit_probe"
+build = false
+
+[rust]
+edition = "2024"
+
+[strict]
+typescript = true
+python = true
+
+[runtime]
+clone-strategy = "aggressive"

--- a/.github/compat/funcy/Smelt.toml
+++ b/.github/compat/funcy/Smelt.toml
@@ -1,0 +1,24 @@
+[project]
+name = "funcy"
+version = "0.0.0"
+description = "funcy Smelt probe"
+
+[sources]
+roots = ["."]
+test-prefix = ["tests/**/test_*.py"]
+entries = ["funcy/__init__.py"]
+
+[output]
+target = "./dist-smelt"
+crate-name = "funcy_probe"
+build = false
+
+[rust]
+edition = "2024"
+
+[strict]
+typescript = true
+python = true
+
+[runtime]
+clone-strategy = "aggressive"

--- a/.github/compat/libraries.json
+++ b/.github/compat/libraries.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Libraries probed by the daily library-probes workflow. Refs are pinned so the report tracks Smelt's progress, not upstream drift. Bump a ref deliberately to re-baseline against a newer library version. `roots` are the source roots scanned for blockers and must match the fixture Smelt.toml.",
+  "libraries": [
+    { "name": "es-toolkit",     "repo": "toss/es-toolkit",                 "ref": "e008a2818cd8d07469a5cc12ee0c02405d523e07", "lang": "ts", "roots": ["src"] },
+    { "name": "radash",         "repo": "sodiray/radash",                  "ref": "4cab1900d08e0997abc4f17aec3cbfe18958d766", "lang": "ts", "roots": ["src"] },
+    { "name": "ts-pattern",     "repo": "gvergnaud/ts-pattern",            "ref": "c92ca435c7e1827e0fd55c539080ef1bfd6fe3f0", "lang": "ts", "roots": ["src", "tests"] },
+    { "name": "valibot",        "repo": "fabian-hiller/valibot",           "ref": "1f9b18338ad5530f1f6c63c2cf241962bd82d6f8", "lang": "ts", "roots": ["library/src"] },
+    { "name": "neverthrow",     "repo": "supermacro/neverthrow",           "ref": "5ef3a018bda74fb960e44b68fc3672635ee8037d", "lang": "ts", "roots": ["src", "tests"] },
+    { "name": "returns",        "repo": "dry-python/returns",              "ref": "04e820c714615192baf815bcbe15eccbbd15541e", "lang": "py", "roots": ["returns", "tests"] },
+    { "name": "result",         "repo": "rustedpy/result",                 "ref": "0b855e1e38a08d6f0a4b0138b10c127c01e54ab4", "lang": "py", "roots": ["src", "tests"] },
+    { "name": "more-itertools", "repo": "more-itertools/more-itertools",   "ref": "5d946b3590bfe92f1465c1b9b9830dd434745c84", "lang": "py", "roots": ["more_itertools", "tests"] },
+    { "name": "funcy",          "repo": "Suor/funcy",                      "ref": "9eb04473e31b6b60bd459e4dda24f6b1db5a3773", "lang": "py", "roots": ["funcy", "tests"] },
+    { "name": "toolz",          "repo": "pytoolz/toolz",                   "ref": "568c2b8393973cd172a466546c9d95779c452438", "lang": "py", "roots": ["toolz"] }
+  ]
+}

--- a/.github/compat/more-itertools/Smelt.toml
+++ b/.github/compat/more-itertools/Smelt.toml
@@ -1,0 +1,24 @@
+[project]
+name = "more-itertools"
+version = "0.0.0"
+description = "more-itertools Smelt probe"
+
+[sources]
+roots = ["."]
+test-prefix = ["tests/**/test_*.py"]
+entries = ["more_itertools/__init__.py"]
+
+[output]
+target = "./dist-smelt"
+crate-name = "more_itertools_probe"
+build = false
+
+[rust]
+edition = "2024"
+
+[strict]
+typescript = true
+python = true
+
+[runtime]
+clone-strategy = "aggressive"

--- a/.github/compat/neverthrow/Smelt.toml
+++ b/.github/compat/neverthrow/Smelt.toml
@@ -1,0 +1,19 @@
+[project]
+name = "neverthrow"
+version = "0.0.0"
+description = "neverthrow Smelt probe"
+[sources]
+roots = ["src", "tests"]
+test-prefix = ["**/*.test.ts"]
+entries = ["src/index.ts"]
+[output]
+target = "./dist-smelt"
+crate-name = "neverthrow_probe"
+build = false
+[rust]
+edition = "2024"
+[strict]
+typescript = true
+python = true
+[runtime]
+clone-strategy = "aggressive"

--- a/.github/compat/radash/Smelt.toml
+++ b/.github/compat/radash/Smelt.toml
@@ -1,0 +1,24 @@
+[project]
+name = "radash"
+version = "0.0.0"
+description = "radash Smelt probe"
+
+[sources]
+roots = ["src"]
+test-prefix = ["tests/**/*.test.ts"]
+entries = ["src/index.ts"]
+
+[output]
+target = "./dist-smelt"
+crate-name = "radash_probe"
+build = false
+
+[rust]
+edition = "2024"
+
+[strict]
+typescript = true
+python = true
+
+[runtime]
+clone-strategy = "aggressive"

--- a/.github/compat/result/Smelt.toml
+++ b/.github/compat/result/Smelt.toml
@@ -1,0 +1,24 @@
+[project]
+name = "result"
+version = "0.0.0"
+description = "result Smelt probe"
+
+[sources]
+roots = ["src", "tests"]
+test-prefix = ["**/test_*.py"]
+entries = ["src/result/__init__.py"]
+
+[output]
+target = "./dist-smelt"
+crate-name = "result_probe"
+build = false
+
+[rust]
+edition = "2024"
+
+[strict]
+typescript = true
+python = true
+
+[runtime]
+clone-strategy = "aggressive"

--- a/.github/compat/returns/Smelt.toml
+++ b/.github/compat/returns/Smelt.toml
@@ -1,0 +1,24 @@
+[project]
+name = "returns"
+version = "0.0.0"
+description = "returns Smelt probe"
+
+[sources]
+roots = ["."]
+test-prefix = ["tests/**/test_*.py"]
+entries = ["returns/__init__.py"]
+
+[output]
+target = "./dist-smelt"
+crate-name = "returns_probe"
+build = false
+
+[rust]
+edition = "2024"
+
+[strict]
+typescript = true
+python = true
+
+[runtime]
+clone-strategy = "aggressive"

--- a/.github/compat/toolz/Smelt.toml
+++ b/.github/compat/toolz/Smelt.toml
@@ -1,0 +1,24 @@
+[project]
+name = "toolz"
+version = "0.0.0"
+description = "toolz Smelt probe"
+
+[sources]
+roots = ["."]
+test-prefix = ["toolz/tests/**/test_*.py"]
+entries = ["toolz/__init__.py"]
+
+[output]
+target = "./dist-smelt"
+crate-name = "toolz_probe"
+build = false
+
+[rust]
+edition = "2024"
+
+[strict]
+typescript = true
+python = true
+
+[runtime]
+clone-strategy = "aggressive"

--- a/.github/compat/ts-pattern/Smelt.toml
+++ b/.github/compat/ts-pattern/Smelt.toml
@@ -1,0 +1,24 @@
+[project]
+name = "ts-pattern"
+version = "0.0.0"
+description = "ts-pattern Smelt probe"
+
+[sources]
+roots = ["src", "tests"]
+test-prefix = ["**/*.test.ts"]
+entries = ["src/index.ts"]
+
+[output]
+target = "./dist-smelt"
+crate-name = "ts_pattern_probe"
+build = false
+
+[rust]
+edition = "2024"
+
+[strict]
+typescript = true
+python = true
+
+[runtime]
+clone-strategy = "aggressive"

--- a/.github/compat/valibot/Smelt.toml
+++ b/.github/compat/valibot/Smelt.toml
@@ -1,0 +1,24 @@
+[project]
+name = "valibot"
+version = "0.0.0"
+description = "valibot Smelt probe"
+
+[sources]
+roots = ["library/src"]
+test-prefix = ["**/*.test.ts"]
+entries = ["library/src/index.ts"]
+
+[output]
+target = "./dist-smelt"
+crate-name = "valibot_probe"
+build = false
+
+[rust]
+edition = "2024"
+
+[strict]
+typescript = true
+python = true
+
+[runtime]
+clone-strategy = "aggressive"

--- a/.github/workflows/library-probes.yml
+++ b/.github/workflows/library-probes.yml
@@ -1,0 +1,71 @@
+name: Library Probes
+
+# Daily transpile probes against pinned third-party TypeScript/Python libraries.
+# Tracks how far Smelt can transpile real-world "bug libraries" over time and
+# writes the result to blocker-logs/library-probes.md. This is independent of
+# the regression CI; it never fails the build, it just refreshes the report.
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    # 06:17 UTC every day.
+    - cron: "17 6 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Smelt
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install native GUI libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libxcb1-dev libxkbcommon-dev libxkbcommon-x11-dev
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            target
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-probes-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build smelt
+        run: cargo build --bin smelt
+
+      - name: Check out probed libraries at pinned refs
+        run: |
+          mkdir -p target/library-probes
+          python3 - <<'PY'
+          import json, os, subprocess
+          cfg = json.load(open(".github/compat/libraries.json"))
+          for lib in cfg["libraries"]:
+              dest = os.path.join("target/library-probes", lib["name"])
+              if os.path.isdir(os.path.join(dest, ".git")):
+                  continue
+              url = f"https://github.com/{lib['repo']}.git"
+              subprocess.run(["git", "clone", "--no-tags", "--filter=blob:none", url, dest], check=True)
+              subprocess.run(["git", "-C", dest, "checkout", lib["ref"]], check=True)
+          PY
+
+      - name: Run probes and generate report
+        run: |
+          python3 scripts/probe_libraries.py \
+            --config .github/compat/libraries.json \
+            --fixtures .github/compat \
+            --work-dir target/library-probes \
+            --output blocker-logs/library-probes.md
+
+      - name: Commit report
+        uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: "chore(ci): update library probe report"
+          file_pattern: blocker-logs/library-probes.md

--- a/blocker-logs/bug-library-probes-2026-06-24.md
+++ b/blocker-logs/bug-library-probes-2026-06-24.md
@@ -1,0 +1,324 @@
+# Bug-library transpile probes (TypeScript + Python)
+
+_Generated 2026-06-24 on branch `claude/remeda-bug-library-probes-oy0h3g`._
+
+Each library below was downloaded at its default-branch HEAD, given a `Smelt.toml`
+pointing at its source root + test glob, and run through `smelt build`. Where the
+whole-crate build aborts at the first unsupported construct, every source/test file
+was additionally scanned individually with `smelt dump-hir` to enumerate the full set
+of distinct blocker classes (single-file mode cannot resolve cross-file imports, so
+bare `unresolved name/identifier` errors are treated as scan noise and excluded).
+
+**Error categories** (as requested):
+- **missing-stdlib** — a JS/Python builtin or library surface Smelt does not model yet
+  (e.g. `Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`).
+- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the construct
+  into Rust that compiles (missing return-type annotations, `try`/`except`, decorators,
+  callback methods not lowered into closures, non-primitive exported `const`, etc.).
+
+## Reference point
+
+`remeda` (the curated compat target) **transpiles** and its generated `cargo test` runs:
+**1768 passed / 21 failed** (full suite). None of the probes below reach that stage yet.
+
+## Summary
+
+| Library | Lang | Transpile | Tests pass | First abort | Distinct blocker classes | Dominant category |
+| --- | --- | --- | --- | --- | ---: | --- |
+| [es-toolkit](https://github.com/toss/es-toolkit) | TS | **no** | n/a (no crate) | `src/array/at.spec.ts` | 79 | non-working Rust (77 rust / 2 stdlib) |
+| [radash](https://github.com/sodiray/radash) | TS | **no** | n/a (no crate) | `src/typed.ts` | 24 | non-working Rust (22 rust / 2 stdlib) |
+| [ts-pattern](https://github.com/gvergnaud/ts-pattern) | TS | **no** | n/a (no crate) | `src/types/Pattern.ts` | 15 | non-working Rust (15 rust / 0 stdlib) |
+| [valibot](https://github.com/fabian-hiller/valibot) | TS | **no** | n/a (no crate) | `library/src/utils/_getByteCount/_getByteCount.ts` | 33 | non-working Rust (32 rust / 1 stdlib) |
+| [neverthrow](https://github.com/supermacro/neverthrow) | TS | **no** | n/a (no crate) | `src/result-async.ts` | 11 | non-working Rust (11 rust / 0 stdlib) |
+| [returns](https://github.com/dry-python/returns) | Py | **no** | n/a (no crate) | `tests/.../test_context.py` | 33 | non-working Rust (33 rust / 0 stdlib) |
+| [result](https://github.com/rustedpy/result) | Py | **no** | n/a (no crate) | `src/result/result.py` | 7 | non-working Rust (7 rust / 0 stdlib) |
+| [more-itertools](https://github.com/more-itertools/more-itertools) | Py | **no** | n/a (no crate) | `more_itertools/recipes.py` | 10 | non-working Rust (10 rust / 0 stdlib) |
+| [funcy](https://github.com/Suor/funcy) | Py | **no** | n/a (no crate) | `funcy/primitives.py` | 14 | non-working Rust (14 rust / 0 stdlib) |
+| [toolz](https://github.com/pytoolz/toolz) | Py | **no** | n/a (no crate) | `toolz/itertoolz.py` | 14 | non-working Rust (14 rust / 0 stdlib) |
+
+## TypeScript libraries
+
+### es-toolkit
+
+- Source: `toss/es-toolkit` (default branch)
+- Transpile: **no** — `smelt build` aborts at `src/array/at.spec.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 1219  ·  files with blockers: 418
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 54 | 54 | non-working Rust | array callback local callback `X` is not in scope |
+| 42 | 42 | missing-stdlib (builtin class) | unresolved class `X` |
+| 31 | 31 | non-working Rust | function expression rest parameters are not lowered in object values yet |
+| 28 | 28 | non-working Rust | `X` is only available inside function bodies |
+| 17 | 17 | non-working Rust | callback conditions must be boolean, optional, or supported truthy checks |
+| 15 | 15 | non-working Rust | exported const values currently support primitive literals and foldable primitive expressi |
+| 12 | 12 | non-working Rust | callback method `X` is not lowered into closure bodies yet |
+| 9 | 9 | non-working Rust | unary operator is not lowered yet: Typeof |
+| 8 | 8 | non-working Rust | expect(...).rejects.toThrow(...) actual value must be a Promise<T> |
+| 8 | 8 | missing-stdlib | TypeScript instanceof target `X` is not a lowered class |
+| 7 | 7 | non-working Rust | array callback local callback `X` is not defined |
+| 6 | 6 | non-working Rust | callback block statements must be const declarations, if guards, return, or throw |
+| 6 | 6 | non-working Rust | method calls are only lowered for class values for now |
+| 6 | 6 | non-working Rust | array concat currently requires exactly one array argument |
+
+### radash
+
+- Source: `sodiray/radash` (default branch)
+- Transpile: **no** — `smelt build` aborts at `src/typed.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 19  ·  files with blockers: 13
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 4 | 3 | non-working Rust | callback method `X` is not lowered into closure bodies yet |
+| 3 | 2 | missing-stdlib (builtin class) | unresolved class `X` |
+| 3 | 1 | non-working Rust | regex replacement requires string-compatible receiver, pattern, and replacement |
+| 2 | 1 | non-working Rust | array fill value must match the array element type |
+| 2 | 1 | non-working Rust | function expression rest parameters are not lowered in object values yet |
+| 1 | 1 | non-working Rust | conditional expression branches must have the same lowered type (then: Some(Union([TypeId( |
+| 1 | 1 | non-working Rust | method calls are only lowered for class values for now |
+| 1 | 1 | non-working Rust | conditional expression branches must have the same lowered type (then: Some(Union([TypeId( |
+| 1 | 1 | non-working Rust | conditional expression branches must have the same lowered type (then: Some(Function(Funct |
+| 1 | 1 | non-working Rust | call argument kind is not lowered yet: UpdateExpression(UpdateExpression { span: Span { st |
+| 1 | 1 | non-working Rust | Promise constructor lowering supports one arrow executor |
+| 1 | 1 | non-working Rust | conditional expression branches must have the same lowered type (then: Some(List(TypeId(10 |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(None)) |
+| 1 | 1 | non-working Rust | parseFloat requires a string argument |
+
+### ts-pattern
+
+- Source: `gvergnaud/ts-pattern` (default branch)
+- Transpile: **no** — `smelt build` aborts at `src/types/Pattern.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 68  ·  files with blockers: 23
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 8 | 3 | non-working Rust | callback method `X` is not lowered into closure bodies yet |
+| 4 | 4 | non-working Rust | spread call requires at least one argument |
+| 2 | 1 | non-working Rust | Boolean requires a primitive argument |
+| 2 | 2 | non-working Rust | array callback methods require exactly one callback argument |
+| 1 | 1 | non-working Rust | field access is only lowered for Record<string, T>, class, and interface values for now (r |
+| 1 | 1 | non-working Rust | type annotation is not lowered yet: TSConstructorType(TSConstructorType { span: Span { sta |
+| 1 | 1 | non-working Rust | exported const expression references unresolved const `X` |
+| 1 | 1 | non-working Rust | dynamic computed and this-parameter interface methods are not lowered yet |
+| 1 | 1 | non-working Rust | string prefix/suffix methods require string receiver and argument |
+| 1 | 1 | non-working Rust | tuple element type is not lowered yet: TSSymbolKeyword(TSSymbolKeyword { span: Span { star |
+| 1 | 1 | non-working Rust | property names must be static identifiers or string literals |
+| 1 | 1 | non-working Rust | statement kind is not lowered yet: TSEnumDeclaration(TSEnumDeclaration { span: Span { star |
+| 1 | 1 | non-working Rust | extended interface `X` is not declared |
+| 1 | 1 | non-working Rust | method calls are only lowered for class values for now |
+
+### valibot
+
+- Source: `fabian-hiller/valibot` (default branch)
+- Transpile: **no** — `smelt build` aborts at `library/src/utils/_getByteCount/_getByteCount.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 1083  ·  files with blockers: 324
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 266 | 266 | non-working Rust | describe blocks only support direct it/test/describe calls for now |
+| 8 | 8 | missing-stdlib (builtin class) | unresolved class `X` |
+| 6 | 6 | non-working Rust | callback method `X` is not lowered into closure bodies yet |
+| 4 | 4 | non-working Rust | new Map entry key and value types must be homogeneous |
+| 3 | 3 | non-working Rust | array callback local callback `X` is not in scope |
+| 3 | 3 | non-working Rust | extended interface `X` is not declared |
+| 2 | 2 | non-working Rust | rest parameter type must resolve to an array type |
+| 2 | 2 | non-working Rust | exported const declarations require an initializer |
+| 2 | 2 | non-working Rust | this-parameter function types are not lowered yet |
+| 2 | 2 | non-working Rust | expect(...).resolves/rejects actual value must be a Promise<T> |
+| 2 | 2 | non-working Rust | array element kind is not lowered yet: FunctionExpression(Function { span: Span { start: 2 |
+| 1 | 1 | non-working Rust | expect(...).toContain(...) requires a string, array, set, or tuple actual value with a mat |
+| 1 | 1 | non-working Rust | array element kind is not lowered yet: AwaitExpression(AwaitExpression { span: Span { star |
+| 1 | 1 | non-working Rust | local closure return type does not match its annotation: actual Some(Dict(TypeId(1), TypeI |
+
+### neverthrow
+
+- Source: `supermacro/neverthrow` (default branch)
+- Transpile: **no** — `smelt build` aborts at `src/result-async.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 8  ·  files with blockers: 6
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 4 | 2 | non-working Rust | exported const values currently support primitive literals and foldable primitive expressi |
+| 3 | 2 | non-working Rust | property names must be static identifiers or string literals |
+| 2 | 1 | non-working Rust | array callback local callback `X` is not defined |
+| 1 | 1 | non-working Rust | callback method `X` is not lowered into closure bodies yet |
+| 1 | 1 | non-working Rust | method calls are only lowered for class values for now |
+| 1 | 1 | non-working Rust | local closure return type does not match its annotation: actual Some(Never), expected Some |
+| 1 | 1 | non-working Rust | describe blocks only support direct it/test/describe calls for now |
+| 1 | 1 | non-working Rust | only expect(...).not matcher modifiers are supported |
+| 1 | 1 | non-working Rust | yield* generator delegation is not lowered yet |
+| 1 | 1 | non-working Rust | String.match() requires exactly one RegExp argument |
+| 1 | 1 | non-working Rust | call expression is not lowered yet |
+
+## Python libraries
+
+### returns
+
+- Source: `dry-python/returns` (default branch)
+- Transpile: **no** — `smelt build` aborts at `tests/.../test_context.py`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 199  ·  files with blockers: 180
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 662 | 152 | non-working Rust | only calls to top-level functions, class constructors, and print() are supported |
+| 51 | 38 | non-working Rust | class 'X': decorator 'X' is not supported |
+| 44 | 31 | non-working Rust | callback expression is not supported yet |
+| 37 | 27 | non-working Rust | class 'X': multiple inheritance is not supported |
+| 26 | 18 | non-working Rust | class 'X': unsupported class body statement 'X' |
+| 25 | 10 | non-working Rust | subscript access requires a list, set, dict, tuple, or string |
+| 19 | 8 | non-working Rust | Callable first argument must be a list of param types, e.g. [int, str] |
+| 18 | 10 | non-working Rust | parameter 'X' must have an explicit type annotation |
+| 17 | 11 | non-working Rust | nested closure bodies need a single return expression |
+| 16 | 11 | non-working Rust | pytest.mark.parametrize names must be a string literal |
+| 14 | 10 | non-working Rust | unknown class field `X` |
+| 13 | 7 | non-working Rust | pytest.mark.parametrize supports only bool, number, string, None, tuple, and list literals |
+| 11 | 6 | non-working Rust | unsupported expression: ellipsis |
+| 10 | 8 | non-working Rust | function 'X' must have an explicit return type annotation |
+
+### result
+
+- Source: `rustedpy/result` (default branch)
+- Transpile: **no** — `smelt build` aborts at `src/result/result.py`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 5  ·  files with blockers: 4
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 46 | 3 | non-working Rust | only calls to top-level functions, class constructors, and print() are supported |
+| 7 | 2 | non-working Rust | async nested closures need async closure-body lowering |
+| 6 | 2 | non-working Rust | callback expression is not supported yet |
+| 3 | 1 | non-working Rust | nested closure bodies need a single return expression |
+| 2 | 1 | non-working Rust | class 'X': unsupported class body statement 'X' |
+| 2 | 1 | non-working Rust | Callable first argument must be a list of param types, e.g. [int, str] |
+| 2 | 1 | non-working Rust | unsupported statement: try |
+
+### more-itertools
+
+- Source: `more-itertools/more-itertools` (default branch)
+- Transpile: **no** — `smelt build` aborts at `more_itertools/recipes.py`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 6  ·  files with blockers: 4
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 185 | 4 | non-working Rust | function 'X' must have an explicit return type annotation |
+| 157 | 2 | non-working Rust | method 'X' must have an explicit return type annotation |
+| 12 | 2 | non-working Rust | parameter 'X' in 'X' must have a type annotation |
+| 6 | 2 | non-working Rust | class 'X': unsupported class body statement 'X' |
+| 6 | 3 | non-working Rust | only calls to top-level functions, class constructors, and print() are supported |
+| 3 | 2 | non-working Rust | class 'X': decorator 'X' is not supported |
+| 3 | 2 | non-working Rust | unsupported statement: try |
+| 2 | 1 | non-working Rust | class 'X': multiple inheritance is not supported |
+| 1 | 1 | non-working Rust | integer literal out of i64 range |
+| 1 | 1 | non-working Rust | unsupported expression: lambda |
+
+### funcy
+
+- Source: `Suor/funcy` (default branch)
+- Transpile: **no** — `smelt build` aborts at `funcy/primitives.py`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 33  ·  files with blockers: 31
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 202 | 21 | non-working Rust | function 'X' must have an explicit return type annotation |
+| 153 | 16 | non-working Rust | only calls to top-level functions, class constructors, and print() are supported |
+| 39 | 5 | non-working Rust | nested closure return type must be explicit |
+| 13 | 4 | non-working Rust | nested class definitions are not yet supported |
+| 6 | 4 | non-working Rust | parameter 'X' in 'X' must have a type annotation |
+| 4 | 3 | non-working Rust | pytest.mark.parametrize supports only bool, number, string, None, tuple, and list literals |
+| 3 | 2 | non-working Rust | unsupported statement: try |
+| 3 | 2 | non-working Rust | parameter 'X' must have an explicit type annotation |
+| 2 | 2 | non-working Rust | method 'X' must have an explicit return type annotation |
+| 2 | 1 | non-working Rust | all() and any() argument must be a bool list |
+| 1 | 1 | non-working Rust | set(value) currently requires a set, list, or homogeneous tuple value |
+| 1 | 1 | non-working Rust | class 'X': unsupported class body statement 'X' |
+| 1 | 1 | non-working Rust | all() and any() currently support exactly one bool list argument |
+| 1 | 1 | non-working Rust | unsupported expression: lambda |
+
+### toolz
+
+- Source: `pytoolz/toolz` (default branch)
+- Transpile: **no** — `smelt build` aborts at `toolz/itertoolz.py`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 31  ·  files with blockers: 28
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 144 | 17 | non-working Rust | only calls to top-level functions, class constructors, and print() are supported |
+| 118 | 17 | non-working Rust | function 'X' must have an explicit return type annotation |
+| 27 | 5 | non-working Rust | nested closure return type must be explicit |
+| 8 | 5 | non-working Rust | nested class definitions are not yet supported |
+| 5 | 2 | non-working Rust | unsupported statement: del |
+| 5 | 3 | non-working Rust | class 'X': unsupported class body statement 'X' |
+| 4 | 2 | non-working Rust | parameter 'X' must have an explicit type annotation |
+| 3 | 2 | non-working Rust | container constructors do not support keyword arguments yet |
+| 3 | 2 | non-working Rust | method 'X' must have an explicit return type annotation |
+| 2 | 1 | non-working Rust | parameter 'X' in 'X' must have a type annotation |
+| 2 | 2 | non-working Rust | class 'X': decorator 'X' is not supported |
+| 2 | 2 | non-working Rust | unsupported expression: lambda |
+| 1 | 1 | non-working Rust | dict.update() requires exactly one dict argument |
+| 1 | 1 | non-working Rust | binary operator 'X' is not supported |
+
+## Highest-leverage transpiler gaps (non-working Rust), ranked by libraries affected
+
+These lowering gaps block more than one probed library; fixing them unlocks the most surface.
+
+| Libraries hit | Total occ. | Blocker class |
+| ---: | ---: | --- |
+| 5 (funcy, more-itertools, result, returns, toolz) | 1011 | only calls to top-level functions, class constructors, and print() are supported |
+| 5 (funcy, more-itertools, result, returns, toolz) | 40 | class 'X': unsupported class body statement 'X' |
+| 5 (es-toolkit, neverthrow, radash, ts-pattern, valibot) | 31 | callback method `X` is not lowered into closure bodies yet |
+| 4 (funcy, more-itertools, returns, toolz) | 515 | function 'X' must have an explicit return type annotation |
+| 4 (funcy, more-itertools, result, returns) | 12 | unsupported statement: try |
+| 4 (es-toolkit, neverthrow, radash, ts-pattern) | 9 | method calls are only lowered for class values for now |
+| 4 (funcy, more-itertools, returns, toolz) | 9 | unsupported expression: lambda |
+| 3 (es-toolkit, neverthrow, valibot) | 272 | describe blocks only support direct it/test/describe calls for now |
+| 3 (funcy, more-itertools, toolz) | 162 | method 'X' must have an explicit return type annotation |
+| 3 (funcy, returns, toolz) | 67 | nested closure return type must be explicit |
+| 3 (more-itertools, returns, toolz) | 56 | class 'X': decorator 'X' is not supported |
+| 3 (funcy, returns, toolz) | 25 | parameter 'X' must have an explicit type annotation |
+| 3 (es-toolkit, neverthrow, radash) | 20 | exported const values currently support primitive literals and foldable primitive expressions |
+| 3 (funcy, more-itertools, toolz) | 20 | parameter 'X' in 'X' must have a type annotation |
+| 3 (es-toolkit, neverthrow, radash) | 10 | array callback local callback `X` is not defined |
+| 3 (es-toolkit, ts-pattern, valibot) | 6 | extended interface `X` is not declared |
+| 3 (es-toolkit, neverthrow, radash) | 5 | call expression is not lowered yet |
+| 3 (es-toolkit, neverthrow, ts-pattern) | 5 | property names must be static identifiers or string literals |
+| 2 (es-toolkit, valibot) | 57 | array callback local callback `X` is not in scope |
+| 2 (result, returns) | 50 | callback expression is not supported yet |
+| 2 (more-itertools, returns) | 39 | class 'X': multiple inheritance is not supported |
+| 2 (es-toolkit, radash) | 33 | function expression rest parameters are not lowered in object values yet |
+| 2 (result, returns) | 21 | Callable first argument must be a list of param types, e.g. [int, str] |
+| 2 (funcy, toolz) | 21 | nested class definitions are not yet supported |
+| 2 (result, returns) | 20 | nested closure bodies need a single return expression |
+| 2 (funcy, returns) | 17 | pytest.mark.parametrize supports only bool, number, string, None, tuple, and list literals |
+| 2 (es-toolkit, ts-pattern) | 8 | array callback methods require exactly one callback argument |
+| 2 (es-toolkit, valibot) | 8 | new Map entry key and value types must be homogeneous |
+| 2 (returns, toolz) | 7 | binary operator 'X' is not supported |
+| 2 (es-toolkit, valibot) | 5 | expect(...).resolves/rejects actual value must be a Promise<T> |
+| 2 (es-toolkit, valibot) | 2 | expect(...).toContain(...) requires a string, array, set, or tuple actual value with a matching expe |
+
+## Missing stdlib builtins observed (TypeScript)
+
+Builtins referenced in `new`/`extends`/callback position that Smelt does not resolve.
+Each is a candidate for the JS stdlib surface.
+
+| Library | Builtins (occurrences) |
+| --- | --- |
+| es-toolkit | `Array`×25, `Number`×9, `globalThis`×4, `ArrayBuffer`×4, `parseInt`×3, `Reflect`×3, `AbortController`×3, `Math`×2, `Map`×2, `Function`×2, `Buffer`×2, `Blob`×2, `Object`×2, `Promise`×2, `WeakMap`×1, `File`×1 |
+| radash | `Proxy`×3, `Reflect`×1 |
+| ts-pattern | `Reflect`×2 |
+| valibot | `TextEncoder`×5, `Number`×1, `isFinite`×1, `Blob`×1, `File`×1 |
+| neverthrow | _none observed_ |
+
+> Python probes are blocked earlier by lowering gaps (untyped signatures, decorators,
+> `try`/`except`, method/attribute calls) than by missing stdlib, so the dominant Python
+> lever is frontend coverage, not stdlib breadth. Smelt also requires fully type-annotated
+> source: `toolz`, `funcy`, and `more-itertools` are not fully annotated and would fail
+> `ty`-strict checking too, so they are partly out of Smelt's stated scope.

--- a/blocker-logs/library-probes.md
+++ b/blocker-logs/library-probes.md
@@ -1,49 +1,34 @@
 # Bug-library transpile probes (TypeScript + Python)
 
-_Generated 2026-06-24 on branch `claude/remeda-bug-library-probes-oy0h3g`._
+_Generated 2026-06-24 by the `library-probes` workflow (`scripts/probe_libraries.py`)._
 
-Each library below was downloaded at its default-branch HEAD, given a `Smelt.toml`
-pointing at its source root + test glob, and run through `smelt build`. Where the
-whole-crate build aborts at the first unsupported construct, every source/test file
-was additionally scanned individually with `smelt dump-hir` to enumerate the full set
-of distinct blocker classes (single-file mode cannot resolve cross-file imports, so
-bare `unresolved name/identifier` errors are treated as scan noise and excluded).
+Each library is checked out at a pinned ref (see `.github/compat/libraries.json`), given its `.github/compat/<name>/Smelt.toml`, and run through `smelt build`. If a crate is emitted, its generated `cargo test` suite is run and counted. Otherwise every source/test file is scanned individually with `smelt dump-hir` to enumerate the full set of distinct blocker classes (single-file mode cannot resolve cross-file imports, so bare `unresolved name/identifier` errors are excluded as scan noise).
 
-**Error categories** (as requested):
-- **missing-stdlib** — a JS/Python builtin or library surface Smelt does not model yet
-  (e.g. `Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`).
-- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the construct
-  into Rust that compiles (missing return-type annotations, `try`/`except`, decorators,
-  callback methods not lowered into closures, non-primitive exported `const`, etc.).
-
-## Reference point
-
-`remeda` (the curated compat target) **transpiles** and its generated `cargo test` runs:
-**1768 passed / 21 failed** (full suite). None of the probes below reach that stage yet.
+**Error categories:**
+- **missing-stdlib** — a JS/Python builtin Smelt does not model yet (`Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`, ...).
+- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the construct into Rust that compiles (missing return-type annotations, `try`/`except`, decorators, callback methods not lowered into closures, non-primitive exported `const`, ...).
 
 ## Summary
 
-| Library | Lang | Transpile | Tests pass | First abort | Distinct blocker classes | Dominant category |
+| Library | Lang | Transpile | Tests (pass/fail) | First abort | Blocker classes | Dominant |
 | --- | --- | --- | --- | --- | ---: | --- |
-| [es-toolkit](https://github.com/toss/es-toolkit) | TS | **no** | n/a (no crate) | `src/array/at.spec.ts` | 79 | non-working Rust (77 rust / 2 stdlib) |
-| [radash](https://github.com/sodiray/radash) | TS | **no** | n/a (no crate) | `src/typed.ts` | 24 | non-working Rust (22 rust / 2 stdlib) |
-| [ts-pattern](https://github.com/gvergnaud/ts-pattern) | TS | **no** | n/a (no crate) | `src/types/Pattern.ts` | 15 | non-working Rust (15 rust / 0 stdlib) |
-| [valibot](https://github.com/fabian-hiller/valibot) | TS | **no** | n/a (no crate) | `library/src/utils/_getByteCount/_getByteCount.ts` | 33 | non-working Rust (32 rust / 1 stdlib) |
-| [neverthrow](https://github.com/supermacro/neverthrow) | TS | **no** | n/a (no crate) | `src/result-async.ts` | 11 | non-working Rust (11 rust / 0 stdlib) |
-| [returns](https://github.com/dry-python/returns) | Py | **no** | n/a (no crate) | `tests/.../test_context.py` | 33 | non-working Rust (33 rust / 0 stdlib) |
-| [result](https://github.com/rustedpy/result) | Py | **no** | n/a (no crate) | `src/result/result.py` | 7 | non-working Rust (7 rust / 0 stdlib) |
-| [more-itertools](https://github.com/more-itertools/more-itertools) | Py | **no** | n/a (no crate) | `more_itertools/recipes.py` | 10 | non-working Rust (10 rust / 0 stdlib) |
-| [funcy](https://github.com/Suor/funcy) | Py | **no** | n/a (no crate) | `funcy/primitives.py` | 14 | non-working Rust (14 rust / 0 stdlib) |
-| [toolz](https://github.com/pytoolz/toolz) | Py | **no** | n/a (no crate) | `toolz/itertoolz.py` | 14 | non-working Rust (14 rust / 0 stdlib) |
+| [es-toolkit](https://github.com/toss/es-toolkit) | TS | **no** | n/a | `src/array/at.spec.ts` | 79 | non-working Rust (77r/2s) |
+| [radash](https://github.com/sodiray/radash) | TS | **no** | n/a | `src/typed.ts` | 24 | non-working Rust (22r/2s) |
+| [ts-pattern](https://github.com/gvergnaud/ts-pattern) | TS | **no** | n/a | `src/types/Pattern.ts` | 15 | non-working Rust (15r/0s) |
+| [valibot](https://github.com/fabian-hiller/valibot) | TS | **no** | n/a | `library/src/utils/_getByteCount/_getByteCount.ts` | 33 | non-working Rust (32r/1s) |
+| [neverthrow](https://github.com/supermacro/neverthrow) | TS | **no** | n/a | `src/result-async.ts` | 11 | non-working Rust (11r/0s) |
+| [returns](https://github.com/dry-python/returns) | PY | **no** | n/a | `tests/test_context/test_requires_context/test_context.py` | 33 | non-working Rust (33r/0s) |
+| [result](https://github.com/rustedpy/result) | PY | **no** | n/a | `src/result/result.py` | 7 | non-working Rust (7r/0s) |
+| [more-itertools](https://github.com/more-itertools/more-itertools) | PY | **no** | n/a | `more_itertools/recipes.py` | 10 | non-working Rust (10r/0s) |
+| [funcy](https://github.com/Suor/funcy) | PY | **no** | n/a | `funcy/primitives.py` | 14 | non-working Rust (14r/0s) |
+| [toolz](https://github.com/pytoolz/toolz) | PY | **no** | n/a | `toolz/itertoolz.py` | 14 | non-working Rust (14r/0s) |
 
-## TypeScript libraries
+## es-toolkit
 
-### es-toolkit
-
-- Source: `toss/es-toolkit` (default branch)
+- Source: `toss/es-toolkit` @ `e008a2818cd8`
 - Transpile: **no** — `smelt build` aborts at `src/array/at.spec.ts`
 - Tests passing: **n/a** (no Rust crate emitted)
-- Files scanned: 1219  ·  files with blockers: 418
+- Files scanned: 1219 · with blockers: 418
 
 | Occurrences | Files | Category | Blocker class |
 | ---: | ---: | --- | --- |
@@ -62,12 +47,12 @@ bare `unresolved name/identifier` errors are treated as scan noise and excluded)
 | 6 | 6 | non-working Rust | method calls are only lowered for class values for now |
 | 6 | 6 | non-working Rust | array concat currently requires exactly one array argument |
 
-### radash
+## radash
 
-- Source: `sodiray/radash` (default branch)
+- Source: `sodiray/radash` @ `4cab1900d08e`
 - Transpile: **no** — `smelt build` aborts at `src/typed.ts`
 - Tests passing: **n/a** (no Rust crate emitted)
-- Files scanned: 19  ·  files with blockers: 13
+- Files scanned: 19 · with blockers: 13
 
 | Occurrences | Files | Category | Blocker class |
 | ---: | ---: | --- | --- |
@@ -86,12 +71,12 @@ bare `unresolved name/identifier` errors are treated as scan noise and excluded)
 | 1 | 1 | non-working Rust | local `X` is not callable (Some(None)) |
 | 1 | 1 | non-working Rust | parseFloat requires a string argument |
 
-### ts-pattern
+## ts-pattern
 
-- Source: `gvergnaud/ts-pattern` (default branch)
+- Source: `gvergnaud/ts-pattern` @ `c92ca435c7e1`
 - Transpile: **no** — `smelt build` aborts at `src/types/Pattern.ts`
 - Tests passing: **n/a** (no Rust crate emitted)
-- Files scanned: 68  ·  files with blockers: 23
+- Files scanned: 68 · with blockers: 22
 
 | Occurrences | Files | Category | Blocker class |
 | ---: | ---: | --- | --- |
@@ -110,12 +95,12 @@ bare `unresolved name/identifier` errors are treated as scan noise and excluded)
 | 1 | 1 | non-working Rust | extended interface `X` is not declared |
 | 1 | 1 | non-working Rust | method calls are only lowered for class values for now |
 
-### valibot
+## valibot
 
-- Source: `fabian-hiller/valibot` (default branch)
+- Source: `fabian-hiller/valibot` @ `1f9b18338ad5`
 - Transpile: **no** — `smelt build` aborts at `library/src/utils/_getByteCount/_getByteCount.ts`
 - Tests passing: **n/a** (no Rust crate emitted)
-- Files scanned: 1083  ·  files with blockers: 324
+- Files scanned: 1083 · with blockers: 324
 
 | Occurrences | Files | Category | Blocker class |
 | ---: | ---: | --- | --- |
@@ -134,12 +119,12 @@ bare `unresolved name/identifier` errors are treated as scan noise and excluded)
 | 1 | 1 | non-working Rust | array element kind is not lowered yet: AwaitExpression(AwaitExpression { span: Span { star |
 | 1 | 1 | non-working Rust | local closure return type does not match its annotation: actual Some(Dict(TypeId(1), TypeI |
 
-### neverthrow
+## neverthrow
 
-- Source: `supermacro/neverthrow` (default branch)
+- Source: `supermacro/neverthrow` @ `5ef3a018bda7`
 - Transpile: **no** — `smelt build` aborts at `src/result-async.ts`
 - Tests passing: **n/a** (no Rust crate emitted)
-- Files scanned: 8  ·  files with blockers: 6
+- Files scanned: 8 · with blockers: 6
 
 | Occurrences | Files | Category | Blocker class |
 | ---: | ---: | --- | --- |
@@ -155,14 +140,12 @@ bare `unresolved name/identifier` errors are treated as scan noise and excluded)
 | 1 | 1 | non-working Rust | String.match() requires exactly one RegExp argument |
 | 1 | 1 | non-working Rust | call expression is not lowered yet |
 
-## Python libraries
+## returns
 
-### returns
-
-- Source: `dry-python/returns` (default branch)
-- Transpile: **no** — `smelt build` aborts at `tests/.../test_context.py`
+- Source: `dry-python/returns` @ `04e820c71461`
+- Transpile: **no** — `smelt build` aborts at `tests/test_context/test_requires_context/test_context.py`
 - Tests passing: **n/a** (no Rust crate emitted)
-- Files scanned: 199  ·  files with blockers: 180
+- Files scanned: 199 · with blockers: 180
 
 | Occurrences | Files | Category | Blocker class |
 | ---: | ---: | --- | --- |
@@ -181,12 +164,12 @@ bare `unresolved name/identifier` errors are treated as scan noise and excluded)
 | 11 | 6 | non-working Rust | unsupported expression: ellipsis |
 | 10 | 8 | non-working Rust | function 'X' must have an explicit return type annotation |
 
-### result
+## result
 
-- Source: `rustedpy/result` (default branch)
+- Source: `rustedpy/result` @ `0b855e1e38a0`
 - Transpile: **no** — `smelt build` aborts at `src/result/result.py`
 - Tests passing: **n/a** (no Rust crate emitted)
-- Files scanned: 5  ·  files with blockers: 4
+- Files scanned: 5 · with blockers: 4
 
 | Occurrences | Files | Category | Blocker class |
 | ---: | ---: | --- | --- |
@@ -198,12 +181,12 @@ bare `unresolved name/identifier` errors are treated as scan noise and excluded)
 | 2 | 1 | non-working Rust | Callable first argument must be a list of param types, e.g. [int, str] |
 | 2 | 1 | non-working Rust | unsupported statement: try |
 
-### more-itertools
+## more-itertools
 
-- Source: `more-itertools/more-itertools` (default branch)
+- Source: `more-itertools/more-itertools` @ `5d946b3590bf`
 - Transpile: **no** — `smelt build` aborts at `more_itertools/recipes.py`
 - Tests passing: **n/a** (no Rust crate emitted)
-- Files scanned: 6  ·  files with blockers: 4
+- Files scanned: 6 · with blockers: 4
 
 | Occurrences | Files | Category | Blocker class |
 | ---: | ---: | --- | --- |
@@ -218,12 +201,12 @@ bare `unresolved name/identifier` errors are treated as scan noise and excluded)
 | 1 | 1 | non-working Rust | integer literal out of i64 range |
 | 1 | 1 | non-working Rust | unsupported expression: lambda |
 
-### funcy
+## funcy
 
-- Source: `Suor/funcy` (default branch)
+- Source: `Suor/funcy` @ `9eb04473e31b`
 - Transpile: **no** — `smelt build` aborts at `funcy/primitives.py`
 - Tests passing: **n/a** (no Rust crate emitted)
-- Files scanned: 33  ·  files with blockers: 31
+- Files scanned: 33 · with blockers: 31
 
 | Occurrences | Files | Category | Blocker class |
 | ---: | ---: | --- | --- |
@@ -242,12 +225,12 @@ bare `unresolved name/identifier` errors are treated as scan noise and excluded)
 | 1 | 1 | non-working Rust | all() and any() currently support exactly one bool list argument |
 | 1 | 1 | non-working Rust | unsupported expression: lambda |
 
-### toolz
+## toolz
 
-- Source: `pytoolz/toolz` (default branch)
+- Source: `pytoolz/toolz` @ `568c2b839397`
 - Transpile: **no** — `smelt build` aborts at `toolz/itertoolz.py`
 - Tests passing: **n/a** (no Rust crate emitted)
-- Files scanned: 31  ·  files with blockers: 28
+- Files scanned: 31 · with blockers: 28
 
 | Occurrences | Files | Category | Blocker class |
 | ---: | ---: | --- | --- |
@@ -266,9 +249,9 @@ bare `unresolved name/identifier` errors are treated as scan noise and excluded)
 | 1 | 1 | non-working Rust | dict.update() requires exactly one dict argument |
 | 1 | 1 | non-working Rust | binary operator 'X' is not supported |
 
-## Highest-leverage transpiler gaps (non-working Rust), ranked by libraries affected
+## Highest-leverage transpiler gaps (non-working Rust)
 
-These lowering gaps block more than one probed library; fixing them unlocks the most surface.
+Lowering gaps blocking more than one probed library; fixing these unlocks the most surface.
 
 | Libraries hit | Total occ. | Blocker class |
 | ---: | ---: | --- |
@@ -304,10 +287,9 @@ These lowering gaps block more than one probed library; fixing them unlocks the 
 | 2 (es-toolkit, valibot) | 5 | expect(...).resolves/rejects actual value must be a Promise<T> |
 | 2 (es-toolkit, valibot) | 2 | expect(...).toContain(...) requires a string, array, set, or tuple actual value with a matching expe |
 
-## Missing stdlib builtins observed (TypeScript)
+## Missing stdlib builtins observed
 
 Builtins referenced in `new`/`extends`/callback position that Smelt does not resolve.
-Each is a candidate for the JS stdlib surface.
 
 | Library | Builtins (occurrences) |
 | --- | --- |
@@ -315,10 +297,4 @@ Each is a candidate for the JS stdlib surface.
 | radash | `Proxy`×3, `Reflect`×1 |
 | ts-pattern | `Reflect`×2 |
 | valibot | `TextEncoder`×5, `Number`×1, `isFinite`×1, `Blob`×1, `File`×1 |
-| neverthrow | _none observed_ |
 
-> Python probes are blocked earlier by lowering gaps (untyped signatures, decorators,
-> `try`/`except`, method/attribute calls) than by missing stdlib, so the dominant Python
-> lever is frontend coverage, not stdlib breadth. Smelt also requires fully type-annotated
-> source: `toolz`, `funcy`, and `more-itertools` are not fully annotated and would fail
-> `ty`-strict checking too, so they are partly out of Smelt's stated scope.

--- a/scripts/probe_blocker_scan.py
+++ b/scripts/probe_blocker_scan.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Scan every source/test file of a probed library through `smelt dump-hir`
+to aggregate the distinct unsupported-construct blocker classes per library.
+
+Used to probe third-party "bug libraries" (see blocker-logs/bug-library-probes-*.md):
+when `smelt build` aborts a whole-crate transpile at the first unsupported file,
+this scanner runs every file independently to enumerate the *full* set of distinct
+blocker classes so the report can categorize them (missing-stdlib vs non-working Rust).
+
+Single-file mode does not resolve cross-file imports, so bare `unresolved name`
+errors for locally-imported symbols are noise; genuine blockers (missing
+stdlib builtins, unlowered constructs, missing annotations) are reported
+reliably. We separate the two.
+
+Usage:
+    SMELT_BIN=target/debug/smelt SMELT_ROOT=$PWD \\
+        python3 scripts/probe_blocker_scan.py <library-dir> <ts|py> [source-root ...]
+"""
+import subprocess, sys, re, os, json
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+
+# `smelt dump-hir` must run from the smelt repo root (it loads node/builtin data
+# relative to the working directory); override via env when invoking elsewhere.
+SMELT_ROOT = os.environ.get("SMELT_ROOT", os.getcwd())
+SMELT = os.environ.get("SMELT_BIN", os.path.join(SMELT_ROOT, "target/debug/smelt"))
+# dump-hir prints errors as a Rust Debug string with escaped inner quotes:
+#   message: \"unresolved callback identifier `Number`\"
+MSG_RE = re.compile(r'message: \\"(.*?)\\"')
+
+def scan_file(path):
+    path = os.path.abspath(path)
+    try:
+        r = subprocess.run([SMELT, "dump-hir", path], capture_output=True, text=True,
+                           timeout=60, cwd=SMELT_ROOT)
+    except subprocess.TimeoutExpired:
+        return path, ["<timeout>"]
+    out = r.stdout + r.stderr
+    msgs = MSG_RE.findall(out)
+    return path, msgs
+
+def normalize(msg):
+    """Collapse a message to its blocker class, keeping stdlib symbol names."""
+    # keep the symbol for unresolved/unsupported builtin references
+    m = re.search(r"(unresolved (?:callback )?(?:identifier|class|name)|unsupported.*?target|instanceof target) [`']([^`']+)[`']", msg)
+    s = re.sub(r"'[^']*'", "'X'", msg)
+    s = re.sub(r"`[^`]*`", "`X`", s)
+    return s
+
+def categorize(msg):
+    stdlib_syms = ("Array","Number","String","Boolean","Object","Reflect","Math","Map","Set",
+        "TextEncoder","TextDecoder","Promise","Date","JSON","RegExp","Symbol","BigInt","Error",
+        "WeakMap","WeakSet","Proxy","Intl","ArrayBuffer","DataView","Iterator")
+    if re.search(r"unresolved.*?(class|identifier|callback)", msg):
+        for sym in stdlib_syms:
+            if re.search(r"[`']"+re.escape(sym)+r"[`']", msg):
+                return "missing-stdlib"
+        # module-level builtins (sys, os, etc.) or genuinely missing -> could be import noise
+        return "unresolved (maybe stdlib / import noise)"
+    if "instanceof" in msg or "TextEncoder" in msg or "TextDecoder" in msg:
+        return "missing-stdlib"
+    return "transpiler-limitation"
+
+def list_files(root, exts):
+    out = []
+    for dp, dn, fn in os.walk(root):
+        if "node_modules" in dp or "/dist-" in dp or "/.git" in dp:
+            continue
+        for f in fn:
+            if any(f.endswith(e) for e in exts) and not f.endswith(".d.ts"):
+                out.append(os.path.join(dp, f))
+    return out
+
+def main():
+    lib_dir = sys.argv[1]
+    exts = [".py"] if sys.argv[2] == "py" else [".ts"]
+    # restrict to source roots passed as remaining args
+    roots = [os.path.join(lib_dir, r) for r in sys.argv[3:]] or [lib_dir]
+    files = []
+    for r in roots:
+        if os.path.isdir(r):
+            files += list_files(r, exts)
+    files = sorted(set(files))
+    cls_counter = Counter()      # blocker class -> count of occurrences
+    cls_files = {}               # blocker class -> set of files
+    cat_counter = Counter()      # category -> distinct classes
+    failing_files = set()
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        for path, msgs in ex.map(scan_file, files):
+            if msgs:
+                failing_files.add(path)
+            for m in msgs:
+                c = normalize(m)
+                cls_counter[c] += 1
+                cls_files.setdefault(c, set()).add(path)
+    result = {
+        "library": os.path.basename(lib_dir.rstrip("/")),
+        "files_scanned": len(files),
+        "files_with_errors": len(failing_files),
+        "classes": []
+    }
+    for cls, n in cls_counter.most_common():
+        result["classes"].append({
+            "class": cls,
+            "occurrences": n,
+            "files": len(cls_files[cls]),
+            "category": categorize(cls),
+        })
+    print(json.dumps(result, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe_libraries.py
+++ b/scripts/probe_libraries.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""Drive the daily third-party "bug library" transpile probes and emit a report.
+
+For each library listed in `.github/compat/libraries.json` (already checked out
+under --work-dir, with its fixture `Smelt.toml` copied into place), this script:
+
+  1. runs `smelt build` to attempt a whole-crate transpile;
+  2. if a Rust crate is emitted, runs `smelt rust-test-report --full` and records
+     how many generated `cargo test` cases pass/fail;
+  3. if the build aborts at the first unsupported construct, scans every source/
+     test file individually with `smelt dump-hir` to enumerate the full set of
+     distinct blocker classes, categorized as missing-stdlib vs non-working Rust.
+
+It writes a single Markdown report (the `Transpile y/n -> tests pass -> per-error
+category -> where we fail` shape) to --output. Designed to run unattended in CI.
+
+Usage:
+    python3 scripts/probe_libraries.py \
+        --config .github/compat/libraries.json \
+        --fixtures .github/compat \
+        --work-dir target/library-probes \
+        --output blocker-logs/library-probes.md
+"""
+from __future__ import annotations
+import argparse, datetime as dt, json, os, re, shutil, subprocess, sys
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor
+
+# --- error classification -------------------------------------------------
+
+# JS/Python builtins Smelt does not model yet -> "missing stdlib".
+STDLIB = {
+    "Array", "Number", "String", "Boolean", "Object", "Reflect", "Math", "Map",
+    "Set", "TextEncoder", "TextDecoder", "Promise", "Date", "JSON", "RegExp",
+    "Symbol", "BigInt", "WeakMap", "WeakSet", "Proxy", "Intl", "ArrayBuffer",
+    "DataView", "Iterator", "Buffer", "Blob", "File", "AbortController",
+    "globalThis", "parseInt", "parseFloat", "isFinite", "isNaN", "Function",
+}
+STDLIB_PHRASES = ("TextEncoder", "TextDecoder", "instanceof")
+# Single-file scanning cannot resolve cross-file symbols; treat bare unresolved
+# identifier/name errors as scan noise so they do not pollute the blocker table.
+NOISE_PREFIXES = ("unresolved name", "unresolved identifier", "unresolved const",
+                  "references unresolved const", "<timeout>")
+
+MSG_RE = re.compile(r'message: \\"(.*?)\\"')
+SYM_RE = re.compile(r"unresolved (?:callback )?(?:identifier|class) [`']([^`']+)[`']")
+ABORT_FILE_RE = re.compile(r'error: "([^"]*\.(?:ts|py))')
+TEST_RESULT_RE = re.compile(r"(\d+) passed; (\d+) failed")
+
+
+def classify(cls: str) -> str:
+    """Map a blocker class to one of: stdlib, stdlib?, noise, rust."""
+    if any(p in cls for p in STDLIB_PHRASES):
+        return "stdlib"
+    if cls.startswith("unresolved class"):
+        return "stdlib?"  # builtin used via new/extends, e.g. `unresolved class Array`
+    if any(cls.startswith(n) for n in NOISE_PREFIXES):
+        return "noise"
+    return "rust"
+
+
+def normalize(msg: str) -> str:
+    """Collapse a message to its blocker class by erasing quoted specifics."""
+    s = re.sub(r"'[^']*'", "'X'", msg)
+    s = re.sub(r"`[^`]*`", "`X`", s)
+    return s
+
+
+# --- smelt invocation -----------------------------------------------------
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+def dump_hir(smelt_bin: str, smelt_root: str, path: str):
+    """Return (messages, stdlib_symbols) for one source file."""
+    try:
+        r = run([smelt_bin, "dump-hir", os.path.abspath(path)], timeout=45, cwd=smelt_root)
+    except subprocess.TimeoutExpired:
+        # Pathological type-level files (e.g. ts-pattern) can hang the frontend;
+        # they are excluded as scan noise, so a short cap keeps CI fast.
+        return ["<timeout>"], []
+    out = r.stdout + r.stderr
+    msgs = MSG_RE.findall(out)
+    syms = [s for m in msgs for s in SYM_RE.findall(m) if s in STDLIB]
+    return msgs, syms
+
+
+def list_source_files(root: str, lang: str):
+    exts = (".py",) if lang == "py" else (".ts",)
+    out = []
+    for dp, _dn, fn in os.walk(root):
+        if any(x in dp for x in ("node_modules", "/dist-", "/.git", "__pycache__")):
+            continue
+        for f in fn:
+            if f.endswith(exts) and not f.endswith(".d.ts"):
+                out.append(os.path.join(dp, f))
+    return out
+
+
+def scan_library(smelt_bin, smelt_root, lib_dir, roots, lang):
+    """Enumerate distinct blocker classes across every file in the library."""
+    files = []
+    for r in roots:
+        p = os.path.join(lib_dir, r)
+        if os.path.isdir(p):
+            files += list_source_files(p, lang)
+    files = sorted(set(files))
+    cls_occ, cls_files, syms = Counter(), defaultdict(set), Counter()
+    fail_files = set()
+    with ThreadPoolExecutor(max_workers=min(8, (os.cpu_count() or 2))) as ex:
+        results = ex.map(lambda f: (f, *dump_hir(smelt_bin, smelt_root, f)), files)
+        for path, msgs, file_syms in results:
+            if msgs:
+                fail_files.add(path)
+            for m in msgs:
+                c = normalize(m)
+                cls_occ[c] += 1
+                cls_files[c].add(path)
+            for s in file_syms:
+                syms[s] += 1
+    classes = [
+        {"class": c, "occurrences": n, "files": len(cls_files[c]), "category": classify(c)}
+        for c, n in cls_occ.most_common()
+    ]
+    return {
+        "files_scanned": len(files),
+        "files_with_errors": len(fail_files),
+        "classes": classes,
+        "stdlib_symbols": dict(syms.most_common()),
+    }
+
+
+def probe_library(smelt_bin, smelt_root, lib, work_dir, fixtures_dir):
+    """Build one library and return its probe result dict."""
+    name, lang, roots = lib["name"], lib["lang"], lib["roots"]
+    lib_dir = os.path.join(work_dir, name)
+    fixture = os.path.join(fixtures_dir, name, "Smelt.toml")
+    shutil.copy(fixture, os.path.join(lib_dir, "Smelt.toml"))
+    manifest = os.path.join(lib_dir, "Smelt.toml")
+
+    build = run([smelt_bin, "build", "--manifest-path", manifest], cwd=smelt_root)
+    build_out = build.stdout + build.stderr
+
+    # output.target / output.crate-name from fixture (default dist-smelt)
+    target = "dist-smelt"
+    m = re.search(r'target\s*=\s*"\.?/?([^"]+)"', open(fixture).read())
+    if m:
+        target = m.group(1)
+    cargo_manifest = os.path.join(lib_dir, target, "Cargo.toml")
+
+    res = {"name": name, "repo": lib["repo"], "ref": lib["ref"], "lang": lang, "roots": roots}
+
+    if os.path.isfile(cargo_manifest):
+        res["transpile"] = True
+        report_path = os.path.join(lib_dir, "_test_report.md")
+        tr = run([smelt_bin, "rust-test-report",
+                  "--build-manifest", manifest,
+                  "--cargo-manifest", cargo_manifest,
+                  "--full", "--suppress-warnings",
+                  "--output", report_path], cwd=smelt_root)
+        report = open(report_path).read() if os.path.isfile(report_path) else (tr.stdout + tr.stderr)
+        mr = TEST_RESULT_RE.search(report)
+        if mr:
+            res["passed"], res["failed"] = int(mr.group(1)), int(mr.group(2))
+        res["test_report"] = report
+    else:
+        res["transpile"] = False
+        ab = ABORT_FILE_RE.search(build_out)
+        if ab:
+            af = ab.group(1).replace(lib_dir + "/", "")
+            af = re.sub(r"^\.?/+", "", af).replace("/./", "/")
+            res["abort_file"] = af
+        else:
+            res["abort_file"] = "(unknown)"
+        res.update(scan_library(smelt_bin, smelt_root, lib_dir, roots, lang))
+    return res
+
+
+# --- report rendering -----------------------------------------------------
+
+CAT_LABEL = {
+    "stdlib": "missing-stdlib",
+    "stdlib?": "missing-stdlib (builtin class)",
+    "rust": "non-working Rust",
+}
+
+
+def visible_classes(res, limit=14):
+    rows = [c for c in res.get("classes", []) if classify(c["class"]) != "noise"]
+    return rows[:limit], rows
+
+
+def render(results, date_str):
+    L = []
+    w = L.append
+    w("# Bug-library transpile probes (TypeScript + Python)")
+    w("")
+    w(f"_Generated {date_str} by the `library-probes` workflow "
+      "(`scripts/probe_libraries.py`)._")
+    w("")
+    w("Each library is checked out at a pinned ref (see "
+      "`.github/compat/libraries.json`), given its `.github/compat/<name>/Smelt.toml`, "
+      "and run through `smelt build`. If a crate is emitted, its generated `cargo test` "
+      "suite is run and counted. Otherwise every source/test file is scanned individually "
+      "with `smelt dump-hir` to enumerate the full set of distinct blocker classes "
+      "(single-file mode cannot resolve cross-file imports, so bare `unresolved "
+      "name/identifier` errors are excluded as scan noise).")
+    w("")
+    w("**Error categories:**")
+    w("- **missing-stdlib** — a JS/Python builtin Smelt does not model yet "
+      "(`Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`, ...).")
+    w("- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the "
+      "construct into Rust that compiles (missing return-type annotations, `try`/`except`, "
+      "decorators, callback methods not lowered into closures, non-primitive exported "
+      "`const`, ...).")
+    w("")
+
+    # summary
+    w("## Summary")
+    w("")
+    w("| Library | Lang | Transpile | Tests (pass/fail) | First abort | Blocker classes | Dominant |")
+    w("| --- | --- | --- | --- | --- | ---: | --- |")
+    for r in results:
+        lang = r["lang"].upper()
+        if r["transpile"]:
+            tests = (f"{r['passed']} / {r['failed']}" if "passed" in r
+                     else "transpiled (counts unparsed)")
+            row = (f"| [{r['name']}](https://github.com/{r['repo']}) | {lang} | **yes** | "
+                   f"{tests} | — | — | — |")
+        else:
+            _, rows = visible_classes(r)
+            nstd = sum(1 for c in rows if classify(c["class"]) in ("stdlib", "stdlib?"))
+            nrust = sum(1 for c in rows if classify(c["class"]) == "rust")
+            dom = "non-working Rust" if nrust >= nstd else "missing-stdlib"
+            row = (f"| [{r['name']}](https://github.com/{r['repo']}) | {lang} | **no** | "
+                   f"n/a | `{r['abort_file']}` | {len(rows)} | {dom} ({nrust}r/{nstd}s) |")
+        w(row)
+    w("")
+
+    # per-library detail
+    for r in results:
+        w(f"## {r['name']}")
+        w("")
+        w(f"- Source: `{r['repo']}` @ `{r['ref'][:12]}`")
+        if r["transpile"]:
+            w("- Transpile: **yes** — Rust crate emitted")
+            if "passed" in r:
+                w(f"- Generated `cargo test`: **{r['passed']} passed / {r['failed']} failed**")
+            else:
+                w("- Generated `cargo test`: transpiled, but pass/fail counts could not be parsed")
+            w("")
+            continue
+        w(f"- Transpile: **no** — `smelt build` aborts at `{r['abort_file']}`")
+        w("- Tests passing: **n/a** (no Rust crate emitted)")
+        w(f"- Files scanned: {r['files_scanned']} · with blockers: {r['files_with_errors']}")
+        w("")
+        rows_md, _ = visible_classes(r)
+        w("| Occurrences | Files | Category | Blocker class |")
+        w("| ---: | ---: | --- | --- |")
+        for c in rows_md:
+            label = CAT_LABEL[classify(c["class"])]
+            w(f"| {c['occurrences']} | {c['files']} | {label} | "
+              f"{c['class'][:90].replace('|', chr(92) + '|')} |")
+        w("")
+
+    # cross-cutting: highest-leverage lowering gaps
+    libcount, occ = defaultdict(set), Counter()
+    for r in results:
+        if r["transpile"]:
+            continue
+        for c in r.get("classes", []):
+            if classify(c["class"]) == "rust":
+                libcount[c["class"]].add(r["name"])
+                occ[c["class"]] += c["occurrences"]
+    ranked = sorted(libcount.items(), key=lambda kv: (len(kv[1]), occ[kv[0]]), reverse=True)
+    multi = [(c, libs) for c, libs in ranked if len(libs) >= 2]
+    if multi:
+        w("## Highest-leverage transpiler gaps (non-working Rust)")
+        w("")
+        w("Lowering gaps blocking more than one probed library; fixing these unlocks the most surface.")
+        w("")
+        w("| Libraries hit | Total occ. | Blocker class |")
+        w("| ---: | ---: | --- |")
+        for c, libs in multi:
+            safe = c[:100].replace("|", "\\|")
+            w(f"| {len(libs)} ({', '.join(sorted(libs))}) | {occ[c]} | {safe} |")
+        w("")
+
+    # cross-cutting: missing stdlib builtins
+    sym_rows = [(r["name"], r["stdlib_symbols"]) for r in results
+                if not r["transpile"] and r.get("stdlib_symbols")]
+    if sym_rows:
+        w("## Missing stdlib builtins observed")
+        w("")
+        w("Builtins referenced in `new`/`extends`/callback position that Smelt does not resolve.")
+        w("")
+        w("| Library | Builtins (occurrences) |")
+        w("| --- | --- |")
+        for name, syms in sym_rows:
+            s = ", ".join(f"`{k}`×{v}" for k, v in syms.items())
+            w(f"| {name} | {s} |")
+        w("")
+    return "\n".join(L) + "\n"
+
+
+# --- main -----------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default=".github/compat/libraries.json")
+    ap.add_argument("--fixtures", default=".github/compat")
+    ap.add_argument("--work-dir", default="target/library-probes")
+    ap.add_argument("--output", default="blocker-logs/library-probes.md")
+    ap.add_argument("--smelt-bin", default=os.environ.get("SMELT_BIN", "target/debug/smelt"))
+    ap.add_argument("--smelt-root", default=os.environ.get("SMELT_ROOT", os.getcwd()))
+    ap.add_argument("--date", default=dt.date.today().isoformat())
+    args = ap.parse_args()
+
+    smelt_bin = os.path.abspath(args.smelt_bin)
+    config = json.load(open(args.config))
+    results = []
+    for lib in config["libraries"]:
+        lib_dir = os.path.join(args.work_dir, lib["name"])
+        if not os.path.isdir(lib_dir):
+            print(f"!! skipping {lib['name']}: not checked out at {lib_dir}", file=sys.stderr)
+            continue
+        print(f">> probing {lib['name']} ...", file=sys.stderr)
+        results.append(probe_library(smelt_bin, args.smelt_root, lib, args.work_dir, args.fixtures))
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    open(args.output, "w").write(render(results, args.date))
+    print(f"wrote {args.output} ({len(results)} libraries)", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Probes how far Smelt can transpile real-world third-party "bug libraries" beyond the curated `remeda` compat target, and turns it into a **daily CI job** that tracks coverage over time.

Probed **5 TypeScript + 5 Python** libraries. Currently **all 10 fail at the transpile stage** — each whole-crate `smelt build` aborts at the first unsupported construct, so none reach the `cargo test` stage yet (reference: `remeda` transpiles, 1768 pass / 21 fail). The report enumerates the full blocker set per library, categorized as **missing-stdlib** vs **non-working Rust** lowering, so the highest-leverage fixes are visible.

- **TS:** es-toolkit, radash, ts-pattern, valibot, neverthrow
- **Py:** returns, result, more-itertools, funcy, toolz

### Highest-leverage gaps found
- All 5 TS libs: `callback method X is not lowered into closure bodies yet`
- All 5 Py libs: `only calls to top-level functions/constructors/print() are supported` (~1011 occurrences)
- 4 Py libs: `function must have an explicit return type annotation` (~515) — note `toolz`/`funcy`/`more-itertools` aren't fully annotated, so they're partly outside Smelt's typed-source scope
- Missing TS stdlib builtins: `Array`, `Number`, `Reflect`, `Proxy`, `TextEncoder`, `ArrayBuffer`, `Map`, `Promise`, ...

## What's in the PR

- **`.github/workflows/library-probes.yml`** — daily (cron) + manual workflow. Builds smelt, checks out each library at its pinned ref, runs the driver, commits the refreshed report. Independent of the regression CI and never fails the build.
- **`scripts/probe_libraries.py`** — config-driven driver. Per library it runs `smelt build`; if a crate is emitted it runs `rust-test-report --full` and records pass/fail counts, otherwise it scans every file with `dump-hir` to enumerate distinct blocker classes and the first abort site. Emits the Markdown report. As Smelt improves, libraries auto-promote from "no / blocker list" to "yes / N tests pass".
- **`.github/compat/libraries.json`** — probe set with pinned commit SHAs + source roots. Pinning means the daily diff reflects Smelt changes, not upstream drift; bump a `ref` to re-baseline.
- **`.github/compat/<lib>/Smelt.toml`** — reproducible per-library fixtures (mirrors the `remeda` pattern) + `.github/compat/README.md`.
- **`scripts/probe_blocker_scan.py`** — standalone per-library blocker enumerator.
- **`blocker-logs/library-probes.md`** — canonical report, refreshed daily by the workflow.

## Notes
- The report uses a stable filename overwritten daily (like `COMPAT.md`), and the workflow commits to the branch it runs on (matching the existing `compat.yml`).
- Refs are pinned to each library's current default-branch HEAD. If you'd rather track latest upstream, that's a one-line config change — but pinned is the better fit for measuring Smelt's own progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)