### PR TITLE
Lower Python callable expression calls

### DIFF
--- a/crates/smelt-frontend-py/src/lowering.rs
+++ b/crates/smelt-frontend-py/src/lowering.rs
@@ -115,6 +115,20 @@ struct FunctionVariadics {
     kwarg: Option<KwArgParam>,
 }
 
+/// Static Python callable signature used for call argument lowering.
+struct CallableCallSignature<'a> {
+    /// Parameter types in lowered call order.
+    params: &'a [TypeId],
+    /// Positional vararg metadata when source `*args` are packed.
+    vararg: Option<VarArgParam>,
+    /// Keyword vararg metadata when source `**kwargs` are packed.
+    kwarg: Option<KwArgParam>,
+    /// Default argument expressions in lowered parameter order.
+    defaults: &'a [Option<smelt_hir::ExprId>],
+    /// Diagnostic label for this kind of callable.
+    label: &'a str,
+}
+
 /// A closure expression prepared for a callback-consuming Python API.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct ClosureCallback {

--- a/crates/smelt-frontend-py/src/lowering/call.rs
+++ b/crates/smelt-frontend-py/src/lowering/call.rs
@@ -279,63 +279,31 @@ impl ModuleBuilder<'_> {
                         }));
                     }
                     Item::Function(f) => {
-                        let return_ty = f.return_ty;
+                        let function = f.clone();
+                        let return_ty = function.return_ty;
                         let callee = body.push_expr(HirExpr {
                             kind: ExprKind::Item(item_id),
-                            ty: return_ty,
+                            ty: self.function_item_type(&function),
                             span,
                         });
                         let variadics = self.function_variadics.get(name_str).copied();
-                        if variadics.and_then(|v| v.kwarg).is_none()
-                            && !call.arguments.keywords.is_empty()
-                        {
-                            return Err(SmeltError::unsupported(
-                                span,
-                                "function keyword arguments require a **kwargs parameter",
-                            ));
-                        }
-                        let vararg_meta = variadics.and_then(|v| v.vararg);
-                        let kwarg_meta = variadics.and_then(|v| v.kwarg);
-                        let packed_param_start = vararg_meta
-                            .map(|meta| meta.index)
-                            .or_else(|| kwarg_meta.map(|meta| meta.index))
-                            .unwrap_or(f.params.len());
-                        if vararg_meta.is_none() && call.arguments.args.len() > packed_param_start {
-                            return Err(SmeltError::unsupported(
-                                span,
-                                "function argument count does not match parameters",
-                            ));
-                        }
-                        let mut args = call
-                            .arguments
-                            .args
+                        let params = function
+                            .params
                             .iter()
-                            .take(packed_param_start)
-                            .map(|a| self.expression(a, body))
-                            .collect::<Result<Vec<_>, _>>()?;
-                        if let Some(meta) = vararg_meta {
-                            let packed_args = call
-                                .arguments
-                                .args
-                                .iter()
-                                .skip(meta.index)
-                                .map(|arg| self.expression(arg, body))
-                                .collect::<Result<Vec<_>, _>>()?;
-                            let rest_ty = self.intern_type(Type::List(meta.item_ty));
-                            args.push(body.push_expr(HirExpr {
-                                kind: ExprKind::ListLit(packed_args),
-                                ty: rest_ty,
-                                span,
-                            }));
-                        }
-                        if let Some(meta) = kwarg_meta {
-                            args.push(self.kwargs_argument(
-                                &call.arguments.keywords,
-                                meta.value_ty,
-                                span,
-                                body,
-                            )?);
-                        }
+                            .map(|param| param.ty)
+                            .collect::<Vec<_>>();
+                        let defaults = vec![None; params.len()];
+                        let args = self.callable_call_args(
+                            call,
+                            body,
+                            &CallableCallSignature {
+                                params: &params,
+                                vararg: variadics.and_then(|v| v.vararg),
+                                kwarg: variadics.and_then(|v| v.kwarg),
+                                defaults: &defaults,
+                                label: "function",
+                            },
+                        )?;
                         return Ok(body.push_expr(HirExpr {
                             kind: ExprKind::Call { callee, args },
                             ty: return_ty,
@@ -345,6 +313,10 @@ impl ModuleBuilder<'_> {
                     Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) => {}
                 }
             }
+        }
+
+        if let Some(expr) = self.callable_expression_call(call, body)? {
+            return Ok(expr);
         }
 
         Err(SmeltError::unsupported(
@@ -371,38 +343,103 @@ impl ModuleBuilder<'_> {
             return Ok(None);
         };
         let callback_meta = self.local_callbacks.get(name).cloned();
-        let vararg_meta = callback_meta.as_ref().and_then(|callback| callback.vararg);
-        let kwarg_meta = callback_meta.as_ref().and_then(|callback| callback.kwarg);
-        let supplied_arg_count = call.arguments.args.len();
-        if kwarg_meta.is_none() && !call.arguments.keywords.is_empty() {
-            return Err(SmeltError::unsupported(
-                self.span(call.range),
-                "closure keyword arguments require a **kwargs closure parameter",
-            ));
-        }
         let defaults = callback_meta
             .as_ref()
             .map_or_else(|| vec![None; function.params.len()], |callback| {
                 callback.defaults.clone()
             });
-        let packed_param_start = vararg_meta
+        let callee = self.identifier_expression(name, call.func.range(), body)?;
+        let args = self.callable_call_args(
+            call,
+            body,
+            &CallableCallSignature {
+                params: &function.params,
+                vararg: callback_meta.as_ref().and_then(|callback| callback.vararg),
+                kwarg: callback_meta.as_ref().and_then(|callback| callback.kwarg),
+                defaults: &defaults,
+                label: "closure",
+            },
+        )?;
+        Ok(Some(body.push_expr(HirExpr {
+            kind: ExprKind::ClosureCall { callee, args },
+            ty: function.return_ty,
+            span: self.span(call.range),
+        })))
+    }
+
+    /// Lower a call whose callee expression has a statically known function type.
+    fn callable_expression_call(
+        &mut self,
+        call: &ruff_python_ast::ExprCall,
+        body: &mut Body,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        if matches!(call.func.as_ref(), Expr::Name(_)) {
+            return Ok(None);
+        }
+        let callee = self.expression(&call.func, body)?;
+        let callee_ty = Self::expr_ty(body, callee);
+        let Some(Type::Function(function)) = self.ctx.krate.types.get(callee_ty).cloned() else {
+            return Ok(None);
+        };
+        let defaults = vec![None; function.params.len()];
+        let args = self.callable_call_args(
+            call,
+            body,
+            &CallableCallSignature {
+                params: &function.params,
+                vararg: None,
+                kwarg: None,
+                defaults: &defaults,
+                label: "callable expression",
+            },
+        )?;
+        Ok(Some(body.push_expr(HirExpr {
+            kind: ExprKind::ClosureCall { callee, args },
+            ty: function.return_ty,
+            span: self.span(call.range),
+        })))
+    }
+
+    /// Lower and validate Python call arguments for a statically typed callable.
+    fn callable_call_args(
+        &mut self,
+        call: &ruff_python_ast::ExprCall,
+        body: &mut Body,
+        signature: &CallableCallSignature<'_>,
+    ) -> Result<Vec<smelt_hir::ExprId>, SmeltError> {
+        let span = self.span(call.range);
+        let supplied_arg_count = call.arguments.args.len();
+        if signature.kwarg.is_none() && !call.arguments.keywords.is_empty() {
+            return Err(SmeltError::unsupported(
+                span,
+                format!(
+                    "{} keyword arguments require a **kwargs parameter",
+                    signature.label
+                ),
+            ));
+        }
+        let packed_param_start = signature
+            .vararg
             .map(|meta| meta.index)
-            .or_else(|| kwarg_meta.map(|meta| meta.index))
-            .unwrap_or(function.params.len());
-        let required_arg_count = defaults
+            .or_else(|| signature.kwarg.map(|meta| meta.index))
+            .unwrap_or(signature.params.len());
+        let required_arg_count = signature
+            .defaults
             .iter()
             .take(packed_param_start)
             .position(Option::is_some)
             .unwrap_or(packed_param_start);
         if supplied_arg_count < required_arg_count
-            || (vararg_meta.is_none() && supplied_arg_count > packed_param_start)
+            || (signature.vararg.is_none() && supplied_arg_count > packed_param_start)
         {
             return Err(SmeltError::unsupported(
-                self.span(call.range),
-                "closure call argument count does not match closure parameters",
+                span,
+                format!(
+                    "{} call argument count does not match parameters",
+                    signature.label
+                ),
             ));
         }
-        let callee = self.identifier_expression(name, call.func.range(), body)?;
         let mut args = call
             .arguments
             .args
@@ -411,15 +448,18 @@ impl ModuleBuilder<'_> {
             .map(|arg| self.expression(arg, body))
             .collect::<Result<Vec<_>, _>>()?;
         for index in supplied_arg_count..packed_param_start {
-            let Some(default) = defaults.get(index).and_then(|default| *default) else {
+            let Some(default) = signature.defaults.get(index).and_then(|default| *default) else {
                 return Err(SmeltError::unsupported(
-                    self.span(call.range),
-                    "closure call argument count does not match closure parameters",
+                    span,
+                    format!(
+                        "{} call argument count does not match parameters",
+                        signature.label
+                    ),
                 ));
             };
             args.push(default);
         }
-        if let Some(meta) = vararg_meta {
+        if let Some(meta) = signature.vararg {
             let packed_args = call
                 .arguments
                 .args
@@ -431,30 +471,24 @@ impl ModuleBuilder<'_> {
             args.push(body.push_expr(HirExpr {
                 kind: ExprKind::ListLit(packed_args),
                 ty: rest_ty,
-                span: self.span(call.range),
+                span,
             }));
         }
-        if let Some(meta) = kwarg_meta {
-            args.push(self.kwargs_argument(
-                &call.arguments.keywords,
-                meta.value_ty,
-                self.span(call.range),
-                body,
-            )?);
+        if let Some(meta) = signature.kwarg {
+            args.push(self.kwargs_argument(&call.arguments.keywords, meta.value_ty, span, body)?);
         }
-        for (arg, expected) in args.iter().zip(&function.params) {
+        for (arg, expected) in args.iter().zip(signature.params) {
             if Self::expr_ty(body, *arg) != *expected {
                 return Err(SmeltError::unsupported(
-                    self.span(call.range),
-                    "closure call argument type does not match closure parameter",
+                    span,
+                    format!(
+                        "{} call argument type does not match parameter",
+                        signature.label
+                    ),
                 ));
             }
         }
-        Ok(Some(body.push_expr(HirExpr {
-            kind: ExprKind::ClosureCall { callee, args },
-            ty: function.return_ty,
-            span: self.span(call.range),
-        })))
+        Ok(args)
     }
 
     /// Packs Python keyword arguments into the lowered `**kwargs` dictionary argument.

--- a/crates/smelt-frontend-py/src/lowering/map.rs
+++ b/crates/smelt-frontend-py/src/lowering/map.rs
@@ -303,19 +303,7 @@ impl ModuleBuilder<'_> {
             if let Some(expr) = self.const_item_expression(item_id, body, span)? {
                 return Ok(expr);
             }
-            let ty = match self.item_ref(item_id) {
-                Item::Function(f) => f.return_ty,
-                Item::Class(c) => {
-                    let sym = c.name;
-                    self.intern_type(Type::Class {
-                        name: sym,
-                        args: vec![],
-                    })
-                }
-                Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) => {
-                    self.intern_type(Type::None)
-                }
-            };
+            let ty = self.item_expr_type(item_id);
             return Ok(body.push_expr(HirExpr {
                 kind: ExprKind::Item(item_id),
                 ty,

--- a/crates/smelt-frontend-py/src/lowering/member.rs
+++ b/crates/smelt-frontend-py/src/lowering/member.rs
@@ -29,7 +29,7 @@ impl ModuleBuilder<'_> {
         };
         let callee = body.push_expr(HirExpr {
             kind: ExprKind::Item(item_id),
-            ty: return_ty,
+            ty: self.item_expr_type(item_id),
             span: self.span(attr.range),
         });
         let args = call
@@ -173,10 +173,11 @@ impl ModuleBuilder<'_> {
                 })))
             }
             Item::Function(function) => {
-                let return_ty = function.return_ty;
+                let function_item = function.clone();
+                let return_ty = function_item.return_ty;
                 let callee = body.push_expr(HirExpr {
                     kind: ExprKind::Item(item_id),
-                    ty: return_ty,
+                    ty: self.function_item_type(&function_item),
                     span: self.span(attr.range),
                 });
                 let args = call
@@ -211,7 +212,10 @@ impl ModuleBuilder<'_> {
     /// Return the HIR type to attach when an item appears as an expression.
     fn item_expr_type(&mut self, item_id: ItemId) -> TypeId {
         match self.item_ref(item_id) {
-            Item::Function(function) => function.return_ty,
+            Item::Function(function) => {
+                let function_item = function.clone();
+                self.function_item_type(&function_item)
+            }
             Item::Class(class) => {
                 let sym = class.name;
                 self.intern_type(Type::Class {
@@ -226,6 +230,19 @@ impl ModuleBuilder<'_> {
                 }
             }
         }
+    }
+
+    /// Return the first-class function type for a HIR function item reference.
+    fn function_item_type(&mut self, function: &Function) -> TypeId {
+        self.intern_type(Type::Function(FunctionType {
+            params: function.params.iter().map(|param| param.ty).collect(),
+            rest: function.rest,
+            required_params: function.required_params,
+            mutable_params: Vec::new(),
+            return_ty: function.return_ty,
+            is_async: function.is_async,
+            may_throw: false,
+        }))
     }
 
     /// Inline an importable constant expression into the current body when supported.

--- a/crates/smelt-frontend-py/src/tests/packages_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/packages_tests.rs
@@ -141,6 +141,77 @@ result: int = httpx.add(2, 3)
 }
 
 #[test]
+fn function_item_references_keep_callable_type() -> TestResult {
+    let source = py!(r#"
+def add(a: int, b: int) -> int:
+    return a + b
+
+alias = add
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let module_body = body(&ctx, module.body.ok_or("expected module body")?)?;
+    let item_expr = module_body
+        .exprs
+        .iter()
+        .find(|expr| matches!(expr.kind, ExprKind::Item(_)))
+        .ok_or_else(|| "expected function item expression".to_owned())?;
+    ensure(
+        matches!(ctx.krate.types.get(item_expr.ty), Some(Type::Function(function)) if function.params.len() == 2),
+        "expected bare function reference to carry a function type",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn callable_field_call_lowers_as_closure_call() -> TestResult {
+    let source = py!(r#"
+from typing import Callable
+
+class Box:
+    callback: Callable[[int], int]
+
+box: Box = Box()
+value: int = box.callback(41)
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let module_body = body(&ctx, module.body.ok_or("expected module body")?)?;
+    ensure(
+        module_body
+            .exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::ClosureCall { .. })),
+        "expected function-typed field call to lower as a closure call",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn callable_index_call_lowers_as_closure_call() -> TestResult {
+    let source = py!(r#"
+from typing import Callable
+
+callbacks: dict[str, Callable[[int], int]] = {}
+value: int = callbacks["next"](41)
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let module_body = body(&ctx, module.body.ok_or("expected module body")?)?;
+    ensure(
+        module_body
+            .exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::ClosureCall { .. })),
+        "expected function-typed index call to lower as a closure call",
+    )?;
+    Ok(())
+}
+
+#[test]
 fn constructed_module_constant_exports_class_instance() -> TestResult {
     let source = py!(r#"
 class NullFile:


### PR DESCRIPTION
## Summary
- refactor Python call lowering to share typed callable argument packing
- lower statically typed callable expression calls for fields and indexes
- preserve first-class function types for Python function item references

## Validation
- cargo check
- cargo clippy
- cargo test -p smelt-frontend-py packages_tests -- --nocapture
- cargo test