### PR TITLE
spike(python): evaluate Astral `ty` as a Python type source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/smelt-test",
     "crates/smelt-cli",
     "crates/smelt-gui",
+    "crates/smelt-py-ty-spike",
 ]
 default-members = [
     "crates/smelt-frontend-ts",

--- a/crates/smelt-py-ty-spike/Cargo.toml
+++ b/crates/smelt-py-ty-spike/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "smelt-py-ty-spike"
+version.workspace = true
+edition.workspace = true
+publish = false
+autoexamples = false
+
+# SPIKE / FEASIBILITY ONLY. This crate is intentionally kept OUT of
+# `default-members` so the heavy `ty` dependency tree (salsa, vendored typeshed,
+# the ty semantic model) does not affect the normal `cargo build`. It exists to
+# evaluate using Astral's `ty` as a real Python type-checker / type source for
+# Smelt's Python frontend. See `specs/python-type-checking-with-ty.md`.
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "1"
+
+# `ty` and the ruff parser crates are not published to crates.io, so they are
+# pulled from the upstream git repo pinned to the SAME revision already used by
+# `smelt-frontend-py` (`ruff_python_parser`/`ruff_python_ast`/`ruff_text_size`),
+# which keeps the workspace on one ruff checkout.
+ruff_db = { git = "https://github.com/astral-sh/ruff", rev = "6c88390f7d49068c6fc2a0102145c3bdd5318e35", features = ["os"] }
+ruff_python_ast = { git = "https://github.com/astral-sh/ruff", rev = "6c88390f7d49068c6fc2a0102145c3bdd5318e35" }
+ty_project = { git = "https://github.com/astral-sh/ruff", rev = "6c88390f7d49068c6fc2a0102145c3bdd5318e35" }
+ty_python_semantic = { git = "https://github.com/astral-sh/ruff", rev = "6c88390f7d49068c6fc2a0102145c3bdd5318e35" }
+
+[[bin]]
+name = "smelt-py-ty-spike"
+path = "src/main.rs"

--- a/crates/smelt-py-ty-spike/src/main.rs
+++ b/crates/smelt-py-ty-spike/src/main.rs
@@ -38,11 +38,23 @@ bad: int = "not an int"
 "#;
 
 fn main() -> Result<()> {
-    // ty's `OsSystem` reads real files, so materialize a one-file project.
-    let dir = std::env::temp_dir().join("smelt-ty-spike");
-    std::fs::create_dir_all(&dir).context("create spike project dir")?;
-    let sample = dir.join("sample.py");
-    std::fs::write(&sample, SAMPLE_PY).context("write sample.py")?;
+    // With two args, check a real project: <project-root> <file-relative-to-root>.
+    // With none, fall back to the built-in SAMPLE_PY one-file project.
+    let mut args = std::env::args().skip(1);
+    let (dir, sample) = match (args.next(), args.next()) {
+        (Some(root), Some(rel)) => {
+            let root = std::path::PathBuf::from(root);
+            let file = root.join(rel);
+            (root, file)
+        }
+        _ => {
+            let dir = std::env::temp_dir().join("smelt-ty-spike");
+            std::fs::create_dir_all(&dir).context("create spike project dir")?;
+            let sample = dir.join("sample.py");
+            std::fs::write(&sample, SAMPLE_PY).context("write sample.py")?;
+            (dir, sample)
+        }
+    };
 
     let root = to_system_path(dir)?;
     let system = OsSystem::new(&root);
@@ -51,14 +63,18 @@ fn main() -> Result<()> {
     let db = ProjectDatabase::use_defaults(metadata, system);
 
     let sample_path = to_system_path(sample)?;
-    let file = system_path_to_file(&db, &sample_path).context("resolve sample.py in ty db")?;
+    let file = system_path_to_file(&db, &sample_path).context("resolve file in ty db")?;
 
     println!("== ty diagnostics ==");
     match check_file(&db, file) {
-        Ok(diagnostics) if diagnostics.is_empty() => println!("(none)"),
+        Ok(diagnostics) if diagnostics.is_empty() => println!("(none — file type-checks clean)"),
         Ok(diagnostics) => {
-            for diagnostic in diagnostics.iter() {
+            println!("{} diagnostic(s):", diagnostics.len());
+            for diagnostic in diagnostics.iter().take(12) {
                 println!("- {}", diagnostic.primary_message());
+            }
+            if diagnostics.len() > 12 {
+                println!("  … {} more", diagnostics.len() - 12);
             }
         }
         Err(fatal) => println!("checker error: {}", fatal.primary_message()),

--- a/crates/smelt-py-ty-spike/src/main.rs
+++ b/crates/smelt-py-ty-spike/src/main.rs
@@ -1,0 +1,104 @@
+//! Spike: evaluate Astral's `ty` as a Python type source for Smelt.
+//!
+//! Smelt's Python frontend (`smelt-frontend-py`) currently uses ruff *only as a
+//! parser* and recovers types from source annotations + its own lowering. Real
+//! Python type inference (call-result types, narrowed unions, generics, stdlib
+//! stubs) is deferred. This binary checks whether `ty`'s semantic engine can be
+//! embedded as a library to supply that information.
+//!
+//! It demonstrates the two capabilities Smelt would need:
+//!   1. **Diagnostics** — run the checker over a file (`check_file`).
+//!   2. **Inferred types** — query the type of arbitrary expressions through the
+//!      `SemanticModel` (`HasType::inferred_type`), including types that come
+//!      from bundled typeshed stubs rather than source annotations.
+//!
+//! Run with: `cargo run -p smelt-py-ty-spike`
+
+use anyhow::{Context, Result, anyhow};
+use ruff_db::files::system_path_to_file;
+use ruff_db::parsed::parsed_module;
+use ruff_db::system::{OsSystem, SystemPathBuf};
+use ruff_python_ast::{Expr, Stmt};
+use ty_project::{ProjectDatabase, ProjectMetadata};
+use ty_python_semantic::{HasType, SemanticModel, check_file};
+
+/// Python that mixes annotated bindings with values whose types must be
+/// *inferred* (literals, arithmetic, a stdlib call returning a stub type, and a
+/// deliberate type error to exercise diagnostics).
+const SAMPLE_PY: &str = r#"
+import math
+
+count: int = 3
+label = "hello"
+ratio = count / 2
+root = math.sqrt(count)
+mixed = [1, 2, 3]
+
+bad: int = "not an int"
+"#;
+
+fn main() -> Result<()> {
+    // ty's `OsSystem` reads real files, so materialize a one-file project.
+    let dir = std::env::temp_dir().join("smelt-ty-spike");
+    std::fs::create_dir_all(&dir).context("create spike project dir")?;
+    let sample = dir.join("sample.py");
+    std::fs::write(&sample, SAMPLE_PY).context("write sample.py")?;
+
+    let root = to_system_path(dir)?;
+    let system = OsSystem::new(&root);
+    let metadata =
+        ProjectMetadata::discover(&root, &system).context("discover ty project metadata")?;
+    let db = ProjectDatabase::use_defaults(metadata, system);
+
+    let sample_path = to_system_path(sample)?;
+    let file = system_path_to_file(&db, &sample_path).context("resolve sample.py in ty db")?;
+
+    println!("== ty diagnostics ==");
+    match check_file(&db, file) {
+        Ok(diagnostics) if diagnostics.is_empty() => println!("(none)"),
+        Ok(diagnostics) => {
+            for diagnostic in diagnostics.iter() {
+                println!("- {}", diagnostic.primary_message());
+            }
+        }
+        Err(fatal) => println!("checker error: {}", fatal.primary_message()),
+    }
+
+    println!("\n== inferred types (top-level bindings) ==");
+    let model = SemanticModel::new(&db, file);
+    let parsed = parsed_module(&db, file).load(&db);
+    for statement in &parsed.syntax().body {
+        match statement {
+            Stmt::Assign(assign) => {
+                let names: Vec<String> = assign.targets.iter().filter_map(name_of).collect();
+                if let Some(ty) = assign.value.inferred_type(&model) {
+                    println!("{} : {}", names.join(", "), ty.display(&db));
+                }
+            }
+            Stmt::AnnAssign(annotated) => {
+                if let (Some(name), Some(value)) =
+                    (name_of(&annotated.target), annotated.value.as_deref())
+                    && let Some(ty) = value.inferred_type(&model)
+                {
+                    println!("{name} : {}", ty.display(&db));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+/// Read the source-language identifier of a simple `Name` assignment target.
+fn name_of(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Name(name) => Some(name.id.to_string()),
+        _ => None,
+    }
+}
+
+/// Convert a filesystem path into ty's UTF-8 `SystemPath`.
+fn to_system_path(path: std::path::PathBuf) -> Result<SystemPathBuf> {
+    SystemPathBuf::from_path_buf(path).map_err(|original| anyhow!("non-UTF-8 path: {original:?}"))
+}

--- a/crates/smelt-py-ty-spike/src/main.rs
+++ b/crates/smelt-py-ty-spike/src/main.rs
@@ -42,10 +42,11 @@ fn main() -> Result<()> {
     // With none, fall back to the built-in SAMPLE_PY one-file project.
     let mut args = std::env::args().skip(1);
     let (dir, sample) = match (args.next(), args.next()) {
-        (Some(root), Some(rel)) => {
+        // `<root> <file>`: check one file. `<root>` alone: scan the whole tree.
+        (Some(root), maybe_rel) => {
             let root = std::path::PathBuf::from(root);
-            let file = root.join(rel);
-            (root, file)
+            let target = maybe_rel.map_or_else(|| root.clone(), |rel| root.join(rel));
+            (root, target)
         }
         _ => {
             let dir = std::env::temp_dir().join("smelt-ty-spike");
@@ -61,6 +62,14 @@ fn main() -> Result<()> {
     let metadata =
         ProjectMetadata::discover(&root, &system).context("discover ty project metadata")?;
     let db = ProjectDatabase::use_defaults(metadata, system);
+
+    // Directory mode: scan every `.py` file under the sample's directory and
+    // aggregate diagnostics by ty rule id, so genuine type errors can be told
+    // apart from environment noise (e.g. `unresolved-import` when third-party
+    // dependencies are not installed).
+    if sample.is_dir() {
+        return scan_directory(&db, &sample);
+    }
 
     let sample_path = to_system_path(sample)?;
     let file = system_path_to_file(&db, &sample_path).context("resolve file in ty db")?;
@@ -104,6 +113,82 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Scan every `.py` file under `root`, aggregating ty diagnostics by rule id.
+fn scan_directory(db: &ProjectDatabase, root: &std::path::Path) -> Result<()> {
+    let mut py_files = Vec::new();
+    collect_py_files(root, &mut py_files);
+    py_files.sort();
+
+    let mut by_rule: std::collections::BTreeMap<String, (usize, String)> =
+        std::collections::BTreeMap::new();
+    let mut checked = 0usize;
+    let mut total = 0usize;
+
+    for path in &py_files {
+        let Ok(system_path) = to_system_path(path.clone()) else {
+            continue;
+        };
+        let Ok(file) = system_path_to_file(db, &system_path) else {
+            continue;
+        };
+        let Ok(diagnostics) = check_file(db, file) else {
+            continue;
+        };
+        checked += 1;
+        for diagnostic in diagnostics.iter() {
+            total += 1;
+            let rule = diagnostic.id().to_string();
+            let entry = by_rule
+                .entry(rule)
+                .or_insert_with(|| (0, diagnostic.primary_message().to_string()));
+            entry.0 += 1;
+        }
+    }
+
+    println!(
+        "== ty over {} ({checked} .py files checked) ==",
+        root.file_name().and_then(|n| n.to_str()).unwrap_or("?")
+    );
+    println!("{total} diagnostics, grouped by rule:\n");
+    // `unresolved-import` (and friends) are environment noise when third-party
+    // dependencies are not installed; everything else is a real finding.
+    let noise = ["unresolved-import", "unresolved-attribute", "unresolved-reference"];
+    let mut real = 0usize;
+    for (rule, (count, sample)) in &by_rule {
+        let tag = if noise.contains(&rule.as_str()) {
+            "env-noise"
+        } else {
+            real += count;
+            "REAL"
+        };
+        println!("[{tag:>9}] {count:>5}  {rule}");
+        println!("            e.g. {sample}");
+    }
+    println!("\nreal type findings (excluding unresolved-import noise): {real}");
+    Ok(())
+}
+
+/// Recursively gather `.py` files, skipping vendored / virtualenv directories.
+fn collect_py_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let skip = matches!(
+                path.file_name().and_then(|n| n.to_str()),
+                Some(".git" | ".venv" | "venv" | "node_modules" | "__pycache__" | "site-packages")
+            );
+            if !skip {
+                collect_py_files(&path, out);
+            }
+        } else if path.extension().and_then(|e| e.to_str()) == Some("py") {
+            out.push(path);
+        }
+    }
 }
 
 /// Read the source-language identifier of a simple `Name` assignment target.

--- a/specs/python-type-checking-with-ty.md
+++ b/specs/python-type-checking-with-ty.md
@@ -164,3 +164,55 @@ to map/suppress them in Smelt's diagnostics policy.
 
 So: not a dream — ty runs on the real probe repos today and yields usable types.
 What's missing is the integration + mapping layer, not the checker.
+
+### Against full applications — and a mypy reality check
+
+Libraries are the easy case (small, dependency-free, heavily typed). The spike
+also has a **directory mode** (`smelt-py-ty-spike <project-root>`) that scans
+every `.py` file and buckets diagnostics by ty rule id, splitting
+`unresolved-*` (environment noise) from real findings. Run against two real apps
+whose third-party dependencies are **not installed**:
+
+| App | files | total | `unresolved-*` (noise) | other ("real") |
+| --- | ---: | ---: | ---: | ---: |
+| `psf/black` (`src/black`) | 25 | 31 | 22 | **9** |
+| `httpie/cli` (pkg dir) | 78 | 519 | 365 | 154 |
+| `httpie/cli` (project root) | 133 | 952 | 266 | 686 |
+
+Two things jump out:
+
+1. **Most volume is dependency cascade, not bugs.** With deps absent, every
+   `import requests`/`click` becomes `Unknown`, and operations on those values
+   then trip `unsupported-operator` (309 on httpie), `not-subscriptable` (93),
+   `unresolved-attribute` (138)… The dependency-free `result` library produced
+   only 3 findings precisely *because* it has nothing to fail to resolve. **A ty
+   integration is useless without resolving the project's own modules + its
+   third-party deps** (installed env or vendored stubs) — same precondition mypy
+   has.
+
+2. **Even with the cascade removed, ty currently over-reports.** `black` is
+   heavily typed and CI-enforced. Running **mypy** on the same 25 files
+   (`mypy --ignore-missing-imports`) →
+
+   ```
+   Success: no issues found in 25 source files
+   ```
+
+   …yet ty flags **9** (`invalid-argument-type` ×3, `invalid-raise` ×2,
+   `invalid-return-type`, `invalid-yield`, `invalid-assignment`,
+   `invalid-ignore-comment`). On type-clean code those are **ty false
+   positives** — ty is younger and stricter/buggier than mypy on real apps.
+
+**Takeaways for Smelt:**
+
+- ty's **type inference** (the types of expressions) is the valuable, working
+  part and is what a Smelt frontend should consume.
+- ty's **diagnostics are not yet a trustworthy "real error" oracle** — they have
+  false positives and are meaningless without dependency resolution. Don't
+  surface them verbatim as Smelt errors yet.
+- mypy is more accurate today but is a Python **subprocess** needing a venv +
+  installed deps — not embeddable as a Rust library the way ty is. The trade is
+  accuracy/maturity (mypy) vs in-process Rust embedding + inference API (ty).
+- The earlier "only return-type mismatches, promising!" was an artifact of
+  testing one tiny dependency-free library; full apps need deps resolved before
+  any conclusion about ty's accuracy holds.

--- a/specs/python-type-checking-with-ty.md
+++ b/specs/python-type-checking-with-ty.md
@@ -128,3 +128,39 @@ This confirms the two capabilities Smelt needs, from a single embedded library:
 **Conclusion:** embedding `ty` as a Python type source is feasible and the API is
 reasonable. The remaining effort is not the embedding but the
 `ty` → Smelt-HIR **type-mapping layer** (see risks above).
+
+### Against a real probe library
+
+Smelt's daily `library-probes` CI already exercises **5 Python libraries**
+(`returns`, `result`, `more-itertools`, `funcy`, `toolz`) alongside 5 TS ones —
+see `.github/compat/libraries.json`. So this isn't hypothetical: there's a real
+Python corpus a ty-backed frontend would run against.
+
+Pointing the spike at `rustedpy/result`'s `src/result/result.py` (the pinned
+probe ref) — `smelt-py-ty-spike <project-root> src/result/result.py` — gives:
+
+```
+== ty diagnostics ==
+3 diagnostic(s):
+- Return type does not match returned value
+- Return type does not match returned value
+- Return type does not match returned value
+
+== inferred types (top-level bindings) ==
+T : TypeVar      E : TypeVar      U : TypeVar      F : TypeVar
+P : ParamSpec    R : TypeVar      TBE : TypeVar
+Result : <types.UnionType special-form 'Ok[T] | Err[E]'>
+OkErr  : tuple[<class 'Ok'>, <class 'Err'>]
+```
+
+ty resolves the library's full type-level vocabulary — `TypeVar`s, a `ParamSpec`,
+the `Result = Ok[T] | Err[E]` union alias, and the `OkErr` class tuple — exactly
+the generic machinery Smelt's annotation-only path struggles with. The 3
+diagnostics are `ty` being stricter than the source's own tooling (`result`
+passes mypy/pyright), so they are candidates for ty false-positives or genuine
+edge cases to triage — a reminder that **ty is still maturing**: adopting it
+means inheriting its current inaccuracies on advanced generics and deciding how
+to map/suppress them in Smelt's diagnostics policy.
+
+So: not a dream — ty runs on the real probe repos today and yields usable types.
+What's missing is the integration + mapping layer, not the checker.

--- a/specs/python-type-checking-with-ty.md
+++ b/specs/python-type-checking-with-ty.md
@@ -1,0 +1,130 @@
+# Spike: using Astral's `ty` as Smelt's Python type source
+
+**Status:** feasibility spike (branch `claude/python-ty-spike`, crate
+`crates/smelt-py-ty-spike`). Not wired into the real frontend yet.
+
+## Motivation
+
+Smelt's TypeScript frontend leans on `oxc` (a crates.io parser) plus its own
+type lowering/inference. The Python frontend (`smelt-frontend-py`) currently uses
+ruff *only as a parser* — `ruff_python_parser` produces the AST and Smelt
+recovers types from source annotations (`[strict] python = true` makes them
+mandatory). Real Python type inference is the hard part: call-result types,
+narrowed unions, generics, and — crucially — types that live in **typeshed
+stubs** rather than user source (`math.sqrt(...) -> float`, `dict.get`, etc.).
+Re-implementing that is a large, perpetually-incomplete effort.
+
+`ty` (Astral's Rust type checker, formerly red-knot) already does all of this and
+is in the **same git repo at the same revision** Smelt already pins for the ruff
+parser. This spike evaluates embedding it as a library to supply Python types,
+the way the TS side could (in principle) lean on a checker.
+
+## What the spike does
+
+`crates/smelt-py-ty-spike/src/main.rs`:
+
+1. Materializes a one-file Python project in a temp dir.
+2. Builds a `ty` project database (`ProjectDatabase::use_defaults`) over an
+   `OsSystem`, discovering metadata like the `ty` CLI does.
+3. Runs the checker on the file (`ty_python_semantic::check_file`) and prints
+   diagnostics — demonstrating **type checking**.
+4. Builds a `SemanticModel` and, for each top-level binding, queries
+   `HasType::inferred_type` on the value expression and prints
+   `Type::display(db)` — demonstrating **type extraction**, including types that
+   come from bundled typeshed (e.g. the result of `math.sqrt`).
+
+## Key API surface (at rev `6c88390f…`)
+
+| Need | Entry point |
+| --- | --- |
+| Database | `ty_project::ProjectDatabase::{use_defaults,fallible}(metadata, system)` |
+| Project metadata | `ty_project::ProjectMetadata::{discover,from_config_file}` |
+| Filesystem | `ruff_db::system::OsSystem` (real FS) or `MemoryFileSystem` (in-memory) |
+| File handle | `ruff_db::files::system_path_to_file(db, path)` |
+| Diagnostics | `ty_python_semantic::check_file(db, file) -> Result<Box<[Diagnostic]>, Diagnostic>` |
+| Parsed AST (db-tracked) | `ruff_db::parsed::parsed_module(db, file).load(db).syntax()` |
+| Type of an expression | `ty_python_semantic::HasType::inferred_type(&model) -> Option<Type>` |
+| Display a type | `Type::display(db)` |
+
+The AST nodes are the *same* `ruff_python_ast` types `smelt-frontend-py` already
+walks, so a real integration would hand ty the file, then annotate the existing
+lowering walk with `inferred_type` lookups keyed on the nodes it already visits.
+
+## Dependency / build implications
+
+- `ty_python_semantic` + `ty_project` pull in `salsa` (crates.io, `0.26.1`), the
+  ruff db/index/source crates, and **`ty_vendored`** (bundled typeshed stubs —
+  sizeable, but it's what makes stdlib inference work out of the box).
+- They do **not** pull the one git-only transitive dep (`lsp-types`, used by
+  `ty_server`/`ruff_server`), so the closure stays inside the single
+  `astral-sh/ruff` git source already pinned.
+- The spike crate is deliberately **excluded from `default-members`** so this
+  heavy tree does not affect the normal `cargo build`; only an explicit
+  `-p smelt-py-ty-spike` builds it.
+- Sandbox/local builds still need the egress workaround (vendor the ruff repo at
+  the pinned rev + a local-only `[patch."https://github.com/astral-sh/ruff"]`).
+  CI, which can fetch GitHub, builds the git deps directly — same as the existing
+  ruff parser deps.
+
+## If we adopt it — integration sketch
+
+1. Build one `ProjectDatabase` per Smelt compilation (rooted at the source
+   project), reusing the user's `pyproject.toml`/`ty` config if present.
+2. During `smelt-frontend-py` lowering, replace annotation-only type recovery
+   with `inferred_type` lookups on the nodes already being walked; keep
+   annotations as the fallback when ty returns no type.
+3. Map `ty_python_semantic::types::Type` → Smelt HIR `Type`. This is the real
+   work: unions/narrowing, generics, callable signatures, and the typeshed
+   nominal types need a translation layer (and a policy for types Smelt can't yet
+   represent — likely `Unknown` with a diagnostic, mirroring the TS side).
+4. Surface ty diagnostics as Smelt errors under `[strict] python = true`.
+
+## Open questions / risks
+
+- **Type-model mapping is the bulk of the effort**, not the embedding. ty's type
+  lattice is richer than Smelt's HIR; we need a defined lossy-but-sound mapping.
+- **Salsa lifecycle**: ty is incremental; Smelt is batch. Simplest is a fresh db
+  per run (what the spike does). Reuse/caching is a later optimization.
+- **Version pinning**: ty's internal API is unstable and moves with ruff. Bumping
+  the pinned rev may require touching the mapping layer.
+- **Build weight & typeshed**: `ty_vendored` adds compile time and binary size;
+  acceptable for a compiler, worth measuring.
+
+## How to run
+
+```bash
+cargo run -p smelt-py-ty-spike
+```
+
+(See the egress note above for local sandbox builds.)
+
+## Spike result
+
+Built and ran locally (vendored ruff at the pinned rev). Output:
+
+```
+== ty diagnostics ==
+- Object of type `Literal["not an int"]` is not assignable to `int`
+
+== inferred types (top-level bindings) ==
+count : Literal[3]
+label : Literal["hello"]
+ratio : float
+root  : int | float
+mixed : list[int]
+bad   : Literal["not an int"]
+```
+
+This confirms the two capabilities Smelt needs, from a single embedded library:
+
+- **Checking** — the deliberate `bad: int = "not an int"` is reported with a
+  precise message.
+- **Inference**, including things Smelt's annotation-only path cannot derive
+  today: `ratio` is `float` from integer division semantics, `mixed` is
+  `list[int]` from element inference, and `root` comes from the **typeshed stub**
+  for `math.sqrt` (no user annotation involved). Literal types (`Literal[3]`)
+  are also available where Smelt would widen to `int`.
+
+**Conclusion:** embedding `ty` as a Python type source is feasible and the API is
+reasonable. The remaining effort is not the embedding but the
+`ty` → Smelt-HIR **type-mapping layer** (see risks above).


### PR DESCRIPTION
## What

A **feasibility spike** for using [Astral's `ty`](https://github.com/astral-sh/ruff) (the Rust Python type checker, formerly red-knot) as a real type source for Smelt's Python frontend — instead of today's annotation-only approach. Python type *checking/inference* is the hard part (stdlib stubs, narrowing, generics, call-result types), and `ty` already does it.

Adds:
- `crates/smelt-py-ty-spike/` — a small binary that embeds `ty` and demonstrates both checking and type extraction. **Kept out of `default-members`** so the heavy `ty`/salsa/typeshed dependency tree does not affect the normal `cargo build`.
- `specs/python-type-checking-with-ty.md` — the writeup: API surface, dependency/build implications, an integration sketch, and risks.

This is exploratory ("can we?") — it does **not** wire `ty` into `smelt-frontend-py`.

## Result (built & run locally against the pinned ruff/ty rev)

```
== ty diagnostics ==
- Object of type `Literal["not an int"]` is not assignable to `int`

== inferred types (top-level bindings) ==
count : Literal[3]
label : Literal["hello"]
ratio : float          # from integer-division semantics
root  : int | float    # from the math.sqrt typeshed stub — no source annotation
mixed : list[int]      # element inference
bad   : Literal["not an int"]
```

So `ty` gives us, from one embedded library:
- **type checking** (the deliberate `bad: int = "not an int"` error), and
- **inference** including things Smelt's annotation-only path can't derive today (division → `float`, list element types, and stdlib types pulled from bundled typeshed).

## Why it's low-risk to land

- `ty` lives in the **same `astral-sh/ruff` repo at the same revision** Smelt already pins for the ruff parser.
- The closure (`ty_project` + `ty_python_semantic`) does **not** pull the one git-only transitive dep (`lsp-types`); `salsa` is a normal crates.io dep.
- Excluded from `default-members`, so day-to-day builds are unaffected.

## Conclusion / next step

Embedding is feasible and the API is reasonable. The real work for adoption is **not** the embedding but a `ty::Type` → Smelt-HIR **type-mapping layer** (unions/narrowing/generics/callables → Smelt's lattice, with a policy for types Smelt can't yet represent). Details + risks in the spec.

## Note on `Cargo.lock`

Intentionally **not** updated in this PR. The new deps resolve from the same pinned rev, but the sandbox's egress policy blocks the ruff git fetch, so the lock can't be regenerated here (the spike was validated against a vendored checkout). A networked `cargo build` will add the `ty` entries deterministically — please regenerate the lock on first build / in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGXacpbfaggsn6TiUBhrz3

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGXacpbfaggsn6TiUBhrz3)_