### PR TITLE
feat(wip): distinct `undefined` vs `null` (Type/Constant::Undefined)

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/coercion.rs
+++ b/crates/smelt-codegen-rust/src/emitter/coercion.rs
@@ -70,7 +70,13 @@ impl FunctionEmitter<'_> {
         if self.is_erased_class_type(target) {
             return self.erase(operand);
         }
-        if matches!(operand, Operand::Const(Constant::None)) {
+        // A nullish constant coerced to a concrete (non-erased) target collapses
+        // to that target's default, exactly like `null`. The distinct
+        // `undefined` tag only matters at the erased boundary handled above.
+        if matches!(
+            operand,
+            Operand::Const(Constant::None | Constant::Undefined)
+        ) {
             return self.default_value(target);
         }
         if let (Some(Type::Optional(source_inner)), Some(Type::Optional(target_inner))) = (
@@ -725,6 +731,13 @@ impl FunctionEmitter<'_> {
 
     /// Converts a statically typed operand into a tagged `SmeltUnknown` value.
     pub(super) fn erase(&self, operand: &Operand) -> Result<String, EmitError> {
+        // `undefined` shares the nullish (`Type::None`) static type with `null`,
+        // so the type-directed arms below cannot tell them apart. Detect the
+        // `undefined` constant up front and emit the distinct runtime tag so
+        // `null !== undefined` and `typeof undefined === "undefined"` hold.
+        if matches!(operand, Operand::Const(Constant::Undefined)) {
+            return Ok("SmeltUnknown::Undefined".to_owned());
+        }
         let text = self.operand_text(operand)?;
         match self.mir.types.get(self.operand_ty(operand)?) {
             Some(Type::Unknown | Type::TypeParam { .. }) => Ok(text),

--- a/crates/smelt-codegen-rust/src/emitter/core.rs
+++ b/crates/smelt-codegen-rust/src/emitter/core.rs
@@ -3548,7 +3548,9 @@ impl<'mir> FunctionEmitter<'mir> {
     pub(super) fn operand_ty(&self, operand: &Operand) -> Result<TypeId, EmitError> {
         match operand {
             Operand::Copy(place) | Operand::Move(place) => self.place_ty(place),
-            Operand::Const(Constant::None) => Ok(self.none_ty),
+            // `undefined` shares the nullish type with `null` so it flows
+            // through the same typed paths; only its emitted runtime tag differs.
+            Operand::Const(Constant::None | Constant::Undefined) => Ok(self.none_ty),
             Operand::Const(Constant::Bool(_)) => self.type_id(Type::Bool),
             Operand::Const(Constant::Int(_)) => self.type_id(Type::Int),
             Operand::Const(Constant::Float(_)) => self.type_id(Type::Float),

--- a/crates/smelt-codegen-rust/src/emitter/literals.rs
+++ b/crates/smelt-codegen-rust/src/emitter/literals.rs
@@ -32,7 +32,10 @@ pub(super) fn constant_text(constant: &Constant) -> String {
                 RustExpr::string_literal(value).into_string()
             )
         }
-        Constant::None => "()".to_owned(),
+        // `undefined` shares the nullish unit type with `null` in non-erased
+        // contexts; the distinct runtime tag is produced by the coercion seam's
+        // `erase`, which special-cases the `Constant::Undefined` operand.
+        Constant::None | Constant::Undefined => "()".to_owned(),
     }
 }
 

--- a/crates/smelt-codegen-rust/src/lib.rs
+++ b/crates/smelt-codegen-rust/src/lib.rs
@@ -642,6 +642,7 @@ fn emit_source_with_free_function_router(
         writer.blank_line();
         writer.block("pub enum SmeltUnknown", |unknown_writer| {
             unknown_writer.line("Null,");
+            unknown_writer.line("Undefined,");
             unknown_writer.line("Bool(bool),");
             unknown_writer.line("Number(f64),");
             unknown_writer.line("String(String),");

--- a/crates/smelt-hir/src/expr/literals.rs
+++ b/crates/smelt-hir/src/expr/literals.rs
@@ -15,8 +15,16 @@ pub enum Literal {
     String(String),
     /// A JavaScript symbol literal lowered as an opaque runtime value.
     Symbol(String),
-    /// The None/null literal.
+    /// The None/null literal (TypeScript `null`, Python `None`).
     None,
+    /// The JavaScript `undefined` value, kept distinct from `None`/`null`.
+    ///
+    /// Although `undefined` shares the nullish type with `None`, it is a
+    /// separate runtime value: `null !== undefined`, `typeof undefined` is
+    /// `"undefined"` (vs `"object"` for `null`), and `String(undefined)` is
+    /// `"undefined"` (vs `""` for `null`). Lowered from the `undefined`
+    /// identifier and the `void` operator result.
+    Undefined,
 }
 
 /// Runtime tags supported by TypeScript `unknown` narrowing.

--- a/crates/smelt-hir/src/format/literals.rs
+++ b/crates/smelt-hir/src/format/literals.rs
@@ -44,5 +44,6 @@ pub(super) fn literal_text(literal: &Literal) -> String {
         Literal::String(value) => format!("\"{value}\""),
         Literal::Symbol(value) => format!("symbol({value:?})"),
         Literal::None => "none".to_owned(),
+        Literal::Undefined => "undefined".to_owned(),
     }
 }

--- a/crates/smelt-mir/src/format.rs
+++ b/crates/smelt-mir/src/format.rs
@@ -1295,6 +1295,7 @@ fn constant_text(constant: &Constant) -> String {
         Constant::String(value) => format!("\"{value}\""),
         Constant::Symbol(value) => format!("symbol({value:?})"),
         Constant::None => "none".to_owned(),
+        Constant::Undefined => "undefined".to_owned(),
     }
 }
 

--- a/crates/smelt-mir/src/lower.rs
+++ b/crates/smelt-mir/src/lower.rs
@@ -3899,6 +3899,7 @@ fn lower_literal(literal: &HirLiteral) -> Constant {
         HirLiteral::String(value) => Constant::String(value.clone()),
         HirLiteral::Symbol(value) => Constant::Symbol(value.clone()),
         HirLiteral::None => Constant::None,
+        HirLiteral::Undefined => Constant::Undefined,
     }
 }
 

--- a/crates/smelt-mir/src/types.rs
+++ b/crates/smelt-mir/src/types.rs
@@ -439,8 +439,14 @@ pub enum Constant {
     String(String),
     /// JavaScript symbol constant.
     Symbol(String),
-    /// `None`.
+    /// `None` (TypeScript `null`, Python `None`).
     None,
+    /// JavaScript `undefined`, distinct from `None`/`null` at runtime.
+    ///
+    /// Shares the nullish type with [`Constant::None`] (see `operand_ty`), so it
+    /// flows through the same typed paths, but emits `SmeltUnknown::Undefined`
+    /// so `null !== undefined` and `typeof undefined === "undefined"` hold.
+    Undefined,
 }
 
 /// An MIR rvalue.


### PR DESCRIPTION
Preserved from the `b2-distinct-undefined` worktree (was uncommitted; WIP-committed during worktree cleanup).

Introduces a dedicated `undefined` value kept distinct from `null`/`None` across HIR (`Literal::Undefined`), MIR (`Constant::Undefined`), and the Rust emitter (`SmeltUnknown::Undefined`), so that `null !== undefined`, `typeof undefined === "undefined"`, and `String(undefined) === "undefined"` hold. Shares the nullish type with `None` so it flows through existing typed paths.

**Status: WIP** — single squashed WIP commit, not independently tested. See memory note "Distinct undefined needs Type::Undefined".

🤖 Generated with [Claude Code](https://claude.com/claude-code)