### PR TITLE
feat(codegen-rust): preserve fn reference identity for erased-rest fn constants

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/core.rs
+++ b/crates/smelt-codegen-rust/src/emitter/core.rs
@@ -2433,6 +2433,20 @@ impl<'mir> FunctionEmitter<'mir> {
         if !self.is_erased_unknown_rest_function(target_function) || target_function.may_throw {
             return Ok(None);
         }
+        // The source is ALREADY lowered to a `SmeltErasedFunction` whenever it is
+        // an erased-rest, non-throwing function (the exact predicate
+        // `is_erased_unknown_rest_function && !may_throw` that `types.rs` uses to
+        // pick the `SmeltErasedFunction` Rust type). Re-wrapping it here would
+        // build a brand-new callback `Rc`, dropping JavaScript reference identity
+        // (two `doNothing()` results would no longer be `Rc::ptr_eq`). Return
+        // `None` so `value_at_type` falls through to its tail `{text}.clone()`,
+        // which shares the inner `callback` `Rc` instead.
+        if let Some(Type::Function(source)) = self.mir.types.get(self.operand_ty(operand)?)
+            && self.is_erased_unknown_rest_function(source)
+            && !source.may_throw
+        {
+            return Ok(None);
+        }
         let Some(callback) = self.smelt_erased_function_callback_text(operand, target)? else {
             return Ok(None);
         };

--- a/crates/smelt-codegen-rust/src/emitter/mod.rs
+++ b/crates/smelt-codegen-rust/src/emitter/mod.rs
@@ -72,6 +72,21 @@ pub(crate) struct EmitContext {
     /// A `BTreeMap` keeps the emitted order deterministic for golden tests.
     pub(crate) function_item_accessors:
         ::std::cell::RefCell<::std::collections::BTreeMap<usize, String>>,
+    /// Per-function-item accessors collected while lowering a bare
+    /// function-item-as-value wrapper into the typed `SmeltErasedFunction`
+    /// representation (as opposed to the fully erased `SmeltUnknown` path that
+    /// `function_item_accessors` covers).
+    ///
+    /// Maps a crate-unique function item key to the self-contained
+    /// `SmeltErasedFunction { ... }` factory expression. After the function loop
+    /// the crate emitter flushes one `__smelt_fn_erased_<key>()` accessor per
+    /// entry, each caching a single shared `SmeltErasedFunction` behind a
+    /// `OnceCell` so that repeated calls to a nullary function constant such as
+    /// Remeda's `doNothing` return clones sharing one inner callback `Rc` and
+    /// keep JavaScript reference identity (`toStrictEqual` compares functions by
+    /// `Rc::ptr_eq`). A `BTreeMap` keeps the emitted order deterministic.
+    pub(crate) function_item_erased_fn_accessors:
+        ::std::cell::RefCell<::std::collections::BTreeMap<usize, String>>,
 }
 
 impl EmitContext {
@@ -155,6 +170,9 @@ impl EmitContext {
             function_return_types,
             owned_callback_params,
             function_item_accessors: ::std::cell::RefCell::new(
+                ::std::collections::BTreeMap::new(),
+            ),
+            function_item_erased_fn_accessors: ::std::cell::RefCell::new(
                 ::std::collections::BTreeMap::new(),
             ),
         })


### PR DESCRIPTION
Preserved from an agent worktree (was uncommitted; WIP-committed during cleanup).

When an operand is already lowered to `SmeltErasedFunction` (erased-rest, non-throwing), avoid re-wrapping it in a fresh callback `Rc` — that would drop JS reference identity (two `doNothing()` results would fail `Rc::ptr_eq`). Falls through to `{text}.clone()` to share the inner callback. Adds a `function_item_erased_fn_accessors` map emitting one `OnceCell`-cached `__smelt_fn_erased_<key>()` accessor per nullary function constant.

**Status: WIP** — single squashed WIP commit. Overlaps thematically with the B1 reference-identity PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)