### PR TITLE
fix(async): flatten erased SmeltUnknown::Promise on await (funnel async, 1786→1789)

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/call.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call.rs
@@ -21,9 +21,26 @@ impl FunctionEmitter<'_> {
         match op {
             smelt_hir::AsyncOp::All | smelt_hir::AsyncOp::AllSettled => {
                 if let [arg] = args
-                    && self.async_list_operand_item_type(arg)?.is_some()
+                    && let Some(item_ty) = self.async_list_operand_item_type(arg)?
                 {
                     let list = self.await_operand_text(arg)?;
+                    // When the futures resolve to erased values, each settled
+                    // value may itself be a `SmeltUnknown::Promise` (an `async`
+                    // function that returns a `Promise`). Collect every future
+                    // first — so funnel/batch schedulers observe all requests
+                    // before any is driven — then flatten each erased promise to
+                    // its resolved value.
+                    let item_is_erased = match self.mir.types.get(item_ty) {
+                        Some(Type::Future(output)) => {
+                            matches!(self.mir.types.get(*output), Some(Type::Unknown))
+                        }
+                        _ => false,
+                    };
+                    if item_is_erased {
+                        return Ok(format!(
+                            "Box::pin(async move {{ let mut __smelt_pending = Vec::new(); for __smelt_future in {list} {{ __smelt_pending.push(__smelt_future.await?); }} let mut __smelt_values = Vec::with_capacity(__smelt_pending.len()); for __smelt_value in __smelt_pending {{ __smelt_values.push(smelt_await_flatten(__smelt_value).await?); }} Ok::<_, Box<dyn std::error::Error>>(SmeltList::from(__smelt_values)) }})"
+                        ));
+                    }
                     return Ok(format!(
                         "Box::pin(async move {{ let mut __smelt_values = Vec::new(); for __smelt_future in {list} {{ __smelt_values.push(__smelt_future.await?); }} Ok::<_, Box<dyn std::error::Error>>(SmeltList::from(__smelt_values)) }})"
                     ));
@@ -32,13 +49,32 @@ impl FunctionEmitter<'_> {
                     .iter()
                     .map(|arg| self.await_operand_text(arg))
                     .collect::<Result<Vec<_>, _>>()?;
+                // Per-element: an awaited erased value may settle to a nested
+                // `SmeltUnknown::Promise` (an `async` fn returning a `Promise`),
+                // so flatten those. `tokio::join!` still polls every future first,
+                // so funnel/batch schedulers observe all requests before any
+                // flattened element drives the scheduler.
+                let erased: Vec<bool> = args
+                    .iter()
+                    .map(|arg| self.awaited_operand_is_erased(arg))
+                    .collect();
+                let flatten = |slot: String, is_erased: bool| {
+                    if is_erased {
+                        format!("smelt_await_flatten({slot}?).await?")
+                    } else {
+                        format!("{slot}?")
+                    }
+                };
                 let body = match rendered_args.as_slice() {
                     [] => "()".to_owned(),
-                    [single] => format!("({single}.await?,)"),
+                    [single] => {
+                        let value = flatten(format!("{single}.await"), erased[0]);
+                        format!("({value},)")
+                    }
                     _ => {
                         let joined = format!("tokio::join!({})", rendered_args.join(", "));
                         let values = (0..rendered_args.len())
-                            .map(|index| format!("__smelt_joined.{index}?"))
+                            .map(|index| flatten(format!("__smelt_joined.{index}"), erased[index]))
                             .collect::<Vec<_>>()
                             .join(", ");
                         format!("{{ let __smelt_joined = {joined}; ({values}) }}")
@@ -240,6 +276,22 @@ impl FunctionEmitter<'_> {
     }
 
     /// Return the future item type when an async combinator operand is a list of futures.
+    /// Whether awaiting this operand yields an erased value that may itself be a
+    /// `SmeltUnknown::Promise` (i.e. the future's `Output` is `Unknown`), so its
+    /// awaited result needs flattening through `smelt_await_flatten`.
+    fn awaited_operand_is_erased(&self, operand: &Operand) -> bool {
+        match self
+            .operand_ty(operand)
+            .ok()
+            .and_then(|ty| self.mir.types.get(ty))
+        {
+            Some(Type::Future(output)) => {
+                matches!(self.mir.types.get(*output), Some(Type::Unknown))
+            }
+            _ => false,
+        }
+    }
+
     fn async_list_operand_item_type(&self, operand: &Operand) -> Result<Option<TypeId>, EmitError> {
         let operand_ty = self.operand_ty(operand)?;
         let Some(Type::List(item_ty)) = self.mir.types.get(operand_ty) else {

--- a/crates/smelt-codegen-rust/src/lib.rs
+++ b/crates/smelt-codegen-rust/src/lib.rs
@@ -776,6 +776,22 @@ fn emit_source_with_free_function_router(
         writer.line("}");
         writer.line("impl ::std::fmt::Debug for SmeltPromise { fn fmt(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result { formatter.debug_struct(\"SmeltPromise\").field(\"id\", &self.id).finish() } }");
         writer.blank_line();
+        // JavaScript `await` flattens: awaiting a value that is itself a promise
+        // resolves through the whole chain. An `async` function that returns a
+        // `Promise` erases that inner promise to `SmeltUnknown::Promise`, so a
+        // consumer that awaits the function's result must keep awaiting while the
+        // settled value is still a promise. This helper drives the shared cell of
+        // each erased promise (which in turn drives the cooperative scheduler),
+        // and is a no-op pass-through for any non-promise value.
+        writer.line("#[allow(dead_code)]");
+        writer.line("async fn smelt_await_flatten(value: SmeltUnknown) -> Result<SmeltUnknown, Box<dyn std::error::Error>> {");
+        writer.line("    let mut current = value;");
+        writer.line("    while let SmeltUnknown::Promise(promise) = current {");
+        writer.line("        current = promise.smelt_await().await?;");
+        writer.line("    }");
+        writer.line("    Ok(current)");
+        writer.line("}");
+        writer.blank_line();
         writer.line("/// Return an erased JavaScript `Array.prototype.sort` method bound to an erased array.");
         writer.line("fn smelt_array_sort_method(values: SmeltArray) -> SmeltUnknown { SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { let mut sorted = values.clone().into_vec(); if let Some(SmeltUnknown::Function(compare)) = args.get(0).cloned() { sorted.sort_by(|left, right| { let result = compare(vec![left.clone(), right.clone()]).unwrap_or(SmeltUnknown::Number(0.0)); let ordering = match result { SmeltUnknown::Number(value) => value, SmeltUnknown::String(value) => value.parse::<f64>().unwrap_or(0.0), SmeltUnknown::Bool(value) => if value { 1.0 } else { 0.0 }, _ => 0.0 }; if ordering < 0.0 { ::std::cmp::Ordering::Less } else if ordering > 0.0 { ::std::cmp::Ordering::Greater } else { ::std::cmp::Ordering::Equal } }); } else { sorted.sort_by(|left, right| left.to_string().cmp(&right.to_string())); } Ok(SmeltUnknown::Array(sorted.into())) })) }");
         writer.blank_line();

--- a/crates/smelt-codegen-rust/src/tests/part_6_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_6_tests.rs
@@ -183,6 +183,33 @@ function makeValue(): Promise<number> {
 }
 
 #[test]
+fn promise_all_flattens_erased_promise_results() {
+    // `Promise.all` over async functions that themselves return a `Promise`
+    // settles each element to an erased `SmeltUnknown::Promise`. Awaiting must
+    // flatten those to their resolved values (driving the scheduler) instead of
+    // collecting the unresolved promise objects.
+    let source = source_for(
+        r#"
+function defer(value: unknown): Promise<unknown> {
+  return new Promise<unknown>((resolve) => {
+    setTimeout(() => resolve(value), 0);
+  });
+}
+
+async function makeOne(value: unknown): Promise<unknown> {
+  return defer(value);
+}
+
+async function run(): Promise<unknown[]> {
+  return await Promise.all([makeOne(1), makeOne(2)]);
+}
+"#,
+    );
+
+    assert!(source.contains("smelt_await_flatten"), "{source}");
+}
+
+#[test]
 fn promise_bare_delay_settimeout_lowers_to_sleep() {
     // The pure-delay shape `new Promise(resolve => setTimeout(resolve, ms))`
     // resolves `undefined` after the delay and carries no value, so collapsing

--- a/examples/typescript/end-to-end/27_optional_chains/expected.rs
+++ b/examples/typescript/end-to-end/27_optional_chains/expected.rs
@@ -327,6 +327,15 @@ impl SmeltPromise {
 }
 impl ::std::fmt::Debug for SmeltPromise { fn fmt(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result { formatter.debug_struct("SmeltPromise").field("id", &self.id).finish() } }
 
+#[allow(dead_code)]
+async fn smelt_await_flatten(value: SmeltUnknown) -> Result<SmeltUnknown, Box<dyn std::error::Error>> {
+    let mut current = value;
+    while let SmeltUnknown::Promise(promise) = current {
+        current = promise.smelt_await().await?;
+    }
+    Ok(current)
+}
+
 /// Return an erased JavaScript `Array.prototype.sort` method bound to an erased array.
 fn smelt_array_sort_method(values: SmeltArray) -> SmeltUnknown { SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { let mut sorted = values.clone().into_vec(); if let Some(SmeltUnknown::Function(compare)) = args.get(0).cloned() { sorted.sort_by(|left, right| { let result = compare(vec![left.clone(), right.clone()]).unwrap_or(SmeltUnknown::Number(0.0)); let ordering = match result { SmeltUnknown::Number(value) => value, SmeltUnknown::String(value) => value.parse::<f64>().unwrap_or(0.0), SmeltUnknown::Bool(value) => if value { 1.0 } else { 0.0 }, _ => 0.0 }; if ordering < 0.0 { ::std::cmp::Ordering::Less } else if ordering > 0.0 { ::std::cmp::Ordering::Greater } else { ::std::cmp::Ordering::Equal } }); } else { sorted.sort_by(|left, right| left.to_string().cmp(&right.to_string())); } Ok(SmeltUnknown::Array(sorted.into())) })) }
 


### PR DESCRIPTION
## Summary

Makes the full remeda generated-test corpus pass: **1786 → 1789, 0 failures**. Fixes the 3 long-standing `funnel_reference_batch_test` failures (`results_as_array`, `results_as_object`, `error_handling`).

## Root cause (corrects the prior plan)

The remaining funnel failures were **not** a scheduler-delivery bug. Instrumenting the generated crate showed the burst timers arm but never fire, and `smelt_await` (the `SmeltPromise` poll-loop) is called **zero** times.

An `async` function that returns a `Promise` — funnel's `call: async (...) => new Promise(...)` — erases the inner promise to `SmeltUnknown::Promise(SmeltPromise::from_future(...))` (the representation already exists in the tree). But `Promise.all` awaited each *outer* `api.call` future and collected the **unresolved** `SmeltUnknown::Promise` objects as-is. The inner polling futures were never awaited → `sleep_ms` never ran → timers never fired → `Promise.all` yielded promise objects, so `.toBe(5)` failed.

## Fix

- New prelude helper `smelt_await_flatten`: awaits through a chain of erased `SmeltUnknown::Promise` values to the settled result; a no-op pass-through for non-promise values. Wires the already-emitted `smelt_await` into the await path.
- Route `Promise.all` through it, gated on the future's `Output` being `Unknown` (typed awaits untouched):
  - **list form**: collect every future first — so funnel/batch schedulers observe all requests *before* any is driven — then flatten each erased element. This preserves batch semantics.
  - **fixed-arity (`tokio::join!`) and single forms**: flatten each erased element after the join polls them all.

## Validation

- remeda generated corpus: **1789 passed / 0 failed** (was 1786 / 3).
- smelt `cargo test`: **1230 / 0**. `cargo check` clean; no new clippy warnings.
- Only golden change: the new prelude helper in `27_optional_chains` e2e expected output.
- Regression test added (`promise_all_flattens_erased_promise_results`).

## Follow-ups (not in scope here)

- A direct `await` of an `async` fn that returns a typed (non-erased) `Promise<T>` still needs return/await flattening (compile-level; surfaced as E0382/E0308 in standalone repros, not exercised by remeda).
- Sub-problem 1 (the `setTimeout` Promise-executor value drop) already landed on `main` separately.

See `specs/remeda-funnel-async-completion-plan.md` for the full diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)