### PR TITLE
refactor(frontend-py): split call_expression_with_hint and class_def into phase helpers

### DIFF
--- a/crates/smelt-frontend-py/src/lowering/call.rs
+++ b/crates/smelt-frontend-py/src/lowering/call.rs
@@ -8,127 +8,16 @@ impl ModuleBuilder<'_> {
     ) -> Result<smelt_hir::ExprId, SmeltError> {
         let span = self.span(call.range);
 
-        if let Some(expr) = self.file_io_call_expression(call, body)? {
+        if let Some(expr) = self.stdlib_module_call_expression(call, body)? {
             return Ok(expr);
         }
-        if let Some(expr) = self.datetime_call_expression(call, body)? {
+        if let Some(expr) = self.string_call_expression(call, body)? {
             return Ok(expr);
         }
-        if let Some(expr) = self.urlparse_call_expression(call, body)? {
+        if let Some(expr) = self.collection_call_expression(call, body)? {
             return Ok(expr);
         }
-        if let Some(expr) = self.int_new_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.class_method_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.module_member_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.asyncio_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.string_case_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.string_trim_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.string_affix_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.string_search_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.string_replace_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.string_remove_affix_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.string_predicate_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.re_expanded_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.string_split_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.string_join_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.dict_projection_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.list_append_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.list_extend_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.list_insert_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.list_reverse_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.list_pop_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.collection_clear_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.set_method_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.list_copy_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.list_count_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.list_index_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.list_remove_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.list_sort_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.dict_pop_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.requests_get_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.dict_get_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.dict_setdefault_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.dict_update_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.dict_copy_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.math_module_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.random_module_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.json_dumps_call_expression(call, body)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.json_loads_call_expression(call, body, type_hint)? {
-            return Ok(expr);
-        }
-        if let Some(expr) = self.re_module_call_expression(call, body)? {
+        if let Some(expr) = self.numeric_module_call_expression(call, body, type_hint)? {
             return Ok(expr);
         }
         if let Some(error) = self.unsupported_deferred_stdlib_call(call) {
@@ -137,59 +26,245 @@ impl ModuleBuilder<'_> {
         if let Some(expr) = self.protocol_call_expression(call, body)? {
             return Ok(expr);
         }
+        if let Some(expr) = self.builtin_name_call_expression(call, body, type_hint, span)? {
+            return Ok(expr);
+        }
+        if let Some(expr) = self.named_item_call_expression(call, body, span)? {
+            return Ok(expr);
+        }
+        if let Some(expr) = self.callable_expression_call(call, body)? {
+            return Ok(expr);
+        }
+
+        Err(SmeltError::unsupported(
+            span,
+            "only calls to top-level functions, class constructors, and print() are supported",
+        ))
+    }
+
+    /// Try stdlib module / interop call handlers (file IO, datetime, urlparse,
+    /// `int()` construction, class-method and module-member dispatch, asyncio).
+    fn stdlib_module_call_expression(
+        &mut self,
+        call: &ruff_python_ast::ExprCall,
+        body: &mut Body,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        if let Some(expr) = self.file_io_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.datetime_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.urlparse_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.int_new_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.class_method_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.module_member_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.asyncio_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        Ok(None)
+    }
+
+    /// Try string-method and regex-expansion call handlers in source order.
+    fn string_call_expression(
+        &mut self,
+        call: &ruff_python_ast::ExprCall,
+        body: &mut Body,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        if let Some(expr) = self.string_case_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.string_trim_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.string_affix_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.string_search_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.string_replace_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.string_remove_affix_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.string_predicate_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.re_expanded_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.string_split_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.string_join_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        Ok(None)
+    }
+
+    /// Try dict/list/set collection-method call handlers in source order.
+    fn collection_call_expression(
+        &mut self,
+        call: &ruff_python_ast::ExprCall,
+        body: &mut Body,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        if let Some(expr) = self.dict_projection_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.list_append_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.list_extend_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.list_insert_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.list_reverse_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.list_pop_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.collection_clear_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.set_method_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.list_copy_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.list_count_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.list_index_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.list_remove_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.list_sort_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.dict_pop_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.requests_get_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.dict_get_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.dict_setdefault_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.dict_update_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.dict_copy_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        Ok(None)
+    }
+
+    /// Try math/random/json/re module-function call handlers in source order.
+    fn numeric_module_call_expression(
+        &mut self,
+        call: &ruff_python_ast::ExprCall,
+        body: &mut Body,
+        type_hint: Option<TypeId>,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        if let Some(expr) = self.math_module_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.random_module_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.json_dumps_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.json_loads_call_expression(call, body, type_hint)? {
+            return Ok(Some(expr));
+        }
+        if let Some(expr) = self.re_module_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
+        Ok(None)
+    }
+
+    /// Lower calls whose callee is a builtin name (`print`, `len`, container and
+    /// primitive constructors, and the numeric/iterator builtins).
+    fn builtin_name_call_expression(
+        &mut self,
+        call: &ruff_python_ast::ExprCall,
+        body: &mut Body,
+        type_hint: Option<TypeId>,
+        span: Span,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
         // `print(...)` → CONSOLE_LOG_SYMBOL item (same as TS's `console.log`).
         if let Expr::Name(name) = call.func.as_ref() {
             if matches!(name.id.as_str(), "list" | "set" | "dict" | "tuple")
                 && let Some(expr) =
                     self.container_constructor_call_expression(call, body, type_hint)?
             {
-                return Ok(expr);
+                return Ok(Some(expr));
             }
             if matches!(name.id.as_str(), "bool" | "int" | "float" | "str")
                 && let Some(expr) = self.primitive_cast_call_expression(call, body)?
             {
-                return Ok(expr);
+                return Ok(Some(expr));
             }
             if name.id.as_str() == "abs" {
-                return self.numeric_abs_call_expression(call, body);
+                return self.numeric_abs_call_expression(call, body).map(Some);
             }
             if matches!(name.id.as_str(), "max" | "min") {
-                return self.numeric_extrema_call_expression(call, body);
+                return self.numeric_extrema_call_expression(call, body).map(Some);
             }
             if name.id.as_str() == "sum"
                 && let Some(expr) = self.numeric_sum_call_expression(call, body)?
             {
-                return Ok(expr);
+                return Ok(Some(expr));
             }
             if matches!(name.id.as_str(), "all" | "any")
                 && let Some(expr) = self.bool_fold_call_expression(call, body)?
             {
-                return Ok(expr);
+                return Ok(Some(expr));
             }
             if name.id.as_str() == "sorted"
                 && let Some(expr) = self.sorted_call_expression(call, body)?
             {
-                return Ok(expr);
+                return Ok(Some(expr));
             }
             if name.id.as_str() == "reversed"
                 && let Some(expr) = self.reversed_call_expression(call, body)?
             {
-                return Ok(expr);
+                return Ok(Some(expr));
             }
             if name.id.as_str() == "enumerate"
                 && let Some(expr) = self.enumerate_call_expression(call, body)?
             {
-                return Ok(expr);
+                return Ok(Some(expr));
             }
             if name.id.as_str() == "zip"
                 && let Some(expr) = self.zip_call_expression(call, body)?
             {
-                return Ok(expr);
+                return Ok(Some(expr));
             }
             if name.id.as_str() == "range"
                 && let Some(expr) = self.range_call_expression(call, body)?
             {
-                return Ok(expr);
+                return Ok(Some(expr));
             }
             if name.id.as_str() == "print" {
                 let print_item = self.ensure_print_item(span);
@@ -205,11 +280,11 @@ impl ModuleBuilder<'_> {
                     .iter()
                     .map(|a| self.expression(a, body))
                     .collect::<Result<_, _>>()?;
-                return Ok(body.push_expr(HirExpr {
+                return Ok(Some(body.push_expr(HirExpr {
                     kind: ExprKind::Call { callee, args },
                     ty: none_ty,
                     span,
-                }));
+                })));
             }
             if name.id.as_str() == "len" {
                 if call.arguments.args.len() != 1 {
@@ -233,19 +308,28 @@ impl ModuleBuilder<'_> {
                     ));
                 }
                 let ty = self.intern_type(Type::Int);
-                return Ok(body.push_expr(HirExpr {
+                return Ok(Some(body.push_expr(HirExpr {
                     kind: ExprKind::Len { operand },
                     ty,
                     span,
-                }));
+                })));
             }
         }
+        Ok(None)
+    }
 
+    /// Lower a named function call or class constructor call resolved by item table.
+    fn named_item_call_expression(
+        &mut self,
+        call: &ruff_python_ast::ExprCall,
+        body: &mut Body,
+        span: Span,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
         // Named function call OR class constructor call.
         if let Expr::Name(name) = call.func.as_ref() {
             let name_str = name.id.as_str();
             if let Some(expr) = self.local_callable_call(call, name_str, body)? {
-                return Ok(expr);
+                return Ok(Some(expr));
             }
             if let Some(&item_id) = self.items.get(name_str) {
                 let item = self.item_ref(item_id);
@@ -269,14 +353,14 @@ impl ModuleBuilder<'_> {
                             .iter()
                             .map(|a| self.expression(a, body))
                             .collect::<Result<_, _>>()?;
-                        return Ok(body.push_expr(HirExpr {
+                        return Ok(Some(body.push_expr(HirExpr {
                             kind: ExprKind::New {
                                 class: class_sym,
                                 args,
                             },
                             ty: class_ty,
                             span,
-                        }));
+                        })));
                     }
                     Item::Function(f) => {
                         let function = f.clone();
@@ -304,25 +388,17 @@ impl ModuleBuilder<'_> {
                                 label: "function",
                             },
                         )?;
-                        return Ok(body.push_expr(HirExpr {
+                        return Ok(Some(body.push_expr(HirExpr {
                             kind: ExprKind::Call { callee, args },
                             ty: return_ty,
                             span,
-                        }));
+                        })));
                     }
                     Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) => {}
                 }
             }
         }
-
-        if let Some(expr) = self.callable_expression_call(call, body)? {
-            return Ok(expr);
-        }
-
-        Err(SmeltError::unsupported(
-            span,
-            "only calls to top-level functions, class constructors, and print() are supported",
-        ))
+        Ok(None)
     }
 
     /// Lower a call whose callee is a local closure or function-typed local.

--- a/crates/smelt-frontend-py/src/lowering/class.rs
+++ b/crates/smelt-frontend-py/src/lowering/class.rs
@@ -1,3 +1,20 @@
+/// Accumulated results of walking a class body: fields, constructor/method
+/// item ids, and enum/abstract-method metadata used to assemble the class item.
+struct ClassBodyLowering {
+    /// Instance fields declared via annotated assignments.
+    fields: Vec<Field>,
+    /// Item id of the user-defined `__init__`, if any.
+    constructor_id: Option<ItemId>,
+    /// Item ids of non-constructor methods in declaration order.
+    method_ids: Vec<ItemId>,
+    /// Whether the class derives from `IntEnum`.
+    is_int_enum: bool,
+    /// Collected `IntEnum` member name → integer value pairs.
+    enum_members: HashMap<String, i64>,
+    /// Abstract-method signatures collected from `@abstractmethod` members.
+    abstract_methods: Vec<MethodSig>,
+}
+
 impl ModuleBuilder<'_> {
     /// Lower a Python class definition into the current HIR module.
     fn class_def(
@@ -16,6 +33,55 @@ impl ModuleBuilder<'_> {
         let materialized = self.materialized_class_definition(class_name_str).cloned();
 
         // --- Decorator check: only @dataclass is allowed ---
+        let mut kind = self.class_kind_from_decorators(class, &materialized, span, class_name_str)?;
+
+        // --- Metaclass and base classes ---
+        let (is_abstract_class, type_params, base) =
+            self.resolve_class_bases(class, &materialized, span, class_name_str)?;
+        if is_abstract_class {
+            kind = ClassKind::Abstract;
+        }
+
+        // --- Fields and methods ---
+        let target = MaterializedClassTarget {
+            name: class_name_str,
+            symbol: class_sym,
+            ty: class_ty,
+            span,
+        };
+        let (mut lowered, class_item_id) = self.lower_class_body(
+            class,
+            &materialized,
+            &target,
+            base,
+            &type_params,
+            &mut kind,
+            hir_module,
+        )?;
+
+        self.finalize_class_definition(
+            class,
+            &materialized,
+            &target,
+            module,
+            base,
+            type_params,
+            kind,
+            &mut lowered,
+            class_item_id,
+            hir_module,
+        )
+    }
+
+    /// Determine the class kind from its decorators, validating that only
+    /// `@dataclass` (or a materialized dataclass) is present.
+    fn class_kind_from_decorators(
+        &mut self,
+        class: &StmtClassDef,
+        materialized: &Option<smelt_specialize::ClassDefinition>,
+        span: Span,
+        class_name_str: &str,
+    ) -> Result<ClassKind, SmeltError> {
         let mut kind = if materialized.as_ref().is_some_and(|manifest_class| {
             manifest_class
                 .metadata
@@ -56,7 +122,18 @@ impl ModuleBuilder<'_> {
                 }
             }
         }
+        Ok(kind)
+    }
 
+    /// Resolve the metaclass abstractness flag, generic type parameters, and the
+    /// single supported base class of a class definition.
+    fn resolve_class_bases(
+        &mut self,
+        class: &StmtClassDef,
+        materialized: &Option<smelt_specialize::ClassDefinition>,
+        span: Span,
+        class_name_str: &str,
+    ) -> Result<(bool, Vec<TypeParamDef>, Option<Symbol>), SmeltError> {
         // --- Metaclass check ---
         let mut is_abstract_class = false;
         if let Some(args) = class.arguments.as_deref() {
@@ -131,11 +208,28 @@ impl ModuleBuilder<'_> {
         } else {
             None
         };
-        if is_abstract_class {
-            kind = ClassKind::Abstract;
-        }
+        Ok((is_abstract_class, type_params, base))
+    }
 
-        // --- Fields and methods ---
+    /// Register the class item stub then walk the class body, collecting fields,
+    /// constructor, methods, enum members, and abstract-method signatures.
+    ///
+    /// `kind` may be promoted to [`ClassKind::Abstract`] when an
+    /// `@abstractmethod` is encountered.
+    fn lower_class_body(
+        &mut self,
+        class: &StmtClassDef,
+        materialized: &Option<smelt_specialize::ClassDefinition>,
+        target: &MaterializedClassTarget<'_>,
+        base: Option<Symbol>,
+        type_params: &[TypeParamDef],
+        kind: &mut ClassKind,
+        hir_module: &mut Module,
+    ) -> Result<(ClassBodyLowering, ItemId), SmeltError> {
+        let class_name_str = target.name;
+        let class_sym = target.symbol;
+        let class_ty = target.ty;
+        let span = target.span;
         let mut fields: Vec<Field> = Vec::new();
         let mut constructor_id: Option<ItemId> = None;
         let mut method_ids: Vec<ItemId> = Vec::new();
@@ -146,7 +240,7 @@ impl ModuleBuilder<'_> {
             name: class_sym,
             span,
             kind: kind.clone(),
-            type_params: type_params.clone(),
+            type_params: type_params.to_vec(),
             base,
             base_args: Vec::new(),
             fields: Vec::new(),
@@ -197,7 +291,7 @@ impl ModuleBuilder<'_> {
                         continue;
                     }
                     if Self::is_abstractmethod(func) {
-                        kind = ClassKind::Abstract;
+                        *kind = ClassKind::Abstract;
                         abstract_methods.push(self.abstract_method_sig(func)?);
                         continue;
                     }
@@ -266,8 +360,48 @@ impl ModuleBuilder<'_> {
             }
         }
 
-        let descriptors = if let Some(manifest_class) = &materialized {
-            self.merge_materialized_class_fields(class_name_str, manifest_class, &mut fields, span);
+        Ok((
+            ClassBodyLowering {
+                fields,
+                constructor_id,
+                method_ids,
+                is_int_enum,
+                enum_members,
+                abstract_methods,
+            },
+            class_item_id,
+        ))
+    }
+
+    /// Merge materialized descriptors/methods, synthesize the constructor, record
+    /// enum members, and write the finished class item back into its slot.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "final class assembly threads all accumulated class-definition phase outputs"
+    )]
+    fn finalize_class_definition(
+        &mut self,
+        class: &StmtClassDef,
+        materialized: &Option<smelt_specialize::ClassDefinition>,
+        target: &MaterializedClassTarget<'_>,
+        module: &ModModule,
+        base: Option<Symbol>,
+        type_params: Vec<TypeParamDef>,
+        kind: ClassKind,
+        lowered: &mut ClassBodyLowering,
+        class_item_id: ItemId,
+        hir_module: &mut Module,
+    ) -> Result<(), SmeltError> {
+        let class_name_str = target.name;
+        let class_sym = target.symbol;
+        let class_ty = target.ty;
+        let span = target.span;
+        let fields = &mut lowered.fields;
+        let method_ids = &mut lowered.method_ids;
+        let mut constructor_id = lowered.constructor_id;
+
+        let descriptors = if let Some(manifest_class) = materialized {
+            self.merge_materialized_class_fields(class_name_str, manifest_class, fields, span);
             self.lower_materialized_descriptors(manifest_class, span)?
         } else {
             Vec::new()
@@ -288,7 +422,7 @@ impl ModuleBuilder<'_> {
                         && Self::constructor_assigns_instance_field(class, field.name, self)
                 })
         });
-        if let Some(manifest_class) = &materialized {
+        if let Some(manifest_class) = materialized {
             let generated = self.lower_materialized_class_methods(
                 &MaterializedClassTarget {
                     name: class_name_str,
@@ -313,7 +447,7 @@ impl ModuleBuilder<'_> {
                     ),
                 ));
             }
-            let init_id = self.synthesize_dataclass_init(class_sym, class_ty, &fields, span)?;
+            let init_id = self.synthesize_dataclass_init(class_sym, class_ty, fields, span)?;
             constructor_id = Some(init_id);
             hir_module.items.push(init_id);
         } else if constructor_id.is_none() {
@@ -321,12 +455,12 @@ impl ModuleBuilder<'_> {
             constructor_id = Some(init_id);
             hir_module.items.push(init_id);
         }
-        if is_int_enum {
+        if lowered.is_int_enum {
             self.ctx
                 .enum_members
-                .insert(class_name_str.to_owned(), enum_members.clone());
+                .insert(class_name_str.to_owned(), lowered.enum_members.clone());
             self.enum_members
-                .insert(class_name_str.to_owned(), enum_members);
+                .insert(class_name_str.to_owned(), std::mem::take(&mut lowered.enum_members));
         }
 
         let class_item = Item::Class(Class {
@@ -336,12 +470,12 @@ impl ModuleBuilder<'_> {
             type_params,
             base,
             base_args: Vec::new(),
-            fields,
+            fields: std::mem::take(fields),
             static_fields: Vec::new(),
             descriptors,
             constructor: constructor_id,
-            methods: method_ids,
-            abstract_methods,
+            methods: std::mem::take(method_ids),
+            abstract_methods: std::mem::take(&mut lowered.abstract_methods),
             implements: vec![],
         });
         let class_index = usize::try_from(class_item_id.0).map_err(|err| {


### PR DESCRIPTION
Follow-up to #39, addressing the Python-frontend organizational findings from the code-quality audit.

## Changes
- **`call_expression_with_hint`** (`lowering/call.rs`, 324 lines / ~44 sequential handler attempts) is now a 33-line orchestrator over six documented domain helpers — stdlib-module calls, string calls, collection calls, numeric-module calls, builtin-name calls, named-item calls — each returning `Result<Option<ExprId>>`. Exact try-order and the final fallthrough error are preserved.
- **`class_def`** (`lowering/class.rs`, 358 lines) is now a 48-line orchestrator over four phase helpers: `class_kind_from_decorators`, `resolve_class_bases`, `lower_class_body`, `finalize_class_definition`, with a documented `ClassBodyLowering` struct bundling body-collection outputs instead of a wide tuple.

Purely mechanical extraction — no logic, ordering, or error-message changes.

Two other audit targets (`sort_keyword_arguments`, `block_from_stmts`) turned out to be misreported: they are 46 and 14 lines respectively, so they were left alone.

## Verification
The sandbox cannot fetch the pinned `astral-sh/ruff` git dependency, so this crate cannot compile locally; each edited file was syntax-checked standalone with `rustc --edition=2024`. **CI is the compile/test gate for this PR** — if anything fails I'll push fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MArKS25FxxY4UM7cByPopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MArKS25FxxY4UM7cByPopw)_