### PR TITLE
fix(codegen): MIR-typed async closure returns; pin capture-borrow soundness invariant

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/core.rs
+++ b/crates/smelt-codegen-rust/src/emitter/core.rs
@@ -1277,6 +1277,26 @@ impl<'mir> FunctionEmitter<'mir> {
     }
 
     /// Renders a read of a local through shared closure storage.
+    ///
+    /// Shared captures live in `Rc<RefCell<T>>`, so a read expands to
+    /// `(*smelt_capture_x.borrow())`. The returned `Ref` guard is a temporary
+    /// that Rust keeps alive to the end of the FULL enclosing statement, so if
+    /// this text were interpolated into a statement that also invokes a closure
+    /// re-borrowing the same cell, the nested `borrow_mut` would panic with
+    /// "already borrowed" — a RefCell double-borrow crash single-threaded JS
+    /// never produces.
+    ///
+    /// That never happens because MIR is three-address form: every
+    /// `Call`/`ClosureCall` is lowered to its own SSA temp binding before any
+    /// statement that consumes the result, and the copy-propagation /
+    /// move-on-last-use passes only rewrite local aliases (they never fuse a
+    /// call rvalue into a consuming statement). So the operands of the
+    /// statement this borrow text lands in are always already-materialized
+    /// locals or literals — never a live call — and the borrow guard drops at
+    /// the statement boundary before any sibling closure can re-enter. Callers
+    /// must preserve this: do not build a single emitted statement that both
+    /// borrows a shared capture and evaluates a call. See the regression test
+    /// `shared_capture_borrow_never_spans_a_sibling_closure_call`.
     pub(super) fn local_value_text(&self, local: LocalId) -> Result<String, EmitError> {
         let name = self.local_name(local)?;
         if name.starts_with("(*smelt_capture_") {
@@ -1290,6 +1310,18 @@ impl<'mir> FunctionEmitter<'mir> {
     }
 
     /// Renders a mutable receiver or assignment through shared closure storage.
+    ///
+    /// Shared captures live in `Rc<RefCell<T>>`, so a write/receiver expands to
+    /// `(*smelt_capture_x.borrow_mut())`. The returned `RefMut` guard lives to
+    /// the end of the FULL enclosing statement; if that statement also invoked
+    /// a closure re-borrowing the same cell, the nested borrow would panic with
+    /// "already borrowed". The same three-address invariant documented on
+    /// [`Self::local_value_text`] prevents this: every call is a separate SSA
+    /// temp statement, so an assignment target's `borrow_mut` guard only ever
+    /// coexists with already-evaluated value operands (e.g.
+    /// `(*smelt_capture_count.borrow_mut()) = _smelt_tmp_N;`), never with a live
+    /// call. Callers must not construct a single statement that both takes this
+    /// mutable borrow and evaluates a call.
     pub(super) fn local_mut_value_text(&self, local: LocalId) -> Result<String, EmitError> {
         let name = self.local_name(local)?;
         if name.starts_with("(*smelt_capture_") {

--- a/crates/smelt-codegen-rust/src/emitter/list_query.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_query.rs
@@ -896,15 +896,19 @@ impl FunctionEmitter<'_> {
                 .collect::<Result<Vec<_>, EmitError>>()?;
             params.extend((0..extra_params).map(|index| format!("_arg{index}")));
             let params_text = params.join(", ");
-            let mut raw_body_text = String::new();
-            emitter.emit_mutable_local_preludes(&mut raw_body_text)?;
-            emitter.emit_closure_block(emitter.entry_block()?, &mut raw_body_text)?;
-            let body_text = promote_trailing_future_binding_return(raw_body_text);
+            let mut body_text = String::new();
+            emitter.emit_mutable_local_preludes(&mut body_text)?;
+            emitter.emit_closure_block(emitter.entry_block()?, &mut body_text)?;
             let returns_future = matches!(
                 emitter.mir.types.get(function.return_ty),
                 Some(Type::Future(_))
             );
-            let awaits_inside_body = contains_await_outside_nested_async_block(&body_text);
+            // Whether this closure needs the async wrapper is decided from MIR,
+            // not from scanning the emitted text: a closure is async when its
+            // declared return type is a future, or when its own body performs an
+            // `await` (nested Promise-continuation closures are separate MIR
+            // functions and are excluded by `closure_body_awaits`).
+            let awaits_inside_body = emitter.closure_body_awaits();
             if returns_future || awaits_inside_body {
                 let output_ty = match emitter.mir.types.get(function.return_ty) {
                     Some(Type::Future(item)) => *item,
@@ -912,7 +916,9 @@ impl FunctionEmitter<'_> {
                 };
                 let output_text = emitter.type_text_with_impl_trait(output_ty, false)?;
                 let return_ty = format!("Result<{output_text}, Box<dyn std::error::Error>>");
-                let async_value_needs_await = async_body_returns_future_value(&body_text);
+                // Whether `smelt_async_value` is itself a future to await is read
+                // from the MIR return operand types, not from the emitted text.
+                let async_value_needs_await = emitter.closure_yields_future_value()?;
                 let return_value = if closure.can_throw && async_value_needs_await {
                     if matches!(
                         emitter.mir.types.get(output_ty),
@@ -1071,6 +1077,59 @@ impl FunctionEmitter<'_> {
         }
     }
 
+    /// Return whether this closure's own MIR body performs an `await`.
+    ///
+    /// The decision is read from MIR types rather than emitted text: a closure
+    /// awaits when any of its own basic blocks contains an `Await` terminator or
+    /// an `Rvalue::Await` statement. Nested closures (Promise continuations,
+    /// `async move` blocks) are separate `MirFunction`s referenced through
+    /// `Rvalue::Closure` and are never inlined into `self.function.blocks`, so
+    /// their awaits are naturally excluded — this is the structural, formatting-
+    /// independent replacement for the old brace-counting text scan.
+    pub(super) fn closure_body_awaits(&self) -> bool {
+        self.function.blocks.iter().any(|block| {
+            let terminator_awaits = matches!(&block.terminator, Some(Terminator::Await { .. }));
+            let statement_awaits = block.statements.iter().any(|statement| {
+                matches!(
+                    statement,
+                    Statement::Assign {
+                        value: Rvalue::Await(_),
+                        ..
+                    }
+                )
+            });
+            terminator_awaits || statement_awaits
+        })
+    }
+
+    /// Return whether the value this closure yields is itself a future.
+    ///
+    /// An async wrapper stores the closure body's result in `smelt_async_value`.
+    /// When that value is already a future (the closure returns a `new Promise`
+    /// or another future without awaiting it first) the wrapper must `.await`
+    /// it before producing the resolved output. This is decided from the MIR
+    /// return operand types: the closure yields a future iff every `Return`
+    /// terminator carries an operand whose type is `Type::Future(_)`.
+    ///
+    /// Returns `false` when the closure has no `Return` terminator so the
+    /// wrapper falls back to treating the body value as already-resolved, which
+    /// matches the previous text-based behaviour for those degenerate shapes.
+    pub(super) fn closure_yields_future_value(&self) -> Result<bool, EmitError> {
+        let mut saw_return = false;
+        for block in &self.function.blocks {
+            if let Some(Terminator::Return(operand)) = &block.terminator {
+                saw_return = true;
+                if !matches!(
+                    self.mir.types.get(self.operand_ty(operand)?),
+                    Some(Type::Future(_))
+                ) {
+                    return Ok(false);
+                }
+            }
+        }
+        Ok(saw_return)
+    }
+
     /// Emits a closure block with return terminators scoped to the closure body.
     pub(super) fn emit_closure_block(
         &self,
@@ -1142,8 +1201,23 @@ impl FunctionEmitter<'_> {
                         out.push_str("    ()\n");
                     }
                 } else {
+                    // For an async closure whose declared return is `Future<inner>`
+                    // the surrounding async wrapper stores this body value in
+                    // `smelt_async_value` and awaits it when it is itself a future
+                    // (see `closure_yields_future_value`). Deciding the tail type
+                    // from MIR keeps the future flowing through: when the returned
+                    // operand is already a future we yield it at the `Future` type,
+                    // so a `new Promise(...)` body returns the future rather than
+                    // collapsing to the inner type's default (the old null / `0.0`
+                    // fallthrough that the textual promotion pass patched up after
+                    // the fact). Only when the operand is a resolved value do we
+                    // strip to the inner type as before.
+                    let operand_is_future = matches!(
+                        self.mir.types.get(self.operand_ty(operand)?),
+                        Some(Type::Future(_))
+                    );
                     let return_ty = match self.mir.types.get(self.function.return_ty) {
-                        Some(Type::Future(item)) => *item,
+                        Some(Type::Future(item)) if !operand_is_future => *item,
                         _ => self.function.return_ty,
                     };
                     let value = self.value_at_type(operand, return_ty)?;
@@ -1489,145 +1563,6 @@ impl FunctionEmitter<'_> {
     }
 
     // Sorted-list helpers continue in `list_ordering.rs`.
-}
-
-/// Return whether the emitted async block body leaves a future as its final value.
-fn async_body_returns_future_value(body_text: &str) -> bool {
-    let mut non_empty_lines = body_text.lines().rev().filter_map(|line| {
-        let trimmed = line.trim().trim_end_matches(';');
-        (!trimmed.is_empty()).then_some(trimmed)
-    });
-    let Some(final_expr) = non_empty_lines.next() else {
-        return false;
-    };
-    if final_expr == "}" {
-        return non_empty_lines.any(|line| {
-            line.contains("as ::std::pin::Pin<Box<dyn ::std::future::Future<Output =")
-        });
-    }
-    body_text.lines().any(|line| {
-        line.trim_start().starts_with(&format!(
-            "let {final_expr}: ::std::pin::Pin<Box<dyn ::std::future::Future"
-        ))
-    })
-}
-
-/// Promote a trailing generated future binding to the closure body value.
-///
-/// Async expression-bodied arrows that return `new Promise(...)` can lower to a
-/// future local followed by the generic null fallthrough. In that shape the
-/// future is the JavaScript return value and should be awaited by the enclosing
-/// async wrapper.
-fn promote_trailing_future_binding_return(body_text: String) -> String {
-    let lines = body_text.lines().collect::<Vec<_>>();
-    // Locate the last non-blank line. Binding `final_line` here (instead of
-    // re-indexing `lines[final_index]`) keeps the check panic-free: the iterator
-    // already handed us the line, so no bounds-checked index is needed.
-    let Some((final_index, final_line)) = lines
-        .iter()
-        .enumerate()
-        .rev()
-        .find(|(_, line)| !line.trim().is_empty())
-    else {
-        return body_text;
-    };
-    if final_line.trim() != "SmeltUnknown::Null" {
-        return body_text;
-    }
-    // Scan the lines preceding the trailing null for the future binding to
-    // promote. `get(..final_index)` yields the same prefix as `lines[..final_index]`
-    // but returns `None` rather than panicking if the range is ever invalid.
-    let Some(future_name) = lines
-        .get(..final_index)
-        .unwrap_or(&[])
-        .iter()
-        .rev()
-        .find_map(|line| {
-            let trimmed = line.trim_start();
-            if !trimmed.starts_with("let ")
-                || !trimmed.contains("::std::future::Future<Output =")
-            {
-                return None;
-            }
-            let rest = trimmed.strip_prefix("let ")?;
-            rest.split(':').next().map(str::trim).filter(|name| {
-                !name.is_empty()
-                    && name
-                        .chars()
-                        .all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
-            })
-        })
-    else {
-        return body_text;
-    };
-    let mut rewritten = String::new();
-    for (index, line) in lines.iter().enumerate() {
-        if index == final_index {
-            let indent_len = line.len().saturating_sub(line.trim_start().len());
-            rewritten.push_str(&line[..indent_len]);
-            rewritten.push_str(future_name);
-            rewritten.push('\n');
-        } else {
-            rewritten.push_str(line);
-        }
-        rewritten.push('\n');
-    }
-    rewritten
-}
-
-/// Return whether closure body text awaits outside generated nested async blocks.
-///
-/// Promise continuations emit `Box::pin(async move { ... .await ... })` inside
-/// otherwise synchronous callbacks. Those nested awaits must not make the
-/// containing callback return a future.
-fn contains_await_outside_nested_async_block(body_text: &str) -> bool {
-    let bytes = body_text.as_bytes();
-    // Byte offsets of the opening `{` that begins each still-open `async move`
-    // block, keyed indirectly by the brace depth recorded when it opened. A
-    // `.await` seen while this stack is empty belongs to the enclosing callback
-    // rather than a nested async block.
-    let mut async_depths = Vec::<usize>::new();
-    let mut brace_depth = 0usize;
-    let mut index = 0usize;
-    // Walk the text one byte at a time. Every offset step is a `saturating`/
-    // `checked`-style advance so no arithmetic can overflow and every lookup uses
-    // `get`, keeping this scanner panic-free on arbitrary emitted text.
-    while let Some(&byte) = bytes.get(index) {
-        if starts_with_at(body_text, index, "async move") {
-            // Skip whitespace after `async move` to find the opening brace.
-            let mut cursor = index.saturating_add("async move".len());
-            while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
-                cursor = cursor.saturating_add(1);
-            }
-            if bytes.get(cursor) == Some(&b'{') {
-                brace_depth = brace_depth.saturating_add(1);
-                async_depths.push(brace_depth);
-                index = cursor.saturating_add(1);
-                continue;
-            }
-        }
-        if starts_with_at(body_text, index, ".await") && async_depths.is_empty() {
-            return true;
-        }
-        match byte {
-            b'{' => brace_depth = brace_depth.saturating_add(1),
-            b'}' => {
-                if async_depths.last().copied() == Some(brace_depth) {
-                    async_depths.pop();
-                }
-                brace_depth = brace_depth.saturating_sub(1);
-            }
-            _ => {}
-        }
-        index = index.saturating_add(1);
-    }
-    false
-}
-
-/// Return whether `needle` starts at byte offset `index`.
-fn starts_with_at(text: &str, index: usize, needle: &str) -> bool {
-    text.get(index..)
-        .is_some_and(|remaining| remaining.starts_with(needle))
 }
 
 /// Rewrites emitted closure text so shared captures use their `RefCell` storage.

--- a/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
@@ -131,6 +131,74 @@ function collect(): string[] {
     );
 }
 
+/// Guards the shared-capture borrow invariant against RefCell double-borrow panics.
+///
+/// A single-threaded JS closure may synchronously call a sibling closure that
+/// reads or writes the same captured binding while the first closure is midway
+/// through evaluating an expression over that binding. In the generated Rust,
+/// shared captures live in `Rc<RefCell<T>>` and each use expands to
+/// `(*smelt_capture_x.borrow())` / `(*smelt_capture_x.borrow_mut())`. A
+/// `borrow`/`borrow_mut` guard is a temporary that lives to the end of the
+/// FULL enclosing statement, so if a borrow text were interpolated into the
+/// same statement as a closure call that re-borrows the same cell, the nested
+/// borrow would panic with "already borrowed" — a crash JS never produces.
+///
+/// The invariant that prevents this: MIR is three-address form, so every
+/// `Call`/`ClosureCall` is lowered to its own SSA temp binding
+/// (`let _smelt_tmp_N = (closure)();`) BEFORE any statement that consumes the
+/// result, and the copy-propagation / move-on-last-use passes only rewrite
+/// local aliases (they never fuse a call rvalue into a consuming statement).
+/// Consequently every emitted borrow guard is confined to a single
+/// three-address statement whose operands are already-materialized locals or
+/// literals — never a live call. This test pins that shape: the sibling call
+/// `bump()` must be bound to its own temp, and the borrow of the shared cell
+/// must appear in a later statement, so no guard is ever held across the call.
+#[test]
+fn shared_capture_borrow_never_spans_a_sibling_closure_call() {
+    let source = source_for(
+        r#"
+function run(): number {
+  let count = 0;
+  function bump(): number {
+    count += 1;
+    return count;
+  }
+  function acc(): void {
+    count = count + bump();
+  }
+  acc();
+  return count;
+}
+"#,
+    );
+
+    // `count` is shared through an `Rc<RefCell<f64>>` capture cell.
+    assert!(
+        source
+            .contains("let smelt_capture_count = ::std::rc::Rc::new(::std::cell::RefCell::new("),
+        "{source}"
+    );
+    // The sibling call is materialized into its own temp before any borrow.
+    assert!(source.contains("= (bump)();"), "{source}");
+    // The `acc` body must never place a `borrow()`/`borrow_mut()` guard in the
+    // same statement as the `(bump)()` call: the line that calls `bump` is a
+    // bare `let _smelt_tmp = (bump)();` with no borrow text on it.
+    let call_line = source
+        .lines()
+        .find(|line| line.contains("= (bump)();"))
+        .unwrap_or_else(|| panic!("no bump call line\n{source}"));
+    assert!(
+        !call_line.contains(".borrow()") && !call_line.contains(".borrow_mut()"),
+        "borrow guard shares a statement with the sibling call: {call_line}\n{source}"
+    );
+    // The assignment back into the shared cell reads a pre-evaluated temp, not
+    // an inline call, so the `borrow_mut()` target guard cannot span a call.
+    assert!(
+        source.contains("(*smelt_capture_count.borrow_mut()) = _smelt_tmp"),
+        "{source}"
+    );
+}
+
 #[test]
 fn emits_function_array_some_without_cloning_callbacks() {
     let source = source_for(


### PR DESCRIPTION
Closes the two remaining semantic-soundness weak spots from the audit (the future-binding text patching + null fallthrough, and the RefCell re-entrancy question).

## Async closure returns now decided by MIR types (fixes the silent-miscompilation class)
Root cause: in the closure `Return` path, a declared `Future<inner>` return was unconditionally stripped to `inner` and the operand coerced — so an async arrow returning `new Promise(...)` collapsed its future into a discarded pending-promise placeholder (erased inner) or the inner type's default. Three emitted-text scanners (`promote_trailing_future_binding_return`, `contains_await_outside_nested_async_block`, `async_body_returns_future_value`) patched this up after the fact and silently returned null whenever their string patterns didn't match.

Now:
- The Return path checks the operand's MIR type: a future flows through at `Future` type for the enclosing async wrapper to await; resolved values behave exactly as before.
- `closure_body_awaits()` (Await terminators/rvalues in the closure's own MIR blocks — nested closures are separate `MirFunction`s, structurally excluded) and `closure_yields_future_value()` (every Return operand is `Future`) replace the text scanners.
- All three textual helpers deleted (net −146 lines of brace-counting/pattern-matching).

Verified 12 async/Promise-arrow variants emit byte-identically before/after, except the one previously-miscompiling shape (erased-return async arrow returning `new Promise`), which now correctly awaits the real future.

## Shared-capture borrow soundness: hazard proven unreachable, invariant pinned
Investigated whether `(*smelt_capture_x.borrow_mut())` guards can live across a re-entrant closure call (RefCell double-borrow panic that JS semantics would never produce). Verdict: **not reachable**. MIR three-address form hoists every `Call`/`ClosureCall` into its own temp statement before any consuming statement takes a borrow, and neither optimizer pass (`CopyPropagation`, `MoveOnLastUse`) can inline a call into a use site. The riskiest shape (sibling closures mutating the same capture, `count = count + bump()`) was emitted and executed: returns the JS-correct result, no panic.

- Invariant documented on `local_value_text`/`local_mut_value_text`.
- New regression test `shared_capture_borrow_never_spans_a_sibling_closure_call` pins the emitted shape as a tripwire for future MIR changes.

## Verification
Local: `cargo check`/`cargo clippy --lib` clean on smelt-codegen-rust; smelt-frontend-ts (674) and smelt-mir (10) green. The codegen snapshot suite and the new regression test compile only in CI (sandbox can't fetch the `ruff` dev-dependency chain) — corpus, remeda-regression, and coverage are the behavioral gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MArKS25FxxY4UM7cByPopw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MArKS25FxxY4UM7cByPopw)_