### PR TITLE
codegen: concrete SmeltMatch type for RegExp match results

### DIFF
--- a/crates/smelt-cli/tests/hir_cli_cross_language_tests.rs
+++ b/crates/smelt-cli/tests/hir_cli_cross_language_tests.rs
@@ -321,6 +321,7 @@ fn end_to_end_examples_match_expected_outputs() -> TestResult {
         "25_private_protected_metadata",
         "26_interface_inheritance_optional_computed",
         "27_optional_chains",
+        "28_regex_match_result",
     ] {
         verify_end_to_end_example(name)?;
     }

--- a/crates/smelt-codegen-rust/src/emitter/strings.rs
+++ b/crates/smelt-codegen-rust/src/emitter/strings.rs
@@ -396,7 +396,13 @@ impl FunctionEmitter<'_> {
         Ok(format!("{pattern_text}.match_string(&{haystack_text})"))
     }
 
-    /// Converts JavaScript `RegExp.prototype.exec` to a stateful match object.
+    /// Converts JavaScript `RegExp.prototype.exec` to a concrete match result.
+    ///
+    /// The runtime `exec` returns a typed `Option<SmeltMatch>`; the HIR result
+    /// type is still the erased `Optional(Unknown)` boundary consumers read
+    /// dynamically, so the concrete match is erased *explicitly* at that
+    /// boundary with `SmeltMatch::into_smelt_unknown`. The erasure is a single,
+    /// visible adapter rather than an inline `SmeltUnknown` property-bag build.
     pub(super) fn regex_exec_text(
         &self,
         regex: &Operand,
@@ -404,10 +410,17 @@ impl FunctionEmitter<'_> {
     ) -> Result<String, EmitError> {
         let regex_text = self.regexp_operand_text(regex)?;
         let haystack_text = self.string_like_operand_text(haystack, "regex exec")?;
-        Ok(format!("{regex_text}.exec(&{haystack_text})"))
+        Ok(format!(
+            "{regex_text}.exec(&{haystack_text}).map(SmeltMatch::into_smelt_unknown)"
+        ))
     }
 
-    /// Converts JavaScript `String.prototype.matchAll` to indexed match records.
+    /// Converts JavaScript `String.prototype.matchAll` to concrete match results.
+    ///
+    /// Mirrors [`Self::regex_exec_text`]: `match_all_indices` yields typed
+    /// `SmeltMatch` values, each erased with the explicit
+    /// `SmeltMatch::into_smelt_unknown` boundary adapter for the erased
+    /// `List(Unknown)` result the frontend assigns.
     pub(super) fn regex_match_all_text(
         &self,
         regex: &Operand,
@@ -415,7 +428,9 @@ impl FunctionEmitter<'_> {
     ) -> Result<String, EmitError> {
         let regex_text = self.regexp_operand_text(regex)?;
         let haystack_text = self.string_like_operand_text(haystack, "regex matchAll")?;
-        Ok(format!("{regex_text}.match_all_indices(&{haystack_text})"))
+        Ok(format!(
+            "{regex_text}.match_all_indices(&{haystack_text}).into_iter().map(SmeltMatch::into_smelt_unknown).collect::<Vec<_>>()"
+        ))
     }
 
     /// Render a value as a `SmeltRegExp`.

--- a/crates/smelt-codegen-rust/src/lib.rs
+++ b/crates/smelt-codegen-rust/src/lib.rs
@@ -1828,8 +1828,13 @@ fn emit_source_with_free_function_router(
                 fn_writer.line("    haystack.to_owned()");
                 fn_writer.line("}");
             });
-            impl_writer.line("/// Execute this RegExp and return a JavaScript-like match object.");
-            impl_writer.block("pub fn exec(&self, haystack: &str) -> Option<SmeltUnknown>", |fn_writer| {
+            impl_writer.line("/// Execute this RegExp and return a concrete `SmeltMatch` result.");
+            impl_writer.line("///");
+            impl_writer.line("/// The match result is a typed `SmeltMatch` value (numbered groups,");
+            impl_writer.line("/// named groups, `index`, `input`) instead of an erased `SmeltUnknown`");
+            impl_writer.line("/// property bag; callers erase it explicitly at a dynamic boundary via");
+            impl_writer.line("/// `SmeltMatch::into_smelt_unknown` when required.");
+            impl_writer.block("pub fn exec(&self, haystack: &str) -> Option<SmeltMatch>", |fn_writer| {
                 fn_writer.line("let regex = self.compiled();");
                 fn_writer.line("let start = if self.has_flag('g') || self.has_flag('y') { *self.last_index.borrow() } else { 0 };");
                 fn_writer.line("let suffix = haystack.get(start..).unwrap_or(\"\");");
@@ -1837,28 +1842,14 @@ fn emit_source_with_free_function_router(
                 fn_writer.line("let matched = captures.get(0)?;");
                 fn_writer.line("if self.has_flag('y') && matched.start() != 0 { *self.last_index.borrow_mut() = 0; return None; }");
                 fn_writer.line("if self.has_flag('g') || self.has_flag('y') { *self.last_index.borrow_mut() = start + matched.end(); }");
-                fn_writer.line("let mut object = ::std::collections::HashMap::new();");
-                fn_writer.line("for index in 0..captures.len() { if let Some(value) = captures.get(index) { object.insert(index.to_string(), SmeltUnknown::String(value.as_str().to_owned())); } else { object.insert(index.to_string(), SmeltUnknown::Undefined); } }");
-                fn_writer.line("let mut groups = ::std::collections::HashMap::new();");
-                fn_writer.line("for name in regex.capture_names().flatten() { let value = captures.name(name).map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::String(value.as_str().to_owned())); groups.insert(name.to_owned(), value.clone()); let mut snake = String::new(); for (index, ch) in name.chars().enumerate() { if ch.is_ascii_uppercase() { if index > 0 { snake.push('_'); } snake.push(ch.to_ascii_lowercase()); } else { snake.push(ch); } } groups.insert(snake, value); }");
-                fn_writer.line("object.insert(\"groups\".to_owned(), SmeltUnknown::Object(SmeltObject::new(groups)));");
-                fn_writer.line("object.insert(\"index\".to_owned(), SmeltUnknown::Number((start + matched.start()) as f64));");
-                fn_writer.line("object.insert(\"input\".to_owned(), SmeltUnknown::String(haystack.to_owned()));");
-                fn_writer.line("Some(SmeltUnknown::Object(SmeltObject::new(object)))");
+                fn_writer.line("Some(SmeltMatch::from_captures(&regex, &captures, start + matched.start(), haystack))");
             });
-            impl_writer.line("/// Return full JavaScript-like match objects for String.prototype.matchAll.");
-            impl_writer.block("pub fn match_all_indices(&self, haystack: &str) -> Vec<SmeltUnknown>", |fn_writer| {
+            impl_writer.line("/// Return concrete `SmeltMatch` results for String.prototype.matchAll.");
+            impl_writer.block("pub fn match_all_indices(&self, haystack: &str) -> Vec<SmeltMatch>", |fn_writer| {
                 fn_writer.line("let Some(regex) = self.try_compiled() else { return Vec::new(); };");
                 fn_writer.block("regex.captures_iter(haystack).filter_map(Result::ok).filter_map(|captures|", |map_writer| {
                     map_writer.line("let matched = captures.get(0)?;");
-                    map_writer.line("let mut object = ::std::collections::HashMap::new();");
-                    map_writer.line("for index in 0..captures.len() { if let Some(value) = captures.get(index) { object.insert(index.to_string(), SmeltUnknown::String(value.as_str().to_owned())); } else { object.insert(index.to_string(), SmeltUnknown::Undefined); } }");
-                    map_writer.line("let mut groups = ::std::collections::HashMap::new();");
-                    map_writer.line("for name in regex.capture_names().flatten() { let value = captures.name(name).map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::String(value.as_str().to_owned())); groups.insert(name.to_owned(), value.clone()); let mut snake = String::new(); for (index, ch) in name.chars().enumerate() { if ch.is_ascii_uppercase() { if index > 0 { snake.push('_'); } snake.push(ch.to_ascii_lowercase()); } else { snake.push(ch); } } groups.insert(snake, value); }");
-                    map_writer.line("object.insert(\"groups\".to_owned(), SmeltUnknown::Object(SmeltObject::new(groups)));");
-                    map_writer.line("object.insert(\"index\".to_owned(), SmeltUnknown::Number(matched.start() as f64));");
-                    map_writer.line("object.insert(\"input\".to_owned(), SmeltUnknown::String(haystack.to_owned()));");
-                    map_writer.line("Some(SmeltUnknown::Object(SmeltObject::new(object)))");
+                    map_writer.line("Some(SmeltMatch::from_captures(&regex, &captures, matched.start(), haystack))");
                 });
                 fn_writer.line(").collect::<Vec<_>>()");
             });
@@ -1885,6 +1876,7 @@ fn emit_source_with_free_function_router(
             });
         });
         writer.blank_line();
+        emit_smelt_match(&mut writer);
     }
     for class in &mir.classes {
         let name = class_name_text(mir, class)?;
@@ -2297,6 +2289,111 @@ fn insert_after_crate_header(mut root: String, text: &str) -> String {
     }
     root.insert_str(0, text);
     root
+}
+
+/// Emit the concrete `SmeltMatch` runtime type for RegExp match results.
+///
+/// `RegExp.prototype.exec` and `String.prototype.matchAll` return a JavaScript
+/// match result: an array-like value whose numbered entries are the capture
+/// groups (entry `0` is the whole match) plus the `index`, `input`, and
+/// `groups` properties. Historically Smelt built this shape inline as a
+/// `SmeltUnknown::Object` property bag, which erased its statically known
+/// structure. `SmeltMatch` models that structure with concrete Rust fields:
+///
+/// * `groups` — numbered capture groups as `Vec<Option<String>>` (an absent
+///   optional group is `None`, matching JavaScript `undefined`).
+/// * `named` — named capture groups keyed by their original name (and a
+///   snake_case alias so generated snake_cased field reads still resolve).
+/// * `match_index` — the zero-based match offset (`.index`).
+/// * `input` — the full searched string (`.input`).
+///
+/// Typed accessors (`group`, `named_group`, `index`, `input`, `len`) let
+/// callers read the shape without any dynamic tagging. When a match value has
+/// to cross a genuinely dynamic boundary (the erased `unknown` result type the
+/// frontend still assigns for `exec`/`matchAll` consumers), it is converted
+/// with the explicit [`IntoSmeltUnknown`] adapter — the single place where the
+/// concrete match is intentionally erased.
+fn emit_smelt_match(writer: &mut CodeWriter) {
+    writer.line("/// A concrete JavaScript RegExp match result (numbered groups, named");
+    writer.line("/// groups, `index`, and `input`).");
+    writer.line("#[derive(Clone, Debug, PartialEq)]");
+    writer.block("pub struct SmeltMatch", |struct_writer| {
+        struct_writer.line("id: usize,");
+        struct_writer.line("/// Numbered capture groups; entry 0 is the whole match. An absent");
+        struct_writer.line("/// optional group is `None` (JavaScript `undefined`).");
+        struct_writer.line("groups: Vec<Option<String>>,");
+        struct_writer.line("/// Named capture groups keyed by name (plus a snake_case alias).");
+        struct_writer.line("named: ::std::collections::HashMap<String, Option<String>>,");
+        struct_writer.line("/// Zero-based offset of the match within `input` (`.index`).");
+        struct_writer.line("match_index: usize,");
+        struct_writer.line("/// The full string that was searched (`.input`).");
+        struct_writer.line("input: String,");
+    });
+    writer.blank_line();
+    writer.line("#[allow(dead_code)]");
+    writer.block("impl SmeltMatch", |impl_writer| {
+        impl_writer.line("/// Build a `SmeltMatch` from a compiled regex and its captures.");
+        impl_writer.block(
+            "fn from_captures(regex: &fancy_regex::Regex, captures: &fancy_regex::Captures<'_>, match_index: usize, input: &str) -> Self",
+            |fn_writer| {
+                fn_writer.line("let groups = (0..captures.len()).map(|index| captures.get(index).map(|value| value.as_str().to_owned())).collect::<Vec<_>>();");
+                fn_writer.line("let mut named = ::std::collections::HashMap::new();");
+                fn_writer.block("for name in regex.capture_names().flatten()", |for_writer| {
+                    for_writer.line("let value = captures.name(name).map(|value| value.as_str().to_owned());");
+                    for_writer.line("named.insert(name.to_owned(), value.clone());");
+                    for_writer.line("let mut snake = String::new();");
+                    for_writer.block("for (index, ch) in name.chars().enumerate()", |snake_writer| {
+                        snake_writer.line("if ch.is_ascii_uppercase() { if index > 0 { snake.push('_'); } snake.push(ch.to_ascii_lowercase()); } else { snake.push(ch); }");
+                    });
+                    for_writer.line("named.insert(snake, value);");
+                });
+                fn_writer.line("Self { id: smelt_next_object_id(), groups, named, match_index, input: input.to_owned() }");
+            },
+        );
+        impl_writer.line("/// Read a numbered capture group (`match[n]`).");
+        impl_writer.block("fn group(&self, index: usize) -> Option<&str>", |fn_writer| {
+            fn_writer.line("self.groups.get(index).and_then(|value| value.as_deref())");
+        });
+        impl_writer.line("/// Read a named capture group (`match.groups.name`).");
+        impl_writer.block("fn named_group(&self, name: &str) -> Option<&str>", |fn_writer| {
+            fn_writer.line("self.named.get(name).and_then(|value| value.as_deref())");
+        });
+        impl_writer.line("/// The zero-based match offset (`match.index`).");
+        impl_writer.block("fn index(&self) -> f64", |fn_writer| {
+            fn_writer.line("self.match_index as f64");
+        });
+        impl_writer.line("/// The full searched string (`match.input`).");
+        impl_writer.block("fn input(&self) -> &str", |fn_writer| {
+            fn_writer.line("&self.input");
+        });
+        impl_writer.line("/// Number of numbered capture groups, including the whole match.");
+        impl_writer.block("fn len(&self) -> usize", |fn_writer| {
+            fn_writer.line("self.groups.len()");
+        });
+        impl_writer.line("/// Whether there are no numbered groups (never true for a real match).");
+        impl_writer.block("fn is_empty(&self) -> bool", |fn_writer| {
+            fn_writer.line("self.groups.is_empty()");
+        });
+    });
+    writer.blank_line();
+    writer.line("/// Erase a concrete match into a `SmeltUnknown` at a dynamic boundary.");
+    writer.line("///");
+    writer.line("/// This reproduces the JavaScript match-array-with-properties shape:");
+    writer.line("/// numbered string keys for the groups plus `groups`, `index`, and");
+    writer.line("/// `input`. It is the single explicit adapter used when a typed");
+    writer.line("/// `SmeltMatch` must flow into erased `unknown` consumer dataflow.");
+    writer.block("impl IntoSmeltUnknown for SmeltMatch", |impl_writer| {
+        impl_writer.block("fn into_smelt_unknown(self) -> SmeltUnknown", |fn_writer| {
+            fn_writer.line("let mut object = ::std::collections::HashMap::new();");
+            fn_writer.line("for (index, value) in self.groups.iter().enumerate() { object.insert(index.to_string(), value.clone().map_or(SmeltUnknown::Undefined, SmeltUnknown::String)); }");
+            fn_writer.line("let groups = self.named.into_iter().map(|(name, value)| (name, value.map_or(SmeltUnknown::Undefined, SmeltUnknown::String))).collect::<::std::collections::HashMap<_, _>>();");
+            fn_writer.line("object.insert(\"groups\".to_owned(), SmeltUnknown::Object(SmeltObject::new(groups)));");
+            fn_writer.line("object.insert(\"index\".to_owned(), SmeltUnknown::Number(self.match_index as f64));");
+            fn_writer.line("object.insert(\"input\".to_owned(), SmeltUnknown::String(self.input));");
+            fn_writer.line("SmeltUnknown::Object(SmeltObject::with_id(self.id, object))");
+        });
+    });
+    writer.blank_line();
 }
 
 /// Emit natural JSON serde support for `SmeltUnknown`.

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -3666,6 +3666,41 @@ for (const { index } of matches) {
 
     assert!(source.contains(".match_all_indices(&"));
     assert!(source.contains("pub fn match_all_indices(&self"));
+    // matchAll builds concrete `SmeltMatch` values, erased explicitly at the
+    // dynamic boundary rather than as inline `SmeltUnknown` bags.
+    assert!(source.contains("pub struct SmeltMatch"));
+    assert!(source.contains(".map(SmeltMatch::into_smelt_unknown)"));
+    assert!(
+        source.contains("-> Vec<SmeltMatch>"),
+        "match_all_indices should return concrete SmeltMatch values: {source}"
+    );
+}
+
+#[test]
+fn emits_regex_exec_as_concrete_smelt_match() {
+    let source = source_for(
+        r#"
+const re = /(?<year>\d{4})-(\d{2})/;
+const m = re.exec("2024-07");
+console.log(m === null);
+"#,
+    );
+
+    // exec returns a concrete `Option<SmeltMatch>`; the typed match dataflow
+    // does not build a `SmeltUnknown` property bag. The single erasure to the
+    // dynamic consumer boundary is the explicit `into_smelt_unknown` adapter.
+    assert!(
+        source.contains("pub fn exec(&self, haystack: &str) -> Option<SmeltMatch>"),
+        "exec should return a concrete SmeltMatch option: {source}"
+    );
+    assert!(source.contains("pub struct SmeltMatch"));
+    assert!(source.contains("impl IntoSmeltUnknown for SmeltMatch"));
+    assert!(source.contains(".exec(&\"2024-07\".to_owned()).map(SmeltMatch::into_smelt_unknown)"));
+    // The numbered-group / named-group / index / input shape is modeled with
+    // concrete fields, not assembled as an untyped object during exec.
+    assert!(source.contains("groups: Vec<Option<String>>"));
+    assert!(source.contains("named: ::std::collections::HashMap<String, Option<String>>"));
+    assert!(source.contains("fn from_captures(regex: &fancy_regex::Regex"));
 }
 
 #[test]

--- a/examples/typescript/end-to-end/28_regex_match_result/expected.mir
+++ b/examples/typescript/end-to-end/28_regex_match_result/expected.mir
@@ -1,0 +1,50 @@
+fn main (FuncId(0)) -> None
+  locals
+    %0 user pattern: RegExp
+    %1 user matches: List<Unknown>
+    %2 user found: Unknown
+    %3 user whole: Unknown
+    %4 user letter: Unknown
+    %5 user digit: Unknown
+    %6 temp: RegExp
+    %7 temp: List<Unknown>
+    %8 temp: Float
+    %9 temp: Float
+    %10 temp: Bool
+    %11 temp: Unknown
+    %12 temp: None
+    %13 temp: None
+    %14 temp: None
+    %15 temp: None
+  bb0:
+    %6 = external_new0("(?P<letter>[a-z])(\d)?", "g")
+    %0 = move %6
+    %7 = regex_match_all move %0, "a1 b c3"
+    %1 = move %7
+    %8 = 0.0
+    goto bb1
+  bb1:
+    %9 = len copy %1
+    %10 = copy %8 < move %9
+    switch move %10 ? bb2 : bb4
+  bb2:
+    %2 = copy %1[copy %8]
+    %3 = copy %2[0.0]
+    %11 = copy %2.field5
+    %4 = copy %11.field6
+    %5 = copy %2[2.0]
+    %12 = call @console_log(move %3) -> bb5
+  bb3:
+    %8 = copy %8 + 1.0
+    goto bb1
+  bb4:
+    return none
+  bb5:
+    %13 = call @console_log(move %4) -> bb6
+  bb6:
+    %14 = call @console_log(move %5) -> bb7
+  bb7:
+    %15 = call @console_log(copy %2.field9) -> bb8
+  bb8:
+    goto bb3
+

--- a/examples/typescript/end-to-end/28_regex_match_result/expected.rs
+++ b/examples/typescript/end-to-end/28_regex_match_result/expected.rs
@@ -1017,61 +1017,63 @@ impl IntoSmeltUnknown for SmeltMatch {
     }
 }
 
-#[derive(Clone, Debug, Default)]
-struct User {
-    name: String,
-    scores: SmeltList<f64>,
-}
-impl IntoSmeltUnknown for User {
-    fn into_smelt_unknown(self) -> SmeltUnknown {
-        SmeltUnknown::Object(SmeltObject::new(::std::collections::HashMap::from([
-        ("name".to_owned(), SmeltUnknown::String(self.name)),
-        ("scores".to_owned(), SmeltUnknown::Array(self.scores.into_iter().map(|value| SmeltUnknown::Number(value as f64)).collect())),
-        ])))
-    }
-}
-
-
 fn main() {
-    let present: Option<User>;
-    let missing: Option<User>;
-    let name: Option<String>;
-    let absent_name: Option<String>;
-    let score: Option<f64>;
-    let label: Option<String>;
-    let _smelt_tmp_8: Option<String>;
-    let _smelt_tmp_9: Option<String>;
-    let _smelt_tmp_10: Option<SmeltList<f64>>;
-    let _smelt_tmp_11: Option<f64>;
-    let _smelt_tmp_12: Option<String>;
-    let _smelt_tmp_6: SmeltList<f64> = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<f64> = vec![3.0]; smelt_list_items }));
-    let mut _smelt_tmp_7: User = User::new("Ada".to_owned(), _smelt_tmp_6);
-    present = Some(_smelt_tmp_7);
-    missing = None::<User>;
-    _smelt_tmp_8 = present.clone().as_ref().map(|_smelt_value| _smelt_value.name.clone());
-    name = _smelt_tmp_8;
-    _smelt_tmp_9 = missing.as_ref().map(|_smelt_value| _smelt_value.name.clone());
-    absent_name = _smelt_tmp_9;
-    _smelt_tmp_10 = present.clone().as_ref().map(|_smelt_value| _smelt_value.scores.clone());
-    _smelt_tmp_11 = _smelt_tmp_10.as_ref().and_then(|_smelt_value| ({ let len = _smelt_value.len() as i64; let index = 0.0 as i64; let normalized = if index < 0 { len + index } else { index }; usize::try_from(normalized).ok() }).and_then(|index| _smelt_value.get(index).cloned()));
-    score = _smelt_tmp_11;
-    _smelt_tmp_12 = present.as_ref().map(|_smelt_value| _smelt_value.label());
-    label = _smelt_tmp_12;
-    let _ = { println!("{:?}", name); };
-    let _ = { println!("{:?}", absent_name); };
-    let _ = { println!("{:?}", score); };
-    let _ = { println!("{:?}", label); };
+    let mut found: SmeltUnknown;
+    let mut whole: SmeltUnknown;
+    let mut letter: SmeltUnknown;
+    let mut digit: SmeltUnknown;
+    let mut _smelt_tmp_9: f64;
+    let mut _smelt_tmp_10: bool;
+    let mut _smelt_tmp_11: SmeltUnknown;
+    let mut _smelt_tmp_6: SmeltRegExp = SmeltRegExp::new("(?P<letter>[a-z])(\\d)?".to_owned(), "g".to_owned());
+    let mut pattern: SmeltRegExp = _smelt_tmp_6;
+    let _smelt_tmp_7: SmeltList<SmeltUnknown> = Into::<SmeltList<_>>::into(pattern.match_all_indices(&"a1 b c3".to_owned()).into_iter().map(SmeltMatch::into_smelt_unknown).collect::<Vec<_>>());
+    let matches: SmeltList<SmeltUnknown> = Into::<SmeltList<_>>::into(_smelt_tmp_7);
+    let mut _smelt_tmp_8: f64 = 0.0;
+    loop {
+    _smelt_tmp_9 = matches.len() as f64;
+    _smelt_tmp_10 = _smelt_tmp_8.clone() < _smelt_tmp_9;
+    if !(_smelt_tmp_10) { break; }
+    found = matches.get({ let len = matches.len() as i64; let index = _smelt_tmp_8.clone() as i64; let normalized = if index < 0 { len + index } else { index }; usize::try_from(normalized).expect("negative index out of bounds") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone();
+    whole = match found.clone() {
+                    SmeltUnknown::String(value) => {
+                        let len = value.chars().count() as i64;
+                        let index = 0.0 as i64;
+                        let normalized = if index < 0 { len + index } else { index };
+                        usize::try_from(normalized).ok().and_then(|index| value.chars().nth(index).map(|ch| SmeltUnknown::String(ch.to_string()))).unwrap_or(SmeltUnknown::Null)
+                    }
+                    SmeltUnknown::Array(values) => {
+                        let len = values.len() as i64;
+                        let index = 0.0 as i64;
+                        let normalized = if index < 0 { len + index } else { index };
+                        usize::try_from(normalized).ok().and_then(|index| values.get(index).cloned()).unwrap_or(SmeltUnknown::Null)
+                    }
+                SmeltUnknown::Object(values) => values.get(&0.0.to_string()).unwrap_or(SmeltUnknown::Null),
+                _ => SmeltUnknown::Null,
+            }.clone();
+    _smelt_tmp_11 = match found.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, "groups"), _ => SmeltUnknown::Undefined }.clone();
+    letter = match _smelt_tmp_11.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, "letter"), _ => SmeltUnknown::Undefined }.clone();
+    digit = match found.clone() {
+                    SmeltUnknown::String(value) => {
+                        let len = value.chars().count() as i64;
+                        let index = 2.0 as i64;
+                        let normalized = if index < 0 { len + index } else { index };
+                        usize::try_from(normalized).ok().and_then(|index| value.chars().nth(index).map(|ch| SmeltUnknown::String(ch.to_string()))).unwrap_or(SmeltUnknown::Null)
+                    }
+                    SmeltUnknown::Array(values) => {
+                        let len = values.len() as i64;
+                        let index = 2.0 as i64;
+                        let normalized = if index < 0 { len + index } else { index };
+                        usize::try_from(normalized).ok().and_then(|index| values.get(index).cloned()).unwrap_or(SmeltUnknown::Null)
+                    }
+                SmeltUnknown::Object(values) => values.get(&2.0.to_string()).unwrap_or(SmeltUnknown::Null),
+                _ => SmeltUnknown::Null,
+            }.clone();
+    let _ = { println!("{}", whole); };
+    let _ = { println!("{}", letter); };
+    let _ = { println!("{}", digit); };
+    let _ = { println!("{}", match found.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, "index"), _ => SmeltUnknown::Undefined }.clone()); };
+    _smelt_tmp_8 = _smelt_tmp_8.clone() + 1.0;
+    }
     return;
-}
-
-impl User {
-    fn new(name: String, scores: SmeltList<f64>) -> Self {
-    let mut this: Self = User { name: String::new(), scores: SmeltList::new(Vec::new()) };
-    this.name = name.clone();
-    this.scores = Into::<SmeltList<_>>::into(scores.clone());
-    return this;
-    }
-    fn label(&self) -> String {
-    return "user".to_owned();
-    }
 }

--- a/examples/typescript/end-to-end/28_regex_match_result/expected.stdout
+++ b/examples/typescript/end-to-end/28_regex_match_result/expected.stdout
@@ -1,0 +1,12 @@
+a1
+a
+1
+0
+b
+b
+undefined
+3
+c3
+c
+3
+5

--- a/examples/typescript/end-to-end/28_regex_match_result/input.ts
+++ b/examples/typescript/end-to-end/28_regex_match_result/input.ts
@@ -1,0 +1,16 @@
+// Exercises the concrete SmeltMatch runtime type through String.prototype.matchAll:
+// the whole match ([0]), a named capture group (.groups.letter), an optional
+// numbered group that is present in some matches and missing in others ([2]),
+// and the match offset (.index).
+const pattern = /(?<letter>[a-z])(\d)?/g;
+
+const matches = "a1 b c3".matchAll(pattern);
+for (const found of matches) {
+  const whole = found[0];
+  const letter = found.groups.letter;
+  const digit = found[2];
+  console.log(whole);
+  console.log(letter);
+  console.log(digit);
+  console.log(found.index);
+}


### PR DESCRIPTION
Closes #50

Follow-up to PR #47 (SmeltUnknown removal wave).

## What changed

`RegExp.prototype.exec` and `String.prototype.matchAll` previously represented match results as erased `SmeltUnknown` marker/property bags, even though the match shape is statically known. This replaces that with a concrete generated-runtime **`SmeltMatch`** type.

`SmeltMatch` models the JavaScript match shape with real Rust fields:
- **numbered capture groups** — `Vec<Option<String>>` (entry `0` is the whole match; an absent optional group is `None`, i.e. JS `undefined`)
- **named capture groups** — `HashMap<String, Option<String>>` (with a snake_case alias key, preserving prior lookup behavior)
- **`index`** — the zero-based match offset
- **`input`** — the full searched string

It exposes typed accessors (`group`, `named_group`, `index`, `input`, `len`) so the shape is read without any dynamic tagging.

The runtime methods are now typed end-to-end:
- `SmeltRegExp::exec` returns `Option<SmeltMatch>`
- `SmeltRegExp::match_all_indices` returns `Vec<SmeltMatch>`

so the match value's dataflow inside the runtime is fully concrete (no `SmeltUnknown`).

## Erasure boundary

The frontend still assigns the erased `unknown` result type that `exec`/`matchAll` consumers read dynamically (`m[0]`, `m.index`, `m.groups`). The concrete `SmeltMatch` is therefore erased at that single boundary via an **explicit `SmeltMatch::into_smelt_unknown` adapter** — the one place the typed value is intentionally erased — instead of building an inline property bag. This satisfies the issue's "keep explicit erasure adapters only when a match crosses a genuine dynamic boundary".

## Tests
- New codegen regression test `emits_regex_exec_as_concrete_smelt_match` (asserts the concrete type, fields, and the explicit adapter) and an extended `matchAll` test.
- New end-to-end example `28_regex_match_result` that **compiles and runs**, covering numbered groups, a **named capture group**, a **missing optional group** (prints `undefined`), and `.index`. The end-to-end harness diffs MIR + generated Rust + runtime stdout.
- Regenerated `27_optional_chains/expected.rs` for the shared RegExp-prelude change (its runtime stdout is unchanged).

Full `cargo test` is green (one unrelated Node-sandbox parity test, `decorated_members_match_node_output`, flaked on a 5s wall-time limit under parallel-build load and passes cleanly in isolation).

## Remaining work (documented, out of scope for a safe single pass)
The *consumer-side* dataflow is not yet typed: `m.index`, `m[0]`, `m.groups`, and named-group reads still go through the erased `SmeltUnknown` path because the frontend result type for `exec`/`matchAll` is `Optional(Unknown)` / `List(Unknown)`. Fully removing the `into_smelt_unknown` boundary would require the frontend to assign a concrete match type and to lower dotted/numbered access against it (`class_field_type` + computed-index + emitter field/index dispatch, plus the `for (const { index } of ... )` destructuring path). That is a larger, higher-risk change across the frontend type system and was left as a follow-up so this change lands green; the concrete type and the single explicit adapter are the foundation for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)