### PR TITLE
feat(frontend-ts,codegen): lower typed setTimeout/setInterval extra args through wrapper closures

### DIFF
--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -5363,3 +5363,27 @@ function fire(payload: unknown): void {
         "untyped path must not synthesize per-argument typed bindings: {source}"
     );
 }
+
+#[test]
+fn timer_unknown_callback_param_keeps_erased_list_path() {
+    // A concretely typed extra whose callback parameter is `unknown` is still a
+    // dynamic boundary: forwarding the `String` directly would drop it into a
+    // `SmeltUnknown` parameter slot without the boundary conversion. The wrapper
+    // path must be declined so the erased `Vec<SmeltUnknown>` ABI (which boxes
+    // each argument) is used instead.
+    let source = source_for(
+        r#"
+function handle(value: unknown): void {}
+setTimeout(handle, 10, "x");
+"#,
+    );
+
+    assert!(
+        source.contains("smelt_timer_args"),
+        "unknown callback parameters must keep the erased Vec<SmeltUnknown> dispatch path: {source}"
+    );
+    assert!(
+        !source.contains("smelt_timer_arg_0"),
+        "unknown callback parameter path must not synthesize typed per-argument bindings: {source}"
+    );
+}

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -5253,3 +5253,113 @@ export function cbRepeat(xs: string[]): string[] {
         "callback body should emit the real string repeat call: {source}"
     );
 }
+
+#[test]
+fn timer_typed_extra_args_use_wrapper_closure_not_erased_list() {
+    // `setTimeout(callback, ms, ...args)` with a statically typed callback and
+    // concretely typed extras must capture the extras in a synthesized
+    // zero-argument wrapper closure and call the callback directly, producing no
+    // erased `Vec<SmeltUnknown>` argument pack.
+    let source = source_for(
+        r#"
+function greet(name: string, count: number): void {
+  console.log(name);
+  console.log(count);
+}
+setTimeout(greet, 10, "hi", 3);
+"#,
+    );
+
+    // Extras keep their concrete Rust types in per-argument bindings; the erased
+    // `smelt_timer_args: Vec<SmeltUnknown>` pack of the dynamic path is absent.
+    assert!(source.contains("smelt_timer_arg_0"), "{source}");
+    assert!(source.contains("smelt_timer_arg_1"), "{source}");
+    assert!(
+        source.contains("let smelt_timer_arg_0: String"),
+        "typed extra should be a concrete String binding: {source}"
+    );
+    assert!(
+        source.contains("let smelt_timer_arg_1: f64"),
+        "typed extra should be a concrete f64 binding: {source}"
+    );
+    assert!(
+        !source.contains("smelt_timer_args"),
+        "typed timer extras must not pack into an erased Vec<SmeltUnknown>: {source}"
+    );
+    // The wrapper captures by value (move) and invokes the callback directly.
+    assert!(source.contains("move ||"), "{source}");
+    assert!(
+        source.contains("(smelt_timer_callback)(smelt_timer_arg_0.clone(), smelt_timer_arg_1.clone())"),
+        "{source}"
+    );
+    assert!(source.contains("smelt_set_timeout("), "{source}");
+}
+
+#[test]
+fn set_interval_typed_extra_args_use_wrapper_closure() {
+    // `setInterval` shares the typed-wrapper path with `setTimeout`.
+    let source = source_for(
+        r#"
+function tick(label: string, n: number): void {
+  console.log(label);
+}
+setInterval(tick, 5, "tock", 2);
+"#,
+    );
+
+    assert!(
+        !source.contains("smelt_timer_args"),
+        "typed interval extras must not pack into an erased Vec<SmeltUnknown>: {source}"
+    );
+    assert!(source.contains("smelt_timer_arg_0"), "{source}");
+    assert!(source.contains("smelt_timer_arg_1"), "{source}");
+    assert!(
+        source.contains("(smelt_timer_callback)(smelt_timer_arg_0.clone(), smelt_timer_arg_1.clone())"),
+        "{source}"
+    );
+    assert!(source.contains("smelt_set_interval("), "{source}");
+}
+
+#[test]
+fn timer_optional_typed_extra_arg_uses_wrapper_closure() {
+    // A single concretely typed extra (matching an optional callback parameter)
+    // still routes through the typed wrapper and forwards exactly one argument.
+    let source = source_for(
+        r#"
+function note(prefix: string, suffix?: string): void {
+  console.log(prefix);
+}
+setTimeout(note, 10, "with-optional", "extra");
+"#,
+    );
+
+    assert!(
+        !source.contains("smelt_timer_args"),
+        "typed optional timer extras must not pack into an erased Vec<SmeltUnknown>: {source}"
+    );
+    assert!(source.contains("smelt_timer_arg_0"), "{source}");
+    assert!(source.contains("smelt_timer_arg_1"), "{source}");
+}
+
+#[test]
+fn timer_untyped_extra_arg_keeps_erased_list_path() {
+    // An `unknown`-typed extra is a genuine dynamic boundary, so the erased
+    // `Vec<SmeltUnknown>` dispatch path must be preserved for it.
+    let source = source_for(
+        r#"
+function handle(value: unknown): void {}
+function fire(payload: unknown): void {
+  setTimeout(handle, 10, payload);
+}
+"#,
+    );
+
+    assert!(
+        source.contains("smelt_timer_args"),
+        "untyped timer extras must keep the erased Vec<SmeltUnknown> dispatch path: {source}"
+    );
+    assert!(
+        !source.contains("smelt_timer_arg_0"),
+        "untyped path must not synthesize per-argument typed bindings: {source}"
+    );
+}

--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -297,6 +297,32 @@ async function run(): Promise<number> {
 }
 ",
         },
+        // --- timer typed extra arguments -------------------------------------
+        Case {
+            name: "timer_typed_extra_args",
+            area: "timers",
+            source: r#"
+function greet(name: string, count: number): void {
+  console.log(name);
+  console.log(count);
+}
+function tick(label: string): void {
+  console.log(label);
+}
+setTimeout(greet, 10, "hi", 3);
+setInterval(tick, 5, "tock");
+"#,
+        },
+        Case {
+            name: "timer_optional_typed_arg",
+            area: "timers",
+            source: r#"
+function note(prefix: string, suffix?: string): void {
+  console.log(prefix);
+}
+setTimeout(note, 10, "with-optional", "extra");
+"#,
+        },
         Case {
             name: "interface_method_call",
             area: "interfaces",

--- a/crates/smelt-codegen-rust/tests/timer_runtime.rs
+++ b/crates/smelt-codegen-rust/tests/timer_runtime.rs
@@ -1,0 +1,169 @@
+//! Runtime execution tests for typed timer extra arguments.
+//!
+//! The `compile_corpus` tier proves the emitted Rust type-checks; this tier
+//! proves the typed timer wrapper closures produced for
+//! `setTimeout(callback, ms, ...args)` / `setInterval(callback, ms, ...args)`
+//! actually run and forward the captured arguments correctly.
+//!
+//! Each case is a TypeScript Vitest test whose body schedules a timer with typed
+//! extra arguments, drives the virtual-time event loop with `await delay(...)`,
+//! and asserts on the effect the callback produced. Lowering a Vitest test emits
+//! a `#[tokio::test]` function, so this tier lowers each program to a crate and
+//! runs `cargo test` on it — a green `cargo test` means every `expect(...)` held
+//! at runtime. Vitest tests are the supported async entry point in generated
+//! code (a user-defined `async function main` is a separate, known codegen gap),
+//! which is why the driver is a test rather than a program `main`.
+//!
+//! The whole tier is `#[ignore]`d because it compiles and executes real crates,
+//! which is slow. CI (and you) run it explicitly:
+//!
+//! ```sh
+//! cargo test -p smelt-codegen-rust --test timer_runtime -- --ignored
+//! ```
+
+#![expect(
+    clippy::expect_used,
+    reason = "runtime tests fail fast on invalid fixture setup"
+)]
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use smelt_codegen_rust::{CrateKind, EmitOptions, emit_crate};
+use smelt_frontend_ts::{HirCtx, to_hir};
+use smelt_hir::FileId;
+
+/// A `delay` helper reused by every fixture: awaiting it advances the shared
+/// virtual-time timer queue so scheduled timers fire deterministically.
+const DELAY_HELPER: &str = r#"
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+"#;
+
+/// Lowers `source` through the real pipeline and emits a runnable program crate.
+fn emit_program(source: &str, crate_name: &str, crate_dir: &Path) {
+    let mut ctx = HirCtx::new();
+    to_hir(source, FileId(0), &mut ctx).expect("HIR lowering");
+    let mut mir = smelt_mir::lower_hir(&ctx.krate).expect("MIR lowering");
+    smelt_mir::opt::optimize(&mut mir);
+    let options = EmitOptions::new(crate_name.to_owned()).with_crate_kind(CrateKind::Program);
+    emit_crate(&mir, crate_dir, &options).expect("crate emission");
+}
+
+/// Runs `cargo test` on the emitted crate; a passing run means every generated
+/// `expect(...)` assertion held at runtime.
+fn run_generated_tests(crate_dir: &Path, target_dir: &Path) {
+    let output = Command::new(env!("CARGO"))
+        .arg("test")
+        .arg("--quiet")
+        .arg("--manifest-path")
+        .arg(crate_dir.join("Cargo.toml"))
+        .env("CARGO_TARGET_DIR", target_dir)
+        .env("RUSTFLAGS", "-Awarnings")
+        .output()
+        .expect("spawn cargo test");
+    assert!(
+        output.status.success(),
+        "generated timer test failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Returns a unique scratch directory root for this test run.
+fn scratch_root() -> PathBuf {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("smelt-timer-runtime-{}-{seq}", std::process::id()))
+}
+
+/// Emit `source` as a crate and run its generated Vitest tests.
+fn run_timer_fixture(source: &str, crate_name: &str) {
+    let root = scratch_root();
+    let crate_dir = root.join("crate");
+    let target_dir = root.join("target");
+    std::fs::create_dir_all(&crate_dir).expect("create crate dir");
+    std::fs::create_dir_all(&target_dir).expect("create target dir");
+    emit_program(source, crate_name, &crate_dir);
+    run_generated_tests(&crate_dir, &target_dir);
+    drop(std::fs::remove_dir_all(&root));
+}
+
+#[test]
+#[ignore = "slow: emits and runs a generated test crate; run in CI via --ignored"]
+fn set_timeout_forwards_multiple_typed_args() {
+    // Two concretely typed extras (`string`, `number`) must be captured by the
+    // synthesized wrapper and forwarded to the callback when the timer fires.
+    let source = format!(
+        r#"
+import {{ test, expect }} from "vitest";
+{DELAY_HELPER}
+test("setTimeout forwards multiple typed args", async () => {{
+  const results: string[] = [];
+  const greet = (name: string, count: number): void => {{
+    results.push(name + ":" + count);
+  }};
+  setTimeout(greet, 10, "hi", 3);
+  await delay(50);
+  expect(results).toContain("hi:3");
+}});
+"#
+    );
+    run_timer_fixture(&source, "smelt_timer_runtime_multiple");
+}
+
+#[test]
+#[ignore = "slow: emits and runs a generated test crate; run in CI via --ignored"]
+fn set_timeout_forwards_optional_typed_arg() {
+    // A callback with an optional parameter routes through the typed wrapper when
+    // every declared parameter (including the optional) is supplied.
+    let source = format!(
+        r#"
+import {{ test, expect }} from "vitest";
+{DELAY_HELPER}
+test("setTimeout forwards optional typed arg", async () => {{
+  const results: string[] = [];
+  const note = (prefix: string, suffix?: string): void => {{
+    results.push(prefix + (suffix ?? "<none>"));
+  }};
+  // Both the optional parameter's value and callback identity must survive being
+  // captured and invoked later by the synthesized wrapper.
+  setTimeout(note, 5, "with:", "extra");
+  await delay(50);
+  expect(results).toContain("with:extra");
+}});
+"#
+    );
+    run_timer_fixture(&source, "smelt_timer_runtime_optional");
+}
+
+#[test]
+#[ignore = "slow: emits and runs a generated test crate; run in CI via --ignored"]
+fn set_interval_forwards_typed_args_and_clears() {
+    // `setInterval` shares the typed-wrapper path; the interval fires with the
+    // forwarded typed argument on each period and stops once cleared by handle.
+    let source = format!(
+        r#"
+import {{ test, expect }} from "vitest";
+{DELAY_HELPER}
+test("setInterval forwards typed args and clears", async () => {{
+  const results: string[] = [];
+  const tick = (label: string): void => {{
+    results.push(label + ":" + (results.length + 1));
+  }};
+  const id = setInterval(tick, 10, "tock");
+  await delay(35);
+  clearInterval(id);
+  await delay(30);
+  expect(results).toContain("tock:1");
+  expect(results).toContain("tock:3");
+  expect(results.length).toBe(3);
+}});
+"#
+    );
+    run_timer_fixture(&source, "smelt_timer_runtime_interval");
+}

--- a/crates/smelt-frontend-ts/src/lowering/callbacks.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks.rs
@@ -16,4 +16,5 @@ mod classify;
 mod closures;
 mod dispatch;
 mod list_ops;
+mod timer_wrapper;
 mod transforms;

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/timer_wrapper.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/timer_wrapper.rs
@@ -39,10 +39,11 @@ impl ModuleBuilder<'_> {
     /// callback directly, so no erased `Vec<SmeltUnknown>` is produced.
     ///
     /// Returns `None` for any residual dynamic boundary — a non-function callback,
-    /// a rest-parameter callback, an `unknown`-typed extra, or an argument count
-    /// that does not match the callback signature exactly — so the caller keeps
-    /// the erased dynamic-dispatch path that mirrors JavaScript's
-    /// fill-`undefined`/ignore-surplus argument semantics.
+    /// a rest-parameter callback, a callback whose parameter types contain
+    /// `unknown`, an `unknown`-typed extra, or an argument count that does not
+    /// match the callback signature exactly — so the caller keeps the erased
+    /// dynamic-dispatch path that mirrors JavaScript's fill-`undefined`/
+    /// ignore-surplus argument semantics.
     ///
     /// `callback` and each entry of `extras` must already be lowered expressions
     /// in `body`; source spreads are handled by the caller and never reach here.
@@ -72,6 +73,20 @@ impl ModuleBuilder<'_> {
         // and rest cases fall back to the erased path, which mirrors JavaScript's
         // argument-forwarding semantics through the dynamic ABI.
         if callback_fn.rest.is_some() || extras.len() != callback_fn.params.len() {
+            return None;
+        }
+
+        // The callback's own parameter types must be concrete. A callback
+        // parameter typed `unknown` is a genuine dynamic boundary: calling it
+        // directly would pass a concrete extra (e.g. a `String`) into a
+        // `SmeltUnknown` parameter slot without the required boundary
+        // conversion, so such callbacks stay on the erased dynamic-dispatch
+        // path (which boxes each argument through the `SmeltUnknown` ABI).
+        if callback_fn
+            .params
+            .iter()
+            .any(|&ty| self.type_contains_unknown(ty))
+        {
             return None;
         }
 

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/timer_wrapper.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/timer_wrapper.rs
@@ -1,0 +1,230 @@
+//! Typed wrapper-closure synthesis for timer extra arguments.
+//!
+//! `setTimeout(callback, ms, ...args)` and `setInterval(callback, ms, ...args)`
+//! forward the trailing `...args` to `callback` when the timer fires. The erased
+//! lowering packs those extras into one `Vec<SmeltUnknown>` and dispatches the
+//! callback through the dynamic `SmeltUnknown` callable ABI. That is only needed
+//! at a genuine dynamic boundary (source spread, an untyped extra, or a callback
+//! whose value type is not a statically known function).
+//!
+//! When the callback is a statically typed function and every extra argument has
+//! a concrete (non-`unknown`) static type, this module instead synthesizes a
+//! zero-argument wrapper closure `move || callback(arg0, arg1, …)` that captures
+//! the callback and each typed extra by value and invokes the original callback
+//! directly. The resulting timer operand is a plain zero-parameter closure, so
+//! the emitter's direct-call fast path runs it without any `Vec<SmeltUnknown>`.
+//!
+//! Capturing by value is required for ownership correctness: the wrapper is
+//! stored in the timer registry and called after the enclosing function returns,
+//! so it must own the callback and the captured argument values rather than
+//! borrow stack locals that would already be gone. MIR escape analysis only
+//! promotes closures reachable from a `return`, and a timer wrapper escapes
+//! through a runtime async-op argument instead, so the by-value modes are set
+//! here at construction time.
+
+use crate::lowering::{
+    Body, CaptureMode, ClosureCapture, Expr, ExprKind, FunctionType, LocalDecl, ModuleBuilder,
+    Pattern, Span, Stmt, Type,
+};
+use smelt_hir::ClosureExpr;
+
+impl ModuleBuilder<'_> {
+    /// Try to lower typed timer extra arguments through a wrapper closure.
+    ///
+    /// Returns `Some(closure_expr)` when the timer arguments are fully static: the
+    /// `callback` is a statically typed function (no rest parameter), every
+    /// operand in `extras` has a concrete static type, and the extras cover the
+    /// callback's parameters exactly. In that case it synthesizes a zero-argument
+    /// wrapper that captures the callback and each extra by value and calls the
+    /// callback directly, so no erased `Vec<SmeltUnknown>` is produced.
+    ///
+    /// Returns `None` for any residual dynamic boundary — a non-function callback,
+    /// a rest-parameter callback, an `unknown`-typed extra, or an argument count
+    /// that does not match the callback signature exactly — so the caller keeps
+    /// the erased dynamic-dispatch path that mirrors JavaScript's
+    /// fill-`undefined`/ignore-surplus argument semantics.
+    ///
+    /// `callback` and each entry of `extras` must already be lowered expressions
+    /// in `body`; source spreads are handled by the caller and never reach here.
+    pub(in crate::lowering) fn timer_typed_wrapper_closure(
+        &mut self,
+        callback: smelt_hir::ExprId,
+        extras: &[smelt_hir::ExprId],
+        span: Span,
+        body: &mut Body,
+    ) -> Option<smelt_hir::ExprId> {
+        let callback_ty = Self::expr_ty(body, callback);
+        let Some(Type::Function(callback_fn)) = self.ctx.krate.types.get(callback_ty).cloned()
+        else {
+            // The callback is not a statically known function value (e.g. it is
+            // erased), so calling it directly is not possible; keep the erased
+            // dynamic-dispatch path.
+            return None;
+        };
+
+        // The provided extras must cover every declared callback parameter
+        // exactly. Forwarding fewer arguments would make the wrapper synthesize
+        // omitted-parameter values, and Rust's typed default
+        // (`String::default()`, `0.0`, …) does not match JavaScript's `undefined`
+        // for an omitted optional — a callback that branches on `arg ?? fallback`
+        // would observe the wrong value. A rest-parameter callback would need
+        // variadic packing (its own erased boundary), so both the mismatched-arity
+        // and rest cases fall back to the erased path, which mirrors JavaScript's
+        // argument-forwarding semantics through the dynamic ABI.
+        if callback_fn.rest.is_some() || extras.len() != callback_fn.params.len() {
+            return None;
+        }
+
+        // Every extra argument must carry a concrete static type. An `unknown`
+        // extra is a real dynamic boundary and must stay in the erased list.
+        let extra_tys = extras
+            .iter()
+            .map(|&extra| Self::expr_ty(body, extra))
+            .collect::<Vec<_>>();
+        if extra_tys
+            .iter()
+            .any(|&ty| self.type_contains_unknown(ty))
+        {
+            return None;
+        }
+
+        // Bind the callback and each extra to fresh outer-body locals so the
+        // wrapper can capture them by value from stable capture sources.
+        let callback_local = self.bind_timer_capture_local(callback, callback_ty, "smelt_timer_callback", span, body);
+        let extra_locals = extras
+            .iter()
+            .zip(&extra_tys)
+            .enumerate()
+            .map(|(index, (&extra, &ty))| {
+                self.bind_timer_capture_local(
+                    extra,
+                    ty,
+                    &format!("smelt_timer_arg_{index}"),
+                    span,
+                    body,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        // Build the wrapper body: a zero-parameter closure whose captures are the
+        // callback and the extra values, and whose tail calls the callback with
+        // the captured extras.
+        let none_ty = self.ctx.krate.types.intern(Type::None);
+        let mut closure_body = Body::new(None, span);
+
+        let callback_symbol = self.ctx.krate.symbols.intern("smelt_timer_callback");
+        let callback_body_local = closure_body.push_local(LocalDecl {
+            name: Some(callback_symbol),
+            ty: callback_ty,
+            mutable: false,
+            span,
+        });
+        let mut captures = vec![ClosureCapture {
+            source_local: callback_local,
+            body_local: Some(callback_body_local),
+            symbol: callback_symbol,
+            ty: callback_ty,
+            mode: CaptureMode::ByValue,
+        }];
+
+        let mut arg_exprs = Vec::with_capacity(extra_locals.len());
+        for (index, (&source_local, &ty)) in extra_locals.iter().zip(&extra_tys).enumerate() {
+            let symbol = self
+                .ctx
+                .krate
+                .symbols
+                .intern(&format!("smelt_timer_arg_{index}"));
+            let body_local = closure_body.push_local(LocalDecl {
+                name: Some(symbol),
+                ty,
+                mutable: false,
+                span,
+            });
+            captures.push(ClosureCapture {
+                source_local,
+                body_local: Some(body_local),
+                symbol,
+                ty,
+                mode: CaptureMode::ByValue,
+            });
+            arg_exprs.push(closure_body.push_expr(Expr {
+                kind: ExprKind::Local(body_local),
+                ty,
+                span,
+            }));
+        }
+
+        let callee_expr = closure_body.push_expr(Expr {
+            kind: ExprKind::Local(callback_body_local),
+            ty: callback_ty,
+            span,
+        });
+        let call_expr = closure_body.push_expr(Expr {
+            kind: ExprKind::ClosureCall {
+                callee: callee_expr,
+                args: arg_exprs,
+            },
+            ty: callback_fn.return_ty,
+            span,
+        });
+        if let Some(root) = closure_body.blocks.first_mut() {
+            root.tail = Some(call_expr);
+        }
+        let body_id = self.ctx.krate.push_body(closure_body);
+
+        let wrapper_fn = FunctionType {
+            params: Vec::new(),
+            rest: None,
+            required_params: Some(0),
+            mutable_params: Vec::new(),
+            return_ty: none_ty,
+            is_async: false,
+            may_throw: callback_fn.may_throw,
+        };
+        let wrapper_ty = self.ctx.krate.types.intern(Type::Function(wrapper_fn));
+
+        Some(body.push_expr(Expr {
+            kind: ExprKind::Closure(ClosureExpr {
+                params: Vec::new(),
+                rest: None,
+                required_params: Some(0),
+                return_ty: none_ty,
+                captures,
+                body: body_id,
+                function_item: None,
+                span,
+            }),
+            ty: wrapper_ty,
+            span,
+        }))
+    }
+
+    /// Bind a lowered value expression to a fresh immutable outer-body local.
+    ///
+    /// The synthesized wrapper closure captures its callback and extra arguments
+    /// from body locals, so each value is first stored in its own `let` binding
+    /// that becomes the capture source.
+    fn bind_timer_capture_local(
+        &mut self,
+        value: smelt_hir::ExprId,
+        ty: smelt_hir::TypeId,
+        name: &str,
+        span: Span,
+        body: &mut Body,
+    ) -> smelt_hir::LocalId {
+        let symbol = self.ctx.krate.symbols.intern(name);
+        let local = body.push_local(LocalDecl {
+            name: Some(symbol),
+            ty,
+            mutable: false,
+            span,
+        });
+        let pat = body.push_pattern(Pattern::Binding(local));
+        body.push_stmt(Stmt::Let {
+            pat,
+            ty,
+            value: Some(value),
+        });
+        local
+    }
+}

--- a/crates/smelt-frontend-ts/src/lowering/guards.rs
+++ b/crates/smelt-frontend-ts/src/lowering/guards.rs
@@ -1651,25 +1651,71 @@ impl ModuleBuilder<'_> {
             }
             // `setTimeout(callback, ms, ...args)` / `setInterval(callback, ms,
             // ...args)` forward the extra arguments to the callback when the
-            // timer fires. The extras (including source spreads) pack into one
-            // erased list operand; the emitter passes it through the dynamic
-            // callback ABI.
+            // timer fires.
+            //
+            // When the callback is a statically typed function and every extra is
+            // a concretely typed positional argument (no source spread), the
+            // extras are captured by a synthesized zero-argument wrapper closure
+            // that calls the callback directly — no erased `Vec<SmeltUnknown>` is
+            // produced. A source spread or an untyped extra is a genuine dynamic
+            // boundary, so those keep the erased-list path where the extras pack
+            // into one operand dispatched through the dynamic callback ABI.
             "setTimeout" | "setInterval" if call.arguments.len() >= 3 => {
                 let callback = self.argument(&call.arguments[0], body)?;
                 let duration = self.argument(&call.arguments[1], body)?;
                 let unknown_ty = self.ctx.krate.types.intern(Type::Unknown);
                 let span = self.span(call.span.start, call.span.end);
+                let op = if callee.name == "setTimeout" {
+                    AsyncOp::SetTimeout
+                } else {
+                    AsyncOp::SetInterval
+                };
+
+                let has_spread = call.arguments[2..]
+                    .iter()
+                    .any(|arg| matches!(arg, Argument::SpreadElement(_)));
+                if !has_spread {
+                    // Lower each extra exactly once. Either the typed wrapper
+                    // consumes them, or they pack into the erased list below —
+                    // never both, so source side effects run once.
+                    let extras = call.arguments[2..]
+                        .iter()
+                        .map(|arg| self.argument(arg, body))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    if let Some(wrapper) =
+                        self.timer_typed_wrapper_closure(callback, &extras, span, body)
+                    {
+                        return Ok(Some(body.push_expr(Expr {
+                            kind: ExprKind::AsyncOp {
+                                op,
+                                args: vec![wrapper, duration],
+                            },
+                            ty: unknown_ty,
+                            span,
+                        })));
+                    }
+                    let list_ty = self.ctx.krate.types.intern(Type::List(unknown_ty));
+                    let extra = body.push_expr(Expr {
+                        kind: ExprKind::ListLit(extras),
+                        ty: list_ty,
+                        span,
+                    });
+                    return Ok(Some(body.push_expr(Expr {
+                        kind: ExprKind::AsyncOp {
+                            op,
+                            args: vec![callback, duration, extra],
+                        },
+                        ty: unknown_ty,
+                        span,
+                    })));
+                }
+
                 let extra = self.packed_spread_arguments(
                     unknown_ty,
                     &call.arguments[2..],
                     span,
                     body,
                 )?;
-                let op = if callee.name == "setTimeout" {
-                    AsyncOp::SetTimeout
-                } else {
-                    AsyncOp::SetInterval
-                };
                 Ok(Some(body.push_expr(Expr {
                     kind: ExprKind::AsyncOp {
                         op,

--- a/crates/smelt-hir/src/format/call.rs
+++ b/crates/smelt-hir/src/format/call.rs
@@ -469,7 +469,7 @@ pub(super) fn expr_text(krate: &Crate, expr: &Expr) -> String {
             format!(
                 "list_reduce {}, {}, {}",
                 expr_ref(*list),
-                initial.map(expr_ref).unwrap_or_else(|| "_".to_owned()),
+                initial.map_or_else(|| "_".to_owned(), expr_ref),
                 expr_ref(*callback)
             )
         }


### PR DESCRIPTION
Closes #52

## Summary

Follow-up to PR #47 (SmeltUnknown removal wave). `setTimeout(callback, ms, ...args)` and `setInterval(callback, ms, ...args)` previously packed every extra argument into one erased `Vec<SmeltUnknown>` and dispatched the callback through the dynamic `SmeltUnknown` callable ABI — even when the callback and its extras were already statically typed.

This change synthesizes a typed **zero-argument wrapper closure** for the statically-typed case:

- New frontend module `crates/smelt-frontend-ts/src/lowering/callbacks/timer_wrapper.rs` builds an HIR `Closure` `move || callback(arg0, arg1, …)` that captures the callback and each typed extra **by value** and calls the callback directly via `ClosureCall`.
- `timer_call` in `guards.rs` tries the wrapper for the 3+-argument `setTimeout`/`setInterval` shapes; the emitter's existing zero-parameter direct-call fast path then runs it. No `Vec<SmeltUnknown>` and no dynamic dispatch are emitted for typed timers.
- The erased path is preserved for genuine dynamic boundaries: a source spread (`...args`), any `unknown`-typed extra, a callback whose value type is not a statically known function, a rest-parameter callback, or an argument count that does not match the callback signature exactly. The exact-arity requirement avoids the wrapper having to synthesize omitted-optional values (a Rust typed default does not match JavaScript's `undefined`) and keeps the change conservative.

Captures are set to `ByValue` at construction because a timer wrapper is stored in the timer registry and invoked after the enclosing function returns; MIR escape analysis only promotes closures reachable from a `return`, so it would not promote a wrapper that escapes through a runtime async-op argument.

## Acceptance criteria

- ✅ Typed timer extra arguments generate no `Vec<SmeltUnknown>` — each extra is a concrete per-argument binding captured by the wrapper.
- ✅ Callback identity/ownership and timer behavior remain correct — the callback is captured by value once and invoked directly; interval re-arm and `clearInterval` still work.
- ✅ Reuses the same path for `setInterval`.
- ✅ Generated-Rust compile and runtime tests for multiple and optional arguments (both `setTimeout` and `setInterval`).

## Tests

- Golden shape tests in `crates/smelt-codegen-rust/src/tests/part_7_tests.rs`: typed multiple-arg `setTimeout` and `setInterval` use the wrapper (no `smelt_timer_args` erased pack); optional-arg case; untyped extra keeps the erased path.
- Compile tests in `crates/smelt-codegen-rust/tests/compile_corpus.rs` (`timers` area): multiple typed args + `setInterval`, and optional-typed-arg shapes (run via `--ignored`).
- Runtime tests in a new `crates/smelt-codegen-rust/tests/timer_runtime.rs` (run via `--ignored`): each fixture is a generated Vitest `#[tokio::test]` that schedules a timer with typed extras, drives the virtual-time loop with `await delay(...)`, and asserts the forwarded values — covering multiple args, an optional arg, and `setInterval` fire/clear.

## Remaining work / notes

- The wrapper is intentionally conservative: rest-parameter callbacks, mismatched argument counts (omitted optionals or surplus args), and `unknown`-typed extras still take the erased path. Note that the erased path is itself pre-existing and does **not** currently compile when the callback is a *typed* function value (it assumes `SmeltUnknown::Function`); this change fixes the common exact-arity typed case and leaves that pre-existing erased-path/typed-callback gap for follow-up. Extending typed forwarding to omitted-optional and rest cases (forwarding `min(extras, params)` and packing a typed `Vec<T>` rest) is the natural next step.
- Runtime fixtures are driven by Vitest tests rather than a program `main`, because a user-defined `async function main` currently mis-emits (double `main` / `Result` return) — a pre-existing codegen gap unrelated to this change.
- Included one incidental pre-existing clippy fix in `crates/smelt-hir/src/format/call.rs` (`map(..).unwrap_or_else(..)` → `map_or_else`) so the clippy gate is green; it is behavior-identical debug formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
