### PR TITLE
type system: model callable-object fields and typed constructor slots

### DIFF
--- a/crates/smelt-cli/src/lowering.rs
+++ b/crates/smelt-cli/src/lowering.rs
@@ -102,6 +102,8 @@ struct FrontendLoweringState {
     ts_interface_index_values: HashMap<smelt_hir::Symbol, smelt_hir::TypeId>,
     /// TypeScript interface call signatures visible across manifest entries.
     ts_interface_call_signatures: HashMap<smelt_hir::Symbol, Vec<smelt_hir::FunctionType>>,
+    /// TypeScript interface construct signatures visible across manifest entries.
+    ts_interface_construct_signatures: HashMap<smelt_hir::Symbol, Vec<smelt_hir::FunctionType>>,
     /// TypeScript callable intersection fields visible across manifest entries.
     ts_callable_fields: HashMap<smelt_hir::TypeId, Vec<smelt_hir::Field>>,
     /// TypeScript aliases whose source surface is a callable object intersection.
@@ -654,6 +656,7 @@ fn lower_manifest_source(
                 interface_extends: state.ts_interface_extends,
                 interface_index_values: state.ts_interface_index_values,
                 interface_call_signatures: state.ts_interface_call_signatures,
+                interface_construct_signatures: state.ts_interface_construct_signatures,
                 callable_fields: state.ts_callable_fields,
                 callable_object_aliases: state.ts_callable_object_aliases,
             };
@@ -688,6 +691,7 @@ fn lower_manifest_source(
                 ts_interface_extends: ctx.interface_extends,
                 ts_interface_index_values: ctx.interface_index_values,
                 ts_interface_call_signatures: ctx.interface_call_signatures,
+                ts_interface_construct_signatures: ctx.interface_construct_signatures,
                 ts_callable_fields: ctx.callable_fields,
                 ts_callable_object_aliases: ctx.callable_object_aliases,
                 py_module_namespaces: state.py_module_namespaces,
@@ -732,6 +736,7 @@ fn lower_manifest_source(
                 ts_interface_extends: state.ts_interface_extends,
                 ts_interface_index_values: state.ts_interface_index_values,
                 ts_interface_call_signatures: state.ts_interface_call_signatures,
+                ts_interface_construct_signatures: state.ts_interface_construct_signatures,
                 ts_callable_fields: state.ts_callable_fields,
                 ts_callable_object_aliases: state.ts_callable_object_aliases,
                 py_module_namespaces: ctx.module_namespaces,

--- a/crates/smelt-cli/tests/hir_cli_typescript_tests.rs
+++ b/crates/smelt-cli/tests/hir_cli_typescript_tests.rs
@@ -1070,3 +1070,59 @@ clone-strategy = "aggressive"
 
     Ok(())
 }
+
+#[test]
+fn build_runs_construct_signature_slot_construction() -> TestResult {
+    // A constructor-only interface (`interface CounterConstructor { new ():
+    // Counter }`) is a typed constructor slot. A class value passed where the
+    // slot is expected is adapted into a constructor closure, and `new ctor()`
+    // constructs the concrete `Counter` — the generated Rust must compile and
+    // run, keeping the concrete constructed type end to end (issue #54).
+    let project = TempProject::new()?;
+    let project_path = project.path();
+    fs::create_dir_all(project_path.join("src"))?;
+    fs::write(
+        project_path.join("Smelt.toml"),
+        r#"[project]
+name = "construct-slot"
+version = "0.1.0"
+
+[sources]
+entries = ["src/main.ts"]
+
+[output]
+target = "./dist"
+crate-name = "construct_slot"
+build = true
+
+[runtime]
+clone-strategy = "aggressive"
+"#,
+    )?;
+    fs::write(
+        project_path.join("src/main.ts"),
+        r#"class Counter {
+  value: number = 7;
+}
+
+interface CounterConstructor {
+  new (): Counter;
+}
+
+function make(ctor: CounterConstructor): Counter {
+  return new ctor();
+}
+
+const counter = make(Counter);
+console.log(counter.value);
+"#,
+    )?;
+
+    let manifest_arg = utf8_path(&project_path.join("Smelt.toml"))?;
+    smelt(&["--manifest-path", &manifest_arg, "build"])?;
+
+    let actual_stdout = cargo_run_manifest(&project_path.join("dist/Cargo.toml"))?;
+    ensure_eq(&actual_stdout, &"7\n".to_owned(), "unexpected stdout")?;
+
+    Ok(())
+}

--- a/crates/smelt-frontend-ts/src/context.rs
+++ b/crates/smelt-frontend-ts/src/context.rs
@@ -116,6 +116,8 @@ pub struct HirCtx {
     pub interface_index_values: HashMap<smelt_hir::Symbol, TypeId>,
     /// Interface call signatures visible to later modules.
     pub interface_call_signatures: HashMap<smelt_hir::Symbol, Vec<FunctionType>>,
+    /// Interface construct signatures (`new (): T`) visible to later modules.
+    pub interface_construct_signatures: HashMap<smelt_hir::Symbol, Vec<FunctionType>>,
     /// Structural fields attached to callable intersection types.
     pub callable_fields: HashMap<TypeId, Vec<Field>>,
     /// Type aliases whose source surface is a callable object intersection.
@@ -141,6 +143,7 @@ impl HirCtx {
             interface_extends: HashMap::new(),
             interface_index_values: HashMap::new(),
             interface_call_signatures: HashMap::new(),
+            interface_construct_signatures: HashMap::new(),
             callable_fields: HashMap::new(),
             callable_object_aliases: HashSet::new(),
         }

--- a/crates/smelt-frontend-ts/src/lowering.rs
+++ b/crates/smelt-frontend-ts/src/lowering.rs
@@ -383,6 +383,15 @@ struct ModuleBuilder<'ctx> {
     interface_index_values: HashMap<smelt_hir::Symbol, smelt_hir::TypeId>,
     /// Interface call signatures for callable interface types.
     interface_call_signatures: HashMap<smelt_hir::Symbol, Vec<FunctionType>>,
+    /// Interface construct signatures (`new (): T`) for constructor-slot types.
+    ///
+    /// A constructor-interface such as `interface MapCacheConstructor { new
+    /// (): MapCache }` is, at runtime, an ordinary callable value: `new
+    /// value()` invokes it to produce the constructed type. Each construct
+    /// signature is stored as the equivalent [`FunctionType`] (its parameters
+    /// and constructed return type) so a reference to the interface can lower to
+    /// a typed constructor slot instead of an erased dictionary.
+    interface_construct_signatures: HashMap<smelt_hir::Symbol, Vec<FunctionType>>,
     /// Fields attached to callable intersection types.
     callable_fields: HashMap<smelt_hir::TypeId, Vec<Field>>,
     /// Type aliases whose source surface is a callable object intersection.

--- a/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
@@ -71,6 +71,7 @@ impl ModuleBuilder<'_> {
         let mut fields = Vec::new();
         let mut methods = Vec::new();
         let mut call_signatures = Vec::new();
+        let mut construct_signatures = Vec::new();
         let mut index_value_ty = None;
 
         let mut heritage_refs = Vec::new();
@@ -270,7 +271,52 @@ return_ty,
                         index_value_ty =
                             Some(self.ts_type_to_hir(&index.type_annotation.type_annotation)?);
                     }
-                    TSSignature::TSConstructSignatureDeclaration(_) => {}
+                    TSSignature::TSConstructSignatureDeclaration(signature) => {
+                        // A construct signature `new (args): T` is, at runtime,
+                        // an ordinary callable value: `new value(args)` invokes
+                        // it to produce a `T`. Lower it to the same
+                        // `FunctionType` a `new (args) => T` constructor-type
+                        // annotation produces, so a reference to this interface
+                        // can resolve to a typed constructor slot (a
+                        // `Type::Function`) instead of an erased dictionary. Its
+                        // own type parameters are scoped so generic construct
+                        // signatures resolve their parameters.
+                        let _construct_type_params = self
+                            .push_type_parameter_scope(signature.type_parameters.as_deref())?;
+                        let result = (|| {
+                            let return_ty = signature
+                                .return_type
+                                .as_ref()
+                                .map(|annotation| self.ts_type_to_hir(&annotation.type_annotation))
+                                .transpose()?
+                                .unwrap_or_else(|| self.ctx.krate.types.intern(Type::Unknown));
+                            let mut params = Vec::new();
+                            for param in &signature.params.items {
+                                let ty = param
+                                    .type_annotation
+                                    .as_ref()
+                                    .map(|annotation| {
+                                        self.ts_type_to_hir(&annotation.type_annotation)
+                                    })
+                                    .transpose()?
+                                    .unwrap_or_else(|| self.ctx.krate.types.intern(Type::Unknown));
+                                params.push(ty);
+                            }
+                            Ok::<_, SmeltError>((return_ty, params))
+                        })();
+                        self.pop_type_parameter_scope();
+                        let (return_ty, params) = result?;
+                        construct_signatures.push(FunctionType {
+                            mutable_params: self
+                                .mutable_params_from_returned_tuple_state(&params, return_ty),
+                            params,
+                            rest: None,
+                            required_params: None,
+                            return_ty,
+                            is_async: false,
+                            may_throw: false,
+                        });
+                    }
                 }
             }
             Ok(())
@@ -309,6 +355,13 @@ return_ty,
         self.ctx
             .interface_call_signatures
             .insert(name, call_signatures);
+        if !construct_signatures.is_empty() {
+            self.interface_construct_signatures
+                .insert(name, construct_signatures.clone());
+            self.ctx
+                .interface_construct_signatures
+                .insert(name, construct_signatures);
+        }
         if let Some(index_value_ty) = index_value_ty {
             self.interface_index_values.insert(name, index_value_ty);
             self.ctx.interface_index_values.insert(name, index_value_ty);

--- a/crates/smelt-frontend-ts/src/lowering/module_init.rs
+++ b/crates/smelt-frontend-ts/src/lowering/module_init.rs
@@ -47,6 +47,7 @@ impl<'ctx> ModuleBuilder<'ctx> {
         let interface_extends = ctx.interface_extends.clone();
         let interface_index_values = ctx.interface_index_values.clone();
         let interface_call_signatures = ctx.interface_call_signatures.clone();
+        let interface_construct_signatures = ctx.interface_construct_signatures.clone();
         let callable_fields = ctx.callable_fields.clone();
         let callable_object_aliases = ctx.callable_object_aliases.clone();
         let allow_unknown_index_access = Self::is_declaration_type_test_path(&path);
@@ -69,6 +70,7 @@ impl<'ctx> ModuleBuilder<'ctx> {
             interface_extends,
             interface_index_values,
             interface_call_signatures,
+            interface_construct_signatures,
             callable_fields,
             callable_object_aliases,
             type_namespace_prefix: Vec::new(),

--- a/crates/smelt-frontend-ts/src/lowering/new_expr.rs
+++ b/crates/smelt-frontend-ts/src/lowering/new_expr.rs
@@ -38,6 +38,18 @@ impl ModuleBuilder<'_> {
                 return Ok(expr);
             }
             if let Expression::StaticMemberExpression(member) = &new_expr.callee {
+                // `new memoize.Cache()` where the member resolves to a typed
+                // constructor slot (a `Type::Function` produced from a construct
+                // signature, e.g. `Cache: new () => MapCache`). The member is a
+                // callable value, so the construction is an ordinary indirect
+                // call through it, typed by the constructor's declared return
+                // type — the constructed value keeps its concrete shape instead
+                // of erasing to `unknown` (issue #54). This mirrors the
+                // identifier value-callee path in `new_through_value_expression`.
+                if let Some(expr) = self.new_through_member_constructor_slot(new_expr, member, body)?
+                {
+                    return Ok(expr);
+                }
                 let class_name = self.intern_type_name(member.property.name.as_str());
                 let args = new_expr
                     .arguments
@@ -383,6 +395,64 @@ impl ModuleBuilder<'_> {
             },
             ty: function.return_ty,
             span: self.span(new_expr.span.start, new_expr.span.end),
+        })))
+    }
+
+    /// Lower `new receiver.member(args)` when `receiver.member` resolves to a
+    /// typed constructor slot, returning `None` so the caller falls through to
+    /// the nested-class construction path otherwise.
+    ///
+    /// A member such as `memoize.Cache` typed with a construct signature
+    /// (`Cache: new () => MapCache`) lowers to a `Type::Function` (see
+    /// `interface_construct_slot_type`). Because JavaScript classes *are*
+    /// constructor functions, `new memoize.Cache()` is just an indirect call
+    /// through that callable value: it reuses the `ExprKind::ClosureCall` path a
+    /// plain `memoize.Cache()` call takes, typed by the constructor's declared
+    /// return type. Only a concrete callable slot is intercepted; a member that
+    /// is not a `Type::Function` (a nested class name, a dynamic bag) is left to
+    /// the existing member-`new` handling so its behavior is unchanged.
+    pub(super) fn new_through_member_constructor_slot(
+        &mut self,
+        new_expr: &oxc::ast::ast::NewExpression<'_>,
+        member: &oxc::ast::ast::StaticMemberExpression<'_>,
+        body: &mut Body,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        // Lower the receiver object once and resolve the member's field type. A
+        // constructor slot is a `Type::Function`; anything else (a nested class
+        // name, a dynamic bag) is not intercepted, so `body` still holds the
+        // lowered receiver but the caller's fallback ignores it — the receiver
+        // of `new Foo.Bar()` is a pure name read with no observable effect.
+        let receiver_value = self.expression(&member.object, body)?;
+        let receiver_ty = Self::expr_ty(body, receiver_value);
+        let field_symbol = self.intern_source_name(member.property.name.as_str());
+        let Ok(member_ty) = self.class_field_type(receiver_ty, field_symbol) else {
+            return Ok(None);
+        };
+        let Some(Type::Function(function)) = self.ctx.krate.types.get(member_ty).cloned() else {
+            return Ok(None);
+        };
+        let span = self.span(new_expr.span.start, new_expr.span.end);
+        let callee_value = body.push_expr(Expr {
+            kind: ExprKind::Field {
+                receiver: receiver_value,
+                field: field_symbol,
+            },
+            ty: member_ty,
+            span,
+        });
+        let args = new_expr
+            .arguments
+            .iter()
+            .take(function.params.len())
+            .map(|arg| self.argument(arg, body))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Some(body.push_expr(Expr {
+            kind: ExprKind::ClosureCall {
+                callee: callee_value,
+                args,
+            },
+            ty: function.return_ty,
+            span,
         })))
     }
 

--- a/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
@@ -1466,6 +1466,19 @@ return_ty: function.return_ty,
                         &lowered_args,
                         self.span(reference.span.start, reference.span.end),
                     )?;
+                    // A constructor-only interface such as `interface
+                    // MapCacheConstructor { new (): MapCache }` is a typed
+                    // constructor slot, not a data record: it carries only a
+                    // construct signature. Lower it to that constructor's
+                    // `Type::Function` so a value of the interface type flows
+                    // through the closure / `new value()` machinery and the
+                    // construction keeps the concrete constructed type instead of
+                    // erasing to `unknown` (issue #54).
+                    if let Some(function_ty) =
+                        self.interface_construct_slot_type(symbol, &substitutions)
+                    {
+                        return Ok(function_ty);
+                    }
                     let instantiated_args = interface
                         .type_params
                         .iter()
@@ -1544,6 +1557,60 @@ return_ty: function.return_ty,
                 }))
             }
         }
+    }
+
+    /// Lower a constructor-only interface to its typed constructor slot.
+    ///
+    /// A constructor-only interface (`interface MapCacheConstructor { new ():
+    /// MapCache }`) carries a construct signature and no data fields or call
+    /// signatures. At runtime it is an ordinary callable value that `new
+    /// value()` invokes to produce the constructed type, so the honest lowering
+    /// is the constructor's [`Type::Function`] — exactly the shape a `new (args)
+    /// => T` constructor-type annotation lowers to (see `constructor_type_to_hir`).
+    /// Type arguments already resolved for the reference are substituted into the
+    /// signature so generic constructor slots keep their instantiated parameter
+    /// and constructed types.
+    ///
+    /// Returns `None` when the interface is not a pure constructor slot (it has
+    /// data fields, method fields, or call signatures), so a mixed
+    /// callable-object interface still lowers as a class record and its member
+    /// lookups are unaffected.
+    pub(in crate::lowering) fn interface_construct_slot_type(
+        &mut self,
+        name: smelt_hir::Symbol,
+        substitutions: &HashMap<smelt_hir::Symbol, smelt_hir::TypeId>,
+    ) -> Option<smelt_hir::TypeId> {
+        let signatures = self.interface_construct_signatures.get(&name).cloned()?;
+        let signature = signatures.first()?;
+        // Only a *pure* constructor slot lowers to a callable: an interface that
+        // also carries data/method fields or a call signature is a mixed
+        // callable-object surface, which stays a class record here.
+        let has_other_members = self
+            .find_interface(name)
+            .is_some_and(|interface| !interface.fields.is_empty())
+            || self
+                .interface_call_signatures
+                .get(&name)
+                .is_some_and(|call_sigs| !call_sigs.is_empty());
+        if has_other_members {
+            return None;
+        }
+        let params = signature
+            .params
+            .iter()
+            .map(|param| self.substitute_type_params(*param, substitutions))
+            .collect::<Vec<_>>();
+        let return_ty = self.substitute_type_params(signature.return_ty, substitutions);
+        let mutable_params = self.mutable_params_from_returned_tuple_state(&params, return_ty);
+        Some(self.ctx.krate.types.intern(Type::Function(FunctionType {
+            params,
+            rest: signature.rest,
+            required_params: signature.required_params,
+            mutable_params,
+            return_ty,
+            is_async: false,
+            may_throw: false,
+        })))
     }
 
     /// Return the full source path for a qualified type name.

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -7222,3 +7222,155 @@ export const boom = makeError(TypeError, "boom");
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
     Ok(())
 }
+
+/// Return whether any expression in the crate is typed as `Type::Class` with
+/// the given class name, used to assert a construction kept a concrete result.
+fn any_expr_is_class(ctx: &HirCtx, class_name: &str) -> bool {
+    ctx.krate
+        .bodies
+        .iter()
+        .flat_map(|body| body.exprs.iter())
+        .any(|expr| {
+            matches!(
+                ctx.krate.types.get(expr.ty),
+                Some(Type::Class { name, .. }) if ctx.krate.symbols.get(*name) == Some(class_name)
+            )
+        })
+}
+
+#[test]
+fn lowers_construct_signature_interface_to_constructor_slot() -> Result<(), String> {
+    // A constructor-only interface (`interface C { new (): T }`) is a typed
+    // constructor slot: a value of that type lowers to a callable `Type::Function`
+    // whose return type is the constructed type, not an erased dictionary.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+interface MapCache {
+  size: number;
+}
+
+interface MapCacheConstructor {
+  new (): MapCache;
+}
+
+function make(ctor: MapCacheConstructor): MapCache {
+  return new ctor();
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        any_expr_is_class(&ctx, "MapCache"),
+        "expected a MapCache-typed construction from a constructor-slot parameter"
+    );
+    ensure!(
+        ctx.krate
+            .bodies
+            .iter()
+            .flat_map(|body| body.exprs.iter())
+            .any(|expr| matches!(expr.kind, ExprKind::ClosureCall { .. }))
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_callable_object_construct_signature_field() -> Result<(), String> {
+    // The `memoize.Cache`-style shape: `memoize` is a callable interface value
+    // that also carries a `Cache` field whose type is a construct-signature
+    // interface. `new memoize.Cache()` must construct the concrete `MapCache`.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+interface MapCache {
+  size: number;
+}
+
+interface MapCacheConstructor {
+  new (): MapCache;
+}
+
+interface Memoize {
+  <T>(func: T): T;
+  Cache: MapCacheConstructor;
+}
+
+declare const memoize: Memoize;
+
+export const cache = new memoize.Cache();
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        any_expr_is_class(&ctx, "MapCache"),
+        "expected `new memoize.Cache()` to produce a concrete MapCache"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn preserves_construct_slot_through_type_alias() -> Result<(), String> {
+    // A type alias for a constructor-only interface must preserve the
+    // constructor slot so assignments and `new` keep the constructed type.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+interface MapCache {
+  size: number;
+}
+
+interface MapCacheConstructor {
+  new (): MapCache;
+}
+
+type CacheCtor = MapCacheConstructor;
+
+function build(ctor: CacheCtor): MapCache {
+  const local: CacheCtor = ctor;
+  return new local();
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        any_expr_is_class(&ctx, "MapCache"),
+        "expected the alias to preserve the constructor slot"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_parameterized_construct_signature_return() -> Result<(), String> {
+    // A generic construct signature keeps its constructed return type through
+    // the reference: `new (): Box<number>` constructs a concrete `Box`.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+interface Box<T> {
+  value: T;
+}
+
+interface BoxConstructor {
+  new (): Box<number>;
+}
+
+function make(ctor: BoxConstructor): Box<number> {
+  return new ctor();
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        any_expr_is_class(&ctx, "Box"),
+        "expected a Box-typed construction from a generic construct signature"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}


### PR DESCRIPTION
Closes #54

Follow-up to PR #47's SmeltUnknown-removal wave. Patterns such as `memoize.Cache`
combine a callable value with object fields, including constructor-interface
fields like `new (): MapCache`. Dynamic `new` previously fell through erased
`unknown` slots when those fields lost their function/constructor shape.

## What changed
- **Construct signatures become typed constructor slots.** Interface `new (): T`
  construct signatures are captured into a new `interface_construct_signatures`
  map (mirroring the existing `interface_call_signatures`), stored on the
  frontend builder and `HirCtx`, and threaded across CLI manifest entries.
- **Constructor-only interfaces lower to a callable.** A reference to a *pure*
  constructor-only interface (`interface MapCacheConstructor { new (): MapCache }`)
  lowers to that constructor's `Type::Function` (parameters + constructed return
  type) instead of an erased dict — so a value of the type is a real callable
  slot. Type arguments are substituted, so generic constructor slots keep their
  instantiated parameter/return types. Mixed callable-object interfaces (with
  data/method fields or a call signature) still lower as class records; their
  member lookups are unchanged.
- **Dynamic-new erasure removed when the result is statically known.**
  `new receiver.member(args)` now routes through the constructor slot when the
  member resolves to a `Type::Function`, reusing the `ClosureCall` path a plain
  `receiver.member()` call takes and typing the result by the constructor's
  return type. Nested-class `new Foo.Bar()` behavior is preserved (only a
  concrete callable slot is intercepted).

## Acceptance criteria
- `memoize.Cache`-style assignment and construction use a concrete `MapCache`
  result — met (frontend test `lowers_callable_object_construct_signature_field`).
- Callable-object constructor fields survive HIR/MIR lowering without
  `SmeltUnknown` — met: constructor slots are concrete `Type::Function` values;
  no new `Type::Unknown`/`UnknownCast` is introduced on these paths.
- Interface, alias, assignment, and generated-Rust compile tests added:
  - `lowers_construct_signature_interface_to_constructor_slot`
  - `lowers_callable_object_construct_signature_field`
  - `preserves_construct_slot_through_type_alias`
  - `lowers_parameterized_construct_signature_return`
  - `build_runs_construct_signature_slot_construction` (end-to-end: builds a
    project, compiles the generated Rust, runs it, and asserts the concrete
    constructed field prints).

## Testing
- `cargo check` clean; `cargo clippy` introduces no new findings from these
  changes (pre-existing crate-level lints in `smelt-frontend-py` are unrelated).
- `cargo test`: `smelt-frontend-ts` 700 tests green (696 prior + 4 new); the
  full `smelt-cli` `hir_cli_typescript_tests` suite is green (21/21) when run
  serially. One pre-existing decorator-caching test can flake under parallel
  execution due to shared `dist`/target build contention; it passes in
  isolation and serially and is unrelated to this change.

## Remaining work / scope notes
- This targets the *named-interface* constructor-slot shape (how lodash-style
  typings spell `memoize.Cache`). Inline object-type literals with a construct
  signature (`{ new (): T }` written directly at a use site) still lower to a
  dict; extending `type_literal_fields`/`type_literal_to_hir` to emit
  construct/call signatures as function-typed fields is a natural follow-up.
- Interfaces that are *both* callable and constructable (a call signature plus a
  construct signature) intentionally stay class records here to avoid regressing
  existing call-signature handling; picking the construct vs call slot per use
  site is left for a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)