### PR TITLE
fix(callbacks): lower method calls into synthesized closure bodies (#64)

### DIFF
--- a/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
@@ -967,3 +967,42 @@ const asBool = Boolean("");
     assert!(!source.contains("float() parse failed"));
     assert!(source.contains(".is_empty()"));
 }
+
+#[test]
+fn emits_captured_class_method_call_inside_map_callback() {
+    // Issue #64: a captured class instance whose method is called inside a
+    // `.map()` callback body must lower into the synthesized closure and emit
+    // valid Rust. The compact callback IR does not model this call shape when
+    // the method body is non-trivial, so it routes through the closure-body
+    // fallback; the whole HIR -> MIR -> Rust pipeline must still succeed (any
+    // failure panics inside `source_for`). The emitted closure captures the
+    // receiver and dispatches the method with the callback's element argument.
+    let source = source_for(
+        r#"
+class Counter {
+  base: number;
+  constructor(b: number) {
+    this.base = b;
+  }
+  scaled(x: number): number {
+    const factor = this.base;
+    return x * factor;
+  }
+}
+
+export function scaleAll(xs: number[]): number[] {
+  const c = new Counter(2);
+  return xs.map((x) => c.scaled(x));
+}
+"#,
+    );
+
+    assert!(
+        source.contains(".scaled("),
+        "captured class method call did not survive callback lowering: {source}"
+    );
+    assert!(
+        source.contains(".map("),
+        "array map iteration was dropped: {source}"
+    );
+}

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/body_lowering.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/body_lowering.rs
@@ -1307,7 +1307,18 @@ impl ModuleBuilder<'_> {
                             .as_ref()
                             .and_then(|function| function.rest)
                     });
-                return self.callback_expr_to_closure_with_return_ty(
+                // The callback tree classified into the compact side-effect-free
+                // expression IR, but the compact IR only lowers a bounded method
+                // table (`.map`/`.at`/`Set.has`/...). A statically-resolvable
+                // method call it does not model (`controller.abort()`,
+                // `date.getTime()`, `text.localeCompare(other)`, a captured class
+                // instance method, ...) is rejected here with a "closure body"
+                // error even though the general expression path knows how to
+                // dispatch it. When that happens, fall through to the full
+                // closure-body lowering below, which routes the arrow body through
+                // `expression`/`statement` (the same path a non-callback method
+                // call uses) instead of surfacing the blocker.
+                match self.callback_expr_to_closure_with_return_ty(
                     return_ty,
                     &callback,
                     &params,
@@ -1317,7 +1328,17 @@ impl ModuleBuilder<'_> {
                         .and_then(|function| function.required_params),
                     span,
                     body,
-                );
+                ) {
+                    Ok(expr) => return Ok(expr),
+                    Err(error) if Self::should_fallback_to_closure_body_for_callback(&error) => {
+                        // Recoverable compact-IR gap: retry through the general
+                        // closure-body path, preserving the compact path's
+                        // resolved return type so the closure keeps its typed
+                        // signature.
+                        return self.arrow_closure_body_expr(arrow, &params, return_ty, body);
+                    }
+                    Err(error) => return Err(error),
+                }
             }
             let mut return_ty = explicit_return_ty
                 .or_else(|| {

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -7603,3 +7603,110 @@ function make(ctor: BoxConstructor): Box<number> {
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
     Ok(())
 }
+
+#[test]
+fn lowers_stdlib_method_call_inside_timer_callback_body() -> Result<(), String> {
+    // A statically-resolvable stdlib method call inside a callback body
+    // (`controller.abort()` in the `setTimeout` callback) is not modeled by the
+    // compact side-effect-free callback IR, which only lowers a bounded method
+    // table. Before issue #64 this surfaced the blocker
+    // "callback method `abort` is not lowered into closure bodies yet". The
+    // arrow-expression lowering now falls back to the full closure-body path,
+    // which routes the receiver through the general method-call lowering (the
+    // same path a non-callback `controller.abort()` uses). Mirrors es-toolkit's
+    // promise/delay.spec.ts `setTimeout(() => controller.abort(), 50)`.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function abortLater(): void {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 50);
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate.bodies.iter().any(|body| {
+            body.exprs.iter().any(|expr| matches!(
+                &expr.kind,
+                ExprKind::Closure(closure) if closure_has_cfg_body(&ctx, closure)
+            ))
+        }),
+        "stdlib method call inside a callback body did not lower through a closure body"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_date_method_call_inside_map_callback_body() -> Result<(), String> {
+    // `date.getTime()` called inside a `.map()` callback is a statically-typed
+    // `Date` method that the compact callback IR does not model. The closure-body
+    // fallback lowers it through the general method-call path instead of
+    // surfacing "callback method `getTime` is not lowered into closure bodies
+    // yet". Mirrors es-toolkit's math/maxBy.spec.ts `date => date.getTime()`.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function toTimes(dates: Date[]): number[] {
+  return dates.map((d) => d.getTime());
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate.bodies.iter().any(|body| {
+            body.exprs.iter().any(|expr| matches!(
+                &expr.kind,
+                ExprKind::Closure(closure) if closure_has_cfg_body(&ctx, closure)
+            ))
+        }),
+        "Date method call inside a map callback did not lower through a closure body"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_captured_class_method_call_inside_map_callback_body() -> Result<(), String> {
+    // A captured class instance whose method is called inside a `.map()` callback
+    // body (`c.scaled(x)`, where `scaled` reads `this.base` through a local) must
+    // lower without the "callback method is not lowered into closure bodies yet"
+    // blocker. The receiver `c` is captured into the synthesized closure and the
+    // method is dispatched with the callback's element argument.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+class Counter {
+  base: number;
+  constructor(b: number) {
+    this.base = b;
+  }
+  scaled(x: number): number {
+    const factor = this.base;
+    return x * factor;
+  }
+}
+
+export function scaleAll(xs: number[]): number[] {
+  const c = new Counter(2);
+  return xs.map((x) => c.scaled(x));
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate.bodies.iter().any(|body| {
+            body.exprs.iter().any(|expr| matches!(
+                &expr.kind,
+                ExprKind::Closure(closure) if !closure.captures.is_empty()
+            ))
+        }),
+        "captured class method callback did not produce a capturing closure"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}


### PR DESCRIPTION
Closes #64

## Problem

The #1 cross-corpus compatibility blocker was `callback method X is not lowered into closure bodies yet` (13 occurrences in es-toolkit, plus neverthrow/radash/ts-pattern/valibot). When a statically-resolvable method call appears inside a callback body — `controller.abort()`, `date.getTime()`, `text.localeCompare(other)`, a captured class instance method, etc. — Smelt could not lower it into the synthesized closure.

## Root cause

Callback bodies are lowered by a compact, side-effect-free expression IR that only models a bounded method table (`.map`/`.at`/`.slice`/`Set.has`/...). Any method the compact IR does not model is rejected with the "closure body" error. `arrow_function_expression_with_hint` tried the compact path and returned that error directly, even though the general closure-body path (`arrow_closure_body_expr`) routes the arrow body through the same `expression`/`statement` lowering that a *non-callback* method call already uses (and which already handles `abort`/`getTime`/class methods/...).

## Fix

`arrow_function_expression_with_hint` now falls through to `arrow_closure_body_expr` when the compact callback path fails with a recoverable "should fall back to closure body" error (the existing `should_fallback_to_closure_body_for_callback` predicate). The compact path's resolved return type is preserved so the closure keeps its typed signature; receiver ownership and captures come from the existing closure-body capture machinery.

Per the SmeltUnknown philosophy: this does **not** widen anything to `SmeltUnknown` to silence the blocker. Erased-receiver artifacts (isolated-file probe noise, where the receiver type genuinely cannot be resolved) remain honest blockers; only statically-resolvable method calls are newly lowered.

## Impact

- **es-toolkit probe:** files-with-blockers **86 → 74**; the 13 `callback method X is not lowered into closure bodies yet` occurrences are **fully eliminated** (it was the dominant blocker class).
- **Remeda regression gate:** stays **1789/0**.
- **Full `cargo test` (bare):** green.

## Tests

- Frontend lowering (`part04_tests.rs`): stdlib method in a `setTimeout` callback (`controller.abort()`), `Date.getTime()` in a `.map()` callback, and a captured class method in a `.map()` callback — each asserts a closure with a populated CFG body / capture and passes HIR validation.
- Codegen emit (`part_1_tests.rs`): the captured-class-method `.map()` callback survives the full HIR → MIR → Rust pipeline and emits the method dispatch. (Also verified by hand that the emitted crate `cargo check`s clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
