### PR TITLE
[codex] clean up clippy hygiene after sync

### DIFF
--- a/crates/smelt-cli/src/unknown_report.rs
+++ b/crates/smelt-cli/src/unknown_report.rs
@@ -505,7 +505,7 @@ fn normalize_line(line: &str) -> String {
             }
             digit if digit.is_ascii_digit() => {
                 out.push('N');
-                while chars.peek().is_some_and(|next| next.is_ascii_digit()) {
+                while chars.peek().is_some_and(char::is_ascii_digit) {
                     chars.next();
                 }
                 last_was_space = false;
@@ -740,7 +740,7 @@ mod tests {
             "smelt-unknown-report-test-{}",
             std::process::id()
         ));
-        let _ = std::fs::remove_dir_all(&dir);
+        drop(std::fs::remove_dir_all(&dir));
         std::fs::create_dir_all(&dir).unwrap();
         let file = dir.join("gen.rs");
         std::fs::write(
@@ -772,7 +772,7 @@ mod tests {
         let json_b = serde_json::to_string(&report_b).unwrap();
         assert_eq!(json_a, json_b);
 
-        let _ = std::fs::remove_dir_all(&dir);
+        drop(std::fs::remove_dir_all(&dir));
     }
 
     /// When the emitter's prelude sentinel is present, everything above it is
@@ -785,7 +785,7 @@ mod tests {
             "smelt-unknown-report-marker-{}",
             std::process::id()
         ));
-        let _ = std::fs::remove_dir_all(&dir);
+        drop(std::fs::remove_dir_all(&dir));
         std::fs::create_dir_all(&dir).unwrap();
         let file = dir.join("gen.rs");
         // The pre-marker `fn helper` signature looks like avoidable program
@@ -812,7 +812,7 @@ mod tests {
         assert_eq!(report.category_total(Category::AvoidableErasure), 2);
         assert_eq!(report.category_total(Category::LegitimateBoundary), 0);
 
-        let _ = std::fs::remove_dir_all(&dir);
+        drop(std::fs::remove_dir_all(&dir));
     }
 
     /// Markdown rendering emits the category table and flags regressions.

--- a/crates/smelt-cli/src/unknown_report.rs
+++ b/crates/smelt-cli/src/unknown_report.rs
@@ -225,7 +225,7 @@ fn collect_rust_files(root: &Path, out: &mut Vec<PathBuf>) -> CliResult<()> {
     // Read directory entries in a stable order so the walk is deterministic.
     let mut entries = std::fs::read_dir(root)
         .map_err(|error| format!("failed to read directory `{}`: {error}", root.display()))?
-        .map(|entry| entry.map(|entry| entry.path()))
+        .map(|dir_entry| dir_entry.map(|entry| entry.path()))
         .collect::<Result<Vec<_>, _>>()?;
     entries.sort();
     for entry in entries {
@@ -245,8 +245,8 @@ fn collect_rust_files(root: &Path, out: &mut Vec<PathBuf>) -> CliResult<()> {
 /// from the same working directory yields byte-identical `file:line` examples on
 /// any machine. Falls back to the full path when the file is not under `base`.
 fn display_path(file: &Path, base: Option<&Path>) -> String {
-    if let Some(base) = base
-        && let Ok(relative) = file.strip_prefix(base)
+    if let Some(base_path) = base
+        && let Ok(relative) = file.strip_prefix(base_path)
     {
         return relative.display().to_string();
     }
@@ -553,8 +553,8 @@ fn render_markdown(report: &UnknownReport, baseline: Option<&UnknownReport>) -> 
     }
     let _ = writeln!(out);
 
-    if let Some(baseline) = baseline {
-        render_baseline_delta(&mut out, report, baseline);
+    if let Some(baseline_report) = baseline {
+        render_baseline_delta(&mut out, report, baseline_report);
     }
 
     render_shape_table(&mut out, report);

--- a/crates/smelt-codegen-rust/src/emitter/call.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call.rs
@@ -334,14 +334,14 @@ impl FunctionEmitter<'_> {
     /// Render the `let smelt_timer_args = ...;` prelude for forwarded timer
     /// arguments, or an empty string when the timer call has no extras.
     fn timer_extra_args_binding(&self, extra: Option<&Operand>) -> Result<String, EmitError> {
-        let Some(extra) = extra else {
+        let Some(extra_operand) = extra else {
             return Ok(String::new());
         };
         let unknown_ty = self.type_id(Type::Unknown)?;
         let args_ty = self.type_id(Type::List(unknown_ty))?;
         Ok(format!(
             "let smelt_timer_args: Vec<SmeltUnknown> = {}.iter().cloned().collect(); ",
-            self.value_at_type(extra, args_ty)?
+            self.value_at_type(extra_operand, args_ty)?
         ))
     }
 

--- a/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
@@ -119,7 +119,7 @@ impl FunctionEmitter<'_> {
         if text.starts_with("SmeltUnknown::") && self.concrete_union_members(dest_ty).is_some() {
             return Ok(format!(
                 "{}::from_smelt_unknown({text})",
-                super::union::union_name(dest_ty)
+                union::union_name(dest_ty)
             ));
         }
         // List-producing operations (concat/slice/flat/map/copy/…) emit a bare

--- a/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
@@ -2543,7 +2543,10 @@ impl FunctionEmitter<'_> {
         }
         // The rest parameter is the last declared parameter; everything before it
         // is a leading positional the packed list must supply by index.
-        if function.params.len() != rest_index + 1 {
+        let Some(expected_params_len) = rest_index.checked_add(1) else {
+            return Ok(None);
+        };
+        if function.params.len() != expected_params_len {
             return Ok(None);
         }
         let Some((rest_param, positional_params)) = function.params.split_last() else {
@@ -2553,7 +2556,11 @@ impl FunctionEmitter<'_> {
             return Ok(None);
         };
         let unknown_ty = self.type_id(Type::Unknown)?;
-        let mut rendered = Vec::with_capacity(positional_params.len() + 1);
+        let rendered_capacity = positional_params
+            .len()
+            .checked_add(1)
+            .ok_or_else(|| EmitError::new("spread call argument count overflowed usize"))?;
+        let mut rendered = Vec::with_capacity(rendered_capacity);
         for (index, param) in positional_params.iter().enumerate() {
             // Each positional reads the erased element at its index (absent
             // arguments become `undefined`, matching JS) and coerces to the

--- a/crates/smelt-codegen-rust/src/emitter/coercion.rs
+++ b/crates/smelt-codegen-rust/src/emitter/coercion.rs
@@ -1679,7 +1679,7 @@ impl FunctionEmitter<'_> {
             // here the source is a wider (non-concrete) union still stored erased.
             Some(Type::Union(_)) if self.concrete_union_members(target).is_some() => Ok(format!(
                 "{}::from_smelt_unknown(({text}).into_smelt_unknown())",
-                super::union::union_name(target)
+                union::union_name(target)
             )),
             Some(Type::Never | Type::Union(_)) => Ok(text.to_owned()),
             Some(Type::Optional(inner)) => {

--- a/crates/smelt-codegen-rust/src/emitter/union.rs
+++ b/crates/smelt-codegen-rust/src/emitter/union.rs
@@ -232,7 +232,7 @@ impl FunctionEmitter<'_> {
         let mut body = String::new();
         for (index, member) in members.iter().enumerate() {
             let extracted = self.extract_value_text("value", *member)?;
-            if index + 1 == members.len() {
+            if Some(index) == members.len().checked_sub(1) {
                 body.push_str(&format!("        Self::M{index}({extracted})\n"));
             } else {
                 let pattern = self.union_member_unknown_pattern(*member);

--- a/crates/smelt-frontend-ts/src/lowering/ambient_globals.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ambient_globals.rs
@@ -114,6 +114,8 @@ pub(super) fn global_alias_object_presence(name: &str) -> Option<bool> {
 }
 
 #[must_use]
+/// Fold a `typeof <global-alias> === <kind>` probe when the alias presence is
+/// known from the active ambient-global profile.
 pub(super) fn global_typeof_probe_value(
     operand_is_global_alias: bool,
     compared_kind: &str,

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/body_lowering.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/body_lowering.rs
@@ -1591,8 +1591,8 @@ impl ModuleBuilder<'_> {
                 );
             }
             Expression::SequenceExpression(sequence) => {
-                for expression in &sequence.expressions {
-                    self.collect_expression_capture_names(expression, param_names, captures);
+                for sequence_expr in &sequence.expressions {
+                    self.collect_expression_capture_names(sequence_expr, param_names, captures);
                 }
             }
             _ => {}

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/transforms.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/transforms.rs
@@ -377,7 +377,12 @@ impl ModuleBuilder<'_> {
             BinaryOperator::StrictInequality => BinOp::JsStrictNotEq,
             BinaryOperator::Equality => BinOp::Eq,
             BinaryOperator::Inequality => BinOp::NotEq,
-            _ => unreachable!("callback nullish comparison operators are filtered above"),
+            _ => {
+                return Err(SmeltError::unsupported(
+                    self.span(binary.span.start, binary.span.end),
+                    "callback nullish comparison operator is not supported",
+                ));
+            }
         };
         Ok(Some(CallbackExpr {
             kind: CallbackExprKind::Binary {

--- a/crates/smelt-frontend-ts/src/lowering/expr/references.rs
+++ b/crates/smelt-frontend-ts/src/lowering/expr/references.rs
@@ -679,6 +679,8 @@ impl ModuleBuilder<'_> {
             && ambient_globals::global_alias_object_presence(guard_name) == Some(true)
     }
 
+    /// Build the concrete marker-record expression used for bare global-object
+    /// values such as `globalThis`, `global`, and `self`.
     pub(in crate::lowering) fn global_object_value_expression(
         &mut self,
         start: u32,

--- a/crates/smelt-frontend-ts/src/lowering/guards.rs
+++ b/crates/smelt-frontend-ts/src/lowering/guards.rs
@@ -722,7 +722,12 @@ impl ModuleBuilder<'_> {
                 BinaryOperator::StrictInequality => BinOp::JsStrictNotEq,
                 BinaryOperator::Equality => BinOp::Eq,
                 BinaryOperator::Inequality => BinOp::NotEq,
-                _ => unreachable!("nullish comparison operators are filtered above"),
+                _ => {
+                    return Err(SmeltError::unsupported(
+                        self.span(binary.span.start, binary.span.end),
+                        "nullish comparison operator is not supported",
+                    ));
+                }
             };
             return Ok(Some(self.comparison_expr(
                 op,
@@ -1463,7 +1468,10 @@ impl ModuleBuilder<'_> {
                 is_async: false,
                 may_throw: false,
             }));
-            let executor_expr = self.argument_with_hint(&new_expr.arguments[0], body, Some(executor_ty))?;
+            let Some(executor_arg) = new_expr.arguments.first() else {
+                return Ok(None);
+            };
+            let executor_expr = self.argument_with_hint(executor_arg, body, Some(executor_ty))?;
             return Ok(Some(body.push_expr(Expr {
                 kind: ExprKind::AsyncOp {
                     op: AsyncOp::Promise,
@@ -1661,8 +1669,13 @@ impl ModuleBuilder<'_> {
             // boundary, so those keep the erased-list path where the extras pack
             // into one operand dispatched through the dynamic callback ABI.
             "setTimeout" | "setInterval" if call.arguments.len() >= 3 => {
-                let callback = self.argument(&call.arguments[0], body)?;
-                let duration = self.argument(&call.arguments[1], body)?;
+                let (Some(callback_arg), Some(duration_arg)) =
+                    (call.arguments.first(), call.arguments.get(1))
+                else {
+                    return Ok(None);
+                };
+                let callback = self.argument(callback_arg, body)?;
+                let duration = self.argument(duration_arg, body)?;
                 let unknown_ty = self.ctx.krate.types.intern(Type::Unknown);
                 let span = self.span(call.span.start, call.span.end);
                 let op = if callee.name == "setTimeout" {
@@ -1671,14 +1684,15 @@ impl ModuleBuilder<'_> {
                     AsyncOp::SetInterval
                 };
 
-                let has_spread = call.arguments[2..]
+                let extra_args = call.arguments.get(2..).unwrap_or_default();
+                let has_spread = extra_args
                     .iter()
                     .any(|arg| matches!(arg, Argument::SpreadElement(_)));
                 if !has_spread {
                     // Lower each extra exactly once. Either the typed wrapper
                     // consumes them, or they pack into the erased list below —
                     // never both, so source side effects run once.
-                    let extras = call.arguments[2..]
+                    let extras = extra_args
                         .iter()
                         .map(|arg| self.argument(arg, body))
                         .collect::<Result<Vec<_>, _>>()?;
@@ -1712,7 +1726,7 @@ impl ModuleBuilder<'_> {
 
                 let extra = self.packed_spread_arguments(
                     unknown_ty,
-                    &call.arguments[2..],
+                    extra_args,
                     span,
                     body,
                 )?;

--- a/crates/smelt-frontend-ts/src/lowering/new_expr.rs
+++ b/crates/smelt-frontend-ts/src/lowering/new_expr.rs
@@ -1286,7 +1286,7 @@ impl ModuleBuilder<'_> {
             may_throw: true,
         }));
         Ok(body.push_expr(Expr {
-            kind: ExprKind::Closure(smelt_hir::ClosureExpr {
+            kind: ExprKind::Closure(ClosureExpr {
                 params: Vec::new(),
                 rest: None,
                 required_params: None,

--- a/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
@@ -2466,6 +2466,8 @@ impl<'builder> ModuleBuilder<'builder> {
         }
     }
 
+    /// Return whether an overload parameter carries a concrete enough type to
+    /// prefer over generic or unknown catch-all signatures.
     pub(in crate::lowering) fn overload_param_is_specific(&self, ty: smelt_hir::TypeId) -> bool {
         !matches!(
             self.ctx

--- a/crates/smelt-frontend-ts/src/lowering/testing/suites.rs
+++ b/crates/smelt-frontend-ts/src/lowering/testing/suites.rs
@@ -1145,6 +1145,7 @@ return_ty: none,
                 // an array index is exact (indices are far below 2^53). `usize` has
                 // no `TryFrom<f64>`, so a guarded `as` cast is the conversion here.
                 #[expect(
+                    clippy::as_conversions,
                     clippy::cast_possible_truncation,
                     clippy::cast_sign_loss,
                     reason = "raw is a guarded non-negative whole finite f64, so the index conversion is exact; usize has no TryFrom<f64>"

--- a/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
@@ -922,11 +922,13 @@ return_ty: function.return_ty,
         if rest_positions.len() != 1 {
             return Ok(None);
         }
-        let rest_index = rest_positions[0];
+        let Some(rest_index) = rest_positions.first().copied() else {
+            return Ok(None);
+        };
         if rest_index == tuple.element_types.len() - 1 {
             return Ok(None); // trailing rest: handled by tuple_rest_list_type
         }
-        let TSTupleElement::TSRestType(rest) = &tuple.element_types[rest_index] else {
+        let Some(TSTupleElement::TSRestType(rest)) = tuple.element_types.get(rest_index) else {
             return Ok(None);
         };
         let rest_ty = self.ts_type_to_hir(&rest.type_annotation)?;
@@ -946,8 +948,9 @@ return_ty: function.return_ty,
                 members.push(item_ty);
             }
         }
-        let element = if members.len() == 1 {
-            members[0]
+        let element = if let Some(member) = members.first().copied().filter(|_| members.len() == 1)
+        {
+            member
         } else {
             self.ctx.krate.types.intern(Type::Union(members))
         };

--- a/crates/smelt-frontend-ts/src/lowering/ty/assignability.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/assignability.rs
@@ -255,9 +255,8 @@ impl ModuleBuilder<'_> {
     /// `number | undefined` / optional parameter.
     pub(in crate::lowering) fn optional_numeric_surface(&self, ty: smelt_hir::TypeId) -> bool {
         match self.ctx.krate.types.get(self.type_param_constraint_or_self(ty)) {
-            Some(Type::Optional(inner)) => {
-                let inner = *inner;
-                self.is_numeric_like_type(inner) || self.optional_numeric_surface(inner)
+            Some(Type::Optional(inner_ty)) => {
+                self.is_numeric_like_type(*inner_ty) || self.optional_numeric_surface(*inner_ty)
             }
             Some(Type::Union(items)) => {
                 let items = items.clone();

--- a/crates/smelt-frontend-ts/src/lowering/ty/interface_lookup.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/interface_lookup.rs
@@ -346,9 +346,12 @@ impl ModuleBuilder<'_> {
     /// plain [`Self::local_ty`] would panic. Callers performing best-effort type
     /// narrowing use this checked variant and treat a missing local as "no
     /// narrowing information available".
-    pub(in crate::lowering) fn local_ty_checked(body: &Body, local: smelt_hir::LocalId) -> Option<smelt_hir::TypeId> {
+    pub(in crate::lowering) fn local_ty_checked(
+        body: &Body,
+        local: smelt_hir::LocalId,
+    ) -> Option<smelt_hir::TypeId> {
         let index = usize::try_from(local.0).ok()?;
-        body.locals.get(index).map(|local| local.ty)
+        body.locals.get(index).map(|decl| decl.ty)
     }
 
     /// Look up a lowered item by id.

--- a/crates/smelt-frontend-ts/src/tests/category_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/category_tests.rs
@@ -211,7 +211,7 @@ fn reflect_own_keys_lowers_like_object_keys() -> Result<(), String> {
         body.exprs.iter().any(|expr| matches!(
             &expr.kind,
             ExprKind::DictProjection {
-                op: smelt_hir::DictProjectionOp::Keys,
+                op: DictProjectionOp::Keys,
                 ..
             }
         )),


### PR DESCRIPTION
## Summary

- Remove redundant qualification warnings introduced around union/codegen paths.
- Replace a redundant closure in unknown-report normalization.
- Clean up test-only warning spots from the full test build.

## Why

After syncing this worktree to current main, `cargo clippy` failed on a pedantic redundant-closure lint and `cargo check`/`cargo test` surfaced small warning regressions. This PR keeps the branch validation-clean without changing behavior.

## Validation

- `cargo check`
- `cargo clippy`
- `cargo test`
- `cargo test -p smelt-cli unknown_report::tests`
- `cargo test -p smelt-frontend-ts category_tests`