### PR TITLE
feat(frontend-ts): generalize exported const member expressions beyond Number/Math

### DIFF
--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -364,6 +364,23 @@ setTimeout(note, 10, "with-optional", "extra");
 "#,
         },
         Case {
+            // Issue #73: exported consts initialized from member expressions
+            // beyond well-known Number/Math constants. Builtin `.prototype`
+            // members and bound builtin methods are erased boundaries that lower
+            // to `SmeltUnknown`; a numeric alias and an object-const field keep
+            // their concrete value. All must emit Rust that compiles.
+            name: "exported_const_member_expressions",
+            area: "exported_consts",
+            source: r#"
+export const MAX_INTEGER = Number.MAX_VALUE;
+export const arrayProto = Array.prototype;
+export const slice = Array.prototype.slice;
+export const objectProto = Object.prototype;
+const limits = { lower: 1, upper: 640 } as const;
+export const UPPER_LIMIT = limits.upper;
+"#,
+        },
+        Case {
             name: "interface_method_call",
             area: "interfaces",
             source: r"

--- a/crates/smelt-frontend-ts/src/lowering/decls/arrows.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/arrows.rs
@@ -907,6 +907,18 @@ return_ty: target_function.return_ty,
     /// global numeric members (`export const MAX_INTEGER = Number.MAX_VALUE`).
     /// These are compile-time constants, so they fold to the same `Float`
     /// literals that the runtime `Number.<constant>` reader produces.
+    ///
+    /// This folder only recognizes the well-known Number/Math numeric constants
+    /// because they are the only member expressions with a stable primitive
+    /// literal value. Other statically resolvable member expressions — an
+    /// object-const field, a namespace member, or a builtin member such as
+    /// `Array.prototype` / `Array.prototype.slice` — are routed through general
+    /// expression lowering at the declaration site (see
+    /// `const_item_declarations`) rather than folded here, so they resolve to
+    /// their concrete or erased-`Unknown` value instead of erroring. The error
+    /// returned here is therefore only reached when a member expression appears
+    /// nested inside another foldable const expression (a binary operand or a
+    /// switch-case label), where a primitive literal is required.
     pub(in crate::lowering) fn member_literal_const_expression(
         &mut self,
         member: &oxc::ast::ast::StaticMemberExpression<'_>,

--- a/crates/smelt-frontend-ts/src/lowering/module_init.rs
+++ b/crates/smelt-frontend-ts/src/lowering/module_init.rs
@@ -1943,6 +1943,23 @@ impl<'ctx> ModuleBuilder<'ctx> {
                 items.push(item);
                 continue;
             }
+            // A member access that is neither a foldable numeric constant nor a
+            // module-local reference (`export const slice = Array.prototype.slice;`,
+            // `export const arrayProto = Array.prototype;`) is a statically
+            // resolvable member expression on a builtin/global root. General
+            // expression lowering already resolves such members — builtin
+            // namespace members lower to their concrete or erased-`Unknown`
+            // value, so route them through the same expression path instead of
+            // rejecting everything but well-known Number/Math constants. Genuine
+            // dynamic boundaries (a prototype object, a bound builtin method)
+            // stay explicit as the `Unknown` value the shared lowering produces.
+            if Self::is_member_access_initializer(init)
+                && self.literal_const_expression(init).is_err()
+            {
+                let item = self.push_expression_const_item(binding, init)?;
+                items.push(item);
+                continue;
+            }
             let value = match self.literal_const_expression(init) {
                 Ok(value) => value,
                 Err(error) if Self::is_known_non_importable_exported_const(init) => {
@@ -2041,6 +2058,35 @@ impl<'ctx> ModuleBuilder<'ctx> {
             || self.const_collections.contains_key(root)
             || self.const_literals.contains_key(root)
             || self.module_globals.contains_key(root)
+    }
+
+    /// Return whether an exported-const initializer is a static or computed
+    /// member access, unwrapping `as` / `satisfies` / non-null / parenthesized
+    /// wrappers.
+    ///
+    /// Used to route non-foldable member expressions on builtin/global roots
+    /// (`Array.prototype`, `Array.prototype.slice`, `Object.prototype`, ...)
+    /// through general expression lowering. Module-local member references are
+    /// handled earlier by [`Self::is_resolvable_module_reference`]; this catches
+    /// the remaining statically resolvable member expressions that the
+    /// well-known Number/Math folder would otherwise reject.
+    pub(super) fn is_member_access_initializer(init: &Expression<'_>) -> bool {
+        match init {
+            Expression::StaticMemberExpression(_) | Expression::ComputedMemberExpression(_) => true,
+            Expression::ParenthesizedExpression(parenthesized) => {
+                Self::is_member_access_initializer(&parenthesized.expression)
+            }
+            Expression::TSAsExpression(as_expr) => {
+                Self::is_member_access_initializer(&as_expr.expression)
+            }
+            Expression::TSSatisfiesExpression(satisfies) => {
+                Self::is_member_access_initializer(&satisfies.expression)
+            }
+            Expression::TSNonNullExpression(non_null) => {
+                Self::is_member_access_initializer(&non_null.expression)
+            }
+            _ => false,
+        }
     }
 
     /// Return the root identifier name of an identifier or static-member

--- a/crates/smelt-frontend-ts/src/tests/part01_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part01_tests.rs
@@ -546,6 +546,75 @@ export const PI_VALUE = Math.PI;
     Ok(())
 }
 
+/// Issue #73: an exported const initialized from a member expression on a
+/// builtin/global root that is not a well-known Number/Math numeric constant
+/// (`Array.prototype`, `Array.prototype.slice`, `Object.prototype`, ...) is a
+/// genuine dynamic boundary. It must route through general expression lowering
+/// into an `Unknown`-typed const instead of being rejected by the numeric
+/// member folder.
+#[test]
+fn exported_const_builtin_member_lowers_to_unknown() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export const arrayProto = Array.prototype;
+export const slice = Array.prototype.slice;
+export const objectProto = Object.prototype;
+export const stringProto = String.prototype;
+export const numberProto = Number.prototype;
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    for name in ["arrayProto", "slice", "objectProto", "stringProto", "numberProto"] {
+        let const_item = named_const_item(&ctx, module, name)?;
+        ensure!(
+            matches!(ctx.krate.types.get(const_item.ty), Some(Type::Unknown)),
+            "expected builtin member const `{name}` to lower to an Unknown-typed const"
+        );
+    }
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+/// Issue #73: a builtin `.prototype` member and a well-known numeric constant
+/// can coexist in the same module — the numeric alias keeps folding to its
+/// literal const while the prototype member routes to the general path — so the
+/// numeric folder is not disturbed by the new member routing.
+#[test]
+fn exported_const_mixed_builtin_member_and_numeric_constant() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export const MAX_INTEGER = Number.MAX_VALUE;
+export const slice = Array.prototype.slice;
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+
+    let max_integer = named_const_item(&ctx, module, "MAX_INTEGER")?;
+    let max_body = ctx
+        .krate
+        .bodies
+        .get(max_integer.body.0 as usize)
+        .ok_or("missing MAX_INTEGER body")?;
+    ensure!(
+        max_body.exprs.iter().any(
+            |expr| matches!(expr.kind, ExprKind::Literal(Literal::Float(value)) if value == f64::MAX)
+        ),
+        "expected MAX_INTEGER to keep folding to its numeric literal"
+    );
+
+    let slice = named_const_item(&ctx, module, "slice")?;
+    ensure!(
+        matches!(ctx.krate.types.get(slice.ty), Some(Type::Unknown)),
+        "expected the builtin member const `slice` to lower to an Unknown-typed const"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
 /// An exported const-from-const array is visible to later modules that import
 /// it, mirroring how exported foldable numeric constants travel across files.
 #[test]
@@ -583,8 +652,13 @@ export function firstSeparator(): string {
     Ok(())
 }
 
-/// Member expressions on names Smelt has not lowered still fail with the
-/// well-known-constants unsupported message rather than lowering incorrectly.
+/// A member expression whose root is genuinely undefined still fails rather
+/// than lowering incorrectly.
+///
+/// Issue #73 routes non-foldable member expressions through general expression
+/// lowering, so an undefined root now surfaces the precise `unresolved
+/// identifier` diagnostic instead of the misleading "well-known Number/Math"
+/// message. The important invariant is that it still errors.
 #[test]
 fn exported_const_unresolved_member_still_errors() -> Result<(), String> {
     let mut ctx = HirCtx::new();
@@ -596,8 +670,8 @@ export const MYSTERY = missingNamespace.someMember;
     )?;
     ensure!(
         errors.iter().any(|error| format!("{error:?}")
-            .contains("exported const member expressions support well-known Number/Math")),
-        "expected the well-known-constants unsupported error, got: {errors:?}"
+            .contains("unresolved identifier `missingNamespace`")),
+        "expected an unresolved-identifier error, got: {errors:?}"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes the es-toolkit blocker where an exported `const` initialized from a member expression that is **not** a well-known `Number.*`/`Math.*` numeric constant was rejected with:

> exported const member expressions support well-known Number/Math numeric constants only

This blocked es-toolkit's builtin `.prototype` re-export consts (5 files):
`Array.prototype`, `Array.prototype.slice`, `Object.prototype`, `String.prototype`, `Number.prototype`.

## What changed

Non-foldable static/computed member initializers are now routed through the **same general expression lowering** that identifier and call/new initializers already use, via a new `is_member_access_initializer` guard in `const_item_declarations`.

- Module-local member references (object-const fields, namespace members, another const's field) were already handled by the resolvable-module-reference path. This adds the remaining case where the member **root is a builtin/global** (`Array`, `Object`, `String`, `Number`, `Math`).
- Builtin members lower to their concrete or erased-`SmeltUnknown` value via the existing `__smelt_builtin_namespace` machinery, so genuine dynamic boundaries (a prototype object, a bound builtin method) stay **explicit** as `Unknown` rather than being force-folded — consistent with the SmeltUnknown philosophy.
- No per-library special cases; the fix is a general routing rule.

Well-known `Number`/`Math` constants keep folding to importable `Float` const literals. A genuinely undefined member root now surfaces the precise `unresolved identifier` diagnostic (it still errors) instead of the misleading numeric message.

## Tests

- `exported_const_builtin_member_lowers_to_unknown` and `exported_const_mixed_builtin_member_and_numeric_constant` (HIR lowering, `part01_tests`).
- Updated `exported_const_unresolved_member_still_errors` to assert the improved diagnostic.
- `exported_const_member_expressions` case in the compile-corpus tier (`tests/compile_corpus.rs`) verifying the emitted Rust compiles.

## Verification

- `cargo check`, `cargo clippy`: clean.
- Full `cargo test` (bare cargo): green.
- Compile-corpus tier (`--ignored`): passes, including the new case.
- Remeda gate: **1789 passed / 0 failed**.
- es-toolkit probe: the "well-known Number/Math" blocker class is **eliminated** (37 -> 36 blocker classes; non-working Rust 36r/1s -> 35r/1s).

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)