### PR TITLE
fix(ts): reconcile callback conditional/if-else branch types (#71)

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/list_query.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_query.rs
@@ -570,7 +570,7 @@ impl FunctionEmitter<'_> {
 
     /// Converts a non-escaping MIR closure into a Rust closure literal.
     pub(super) fn closure_text(&self, id: smelt_mir::ClosureId) -> Result<String, EmitError> {
-        self.closure_text_with_extra_params(id, 0, None)
+        self.closure_text_with_extra_params(id, &[], None)
     }
 
     /// Converts a MIR closure into a Rust closure literal shaped for `dest_ty`.
@@ -579,7 +579,14 @@ impl FunctionEmitter<'_> {
         id: smelt_mir::ClosureId,
         dest_ty: TypeId,
     ) -> Result<String, EmitError> {
-        let extra_params = match self.mir.types.get(dest_ty) {
+        // A JS callback often accepts fewer arguments than the contextual
+        // function type provides (e.g. `.map(value => ...)` is called with
+        // `(value, index, array)`). The emitted closure appends one ignored
+        // parameter per surplus contextual argument; capture the *types* of
+        // those surplus parameters so the emitted `_arg{i}` can be annotated
+        // (an unannotated ignored param is uninferable — E0282 — when the
+        // closure is stored behind an `Rc`/`dyn Fn` that erases its signature).
+        let extra_param_tys: Vec<TypeId> = match self.mir.types.get(dest_ty) {
             Some(Type::Function(function)) => {
                 let closure = self
                     .mir
@@ -588,9 +595,14 @@ impl FunctionEmitter<'_> {
                     .ok_or_else(|| {
                         EmitError::new("closure rvalue references an unknown closure")
                     })?;
-                function.params.len().saturating_sub(closure.params.len())
+                function
+                    .params
+                    .iter()
+                    .skip(closure.params.len())
+                    .copied()
+                    .collect()
             }
-            _ => 0,
+            _ => Vec::new(),
         };
         let has_captures = !self
             .mir
@@ -628,7 +640,8 @@ impl FunctionEmitter<'_> {
             Some(Type::Function(function)) => Some(function.return_ty),
             _ => None,
         };
-        let closure = self.closure_text_with_extra_params(id, extra_params, target_return_ty)?;
+        let closure =
+            self.closure_text_with_extra_params(id, &extra_param_tys, target_return_ty)?;
         if matches!(self.mir.types.get(dest_ty), Some(Type::Function(_))) {
             let adjusted_closure = if !has_captures
                 || closure.starts_with("move ")
@@ -793,10 +806,16 @@ impl FunctionEmitter<'_> {
 
     /// Emits ignored trailing parameters when a JS callback accepts fewer
     /// arguments than the contextual function type provides.
+    ///
+    /// `extra_param_tys` carries the contextual types of those surplus
+    /// parameters (e.g. the `index: number` and `array: T[]` a `.map` callback
+    /// ignores). Each is emitted as an annotated `_arg{i}: <ty>` binding so the
+    /// closure signature is fully typed even when it is stored behind an erased
+    /// `Rc`/`dyn Fn` where Rust cannot otherwise infer the ignored parameters.
     fn closure_text_with_extra_params(
         &self,
         id: smelt_mir::ClosureId,
-        extra_params: usize,
+        extra_param_tys: &[TypeId],
         return_override: Option<TypeId>,
     ) -> Result<String, EmitError> {
         let closure = self
@@ -830,7 +849,12 @@ impl FunctionEmitter<'_> {
                     ))
                 })
                 .collect::<Result<Vec<_>, EmitError>>()?;
-            param_decls.extend((0..extra_params).map(|index| format!("_arg{index}: SmeltUnknown")));
+            for (index, extra_ty) in extra_param_tys.iter().enumerate() {
+                param_decls.push(format!(
+                    "_arg{index}: {}",
+                    self.type_text_with_impl_trait(*extra_ty, false)?
+                ));
+            }
             return Ok(format!(
                 "|{}| -> {} {{ {} }}",
                 param_decls.join(", "),
@@ -940,7 +964,12 @@ impl FunctionEmitter<'_> {
                     ))
                 })
                 .collect::<Result<Vec<_>, EmitError>>()?;
-            params.extend((0..extra_params).map(|index| format!("_arg{index}")));
+            for (index, extra_ty) in extra_param_tys.iter().enumerate() {
+                params.push(format!(
+                    "_arg{index}: {}",
+                    emitter.type_text_with_impl_trait(*extra_ty, false)?
+                ));
+            }
             let params_text = params.join(", ");
             let mut body_text = String::new();
             emitter.emit_mutable_local_preludes(&mut body_text)?;

--- a/crates/smelt-codegen-rust/src/tests/snapshots/smelt_codegen_rust__tests__snapshot_tests__array_callback_methods_emission.snap
+++ b/crates/smelt-codegen-rust/src/tests/snapshots/smelt_codegen_rust__tests__snapshot_tests__array_callback_methods_emission.snap
@@ -86,7 +86,7 @@ fn main() {
     _smelt_tmp_27 = value + 1.0;
     _smelt_tmp_24 = _smelt_tmp_24.clone() + 1.0;
     }
-    _smelt_tmp_29 = values.iter().enumerate().fold(0.0, |acc, (index, item)| { let item = (*item).clone(); let index = index as f64; let array = values.clone(); { let smelt_callback = ::std::rc::Rc::new(|closure_arg_0: f64, closure_arg_1: f64, _arg0, _arg1| {
+    _smelt_tmp_29 = values.iter().enumerate().fold(0.0, |acc, (index, item)| { let item = (*item).clone(); let index = index as f64; let array = values.clone(); { let smelt_callback = ::std::rc::Rc::new(|closure_arg_0: f64, closure_arg_1: f64, _arg0: i64, _arg1: SmeltList<f64>| {
     let _smelt_tmp_2: f64 = closure_arg_0.clone() + closure_arg_1.clone();
     _smelt_tmp_2.clone()
     }); (smelt_callback)(acc, item, index, array) } });
@@ -100,7 +100,7 @@ fn main() {
     _smelt_tmp_3.clone()
     }); let smelt_array = values.clone(); smelt_array.iter().enumerate().map(|(index, item)| { (smelt_callback)(item.clone(), index as i64, smelt_array.clone()) }).collect::<Vec<_>>() });
     indexed = Into::<SmeltList<_>>::into(_smelt_tmp_31);
-    _smelt_tmp_33 = { let mut reduce_items = values.iter().enumerate(); let (_, first) = reduce_items.next().expect("reduce of empty array with no initial value"); reduce_items.fold(first.clone(), |acc, (index, item)| { let item = (*item).clone(); let index = index as f64; let array = values; { let smelt_callback = ::std::rc::Rc::new(|closure_arg_0: f64, closure_arg_1: f64, closure_arg_2: i64, _arg0| {
+    _smelt_tmp_33 = { let mut reduce_items = values.iter().enumerate(); let (_, first) = reduce_items.next().expect("reduce of empty array with no initial value"); reduce_items.fold(first.clone(), |acc, (index, item)| { let item = (*item).clone(); let index = index as f64; let array = values; { let smelt_callback = ::std::rc::Rc::new(|closure_arg_0: f64, closure_arg_1: f64, closure_arg_2: i64, _arg0: SmeltList<f64>| {
     let _smelt_tmp_3: f64 = closure_arg_0.clone() + closure_arg_1.clone();
     let _smelt_tmp_4: f64 = _smelt_tmp_3.clone() + (closure_arg_2.clone() as f64);
     _smelt_tmp_4.clone()

--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -181,6 +181,44 @@ function collectIndices(values: number[]): number[] {
 }
 ",
         },
+        Case {
+            name: "callback_conditional_branches",
+            area: "closures",
+            // Callback bodies whose `cond ? a : b` / `if`-`else` branches lower
+            // to different concrete Rust types must reconcile to a single lowered
+            // type and compile. `classify` is a value-yielding `if/else` lowered
+            // as a direct conditional; `widen` is a ternary whose list branches
+            // have different element types; `normalize` mutates the callback
+            // parameter in an `if/else if` chain and must fall back to a full
+            // closure body. Mirrors es-toolkit `keys`/`fill`/`toFinite` mappers.
+            source: r#"
+function classify(values: number[]): string[] {
+  return values.map((value) => {
+    if (value > 0) {
+      return "pos";
+    } else {
+      return "nonpos";
+    }
+  });
+}
+
+function widen(values: (string | undefined)[]): (string | number)[][] {
+  return values.map((value) => (value === undefined ? ["a"] : [1, 2, 3]));
+}
+
+function normalize(values: number[]): number[][] {
+  return values.map((value) => {
+    if (value === 0) {
+      value = 1;
+    } else if (value !== value) {
+      value = 0;
+    }
+    const neg = value === 0 ? 0 : -value;
+    return [value, neg];
+  });
+}
+"#,
+        },
         // --- string / list operations ----------------------------------------
         Case {
             name: "list_collection",

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/body_lowering.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/body_lowering.rs
@@ -62,11 +62,64 @@ impl ModuleBuilder<'_> {
                 result
             }
             Statement::IfStatement(if_stmt) => {
-                if if_stmt.alternate.is_some() {
-                    return Err(SmeltError::unsupported(
+                // A callback `if/else` where both arms terminate with a value
+                // (`if (c) { return a; } else { return b; }`) is a direct
+                // conditional expression: lower each arm as a terminating
+                // statement and reconcile the two branch types the same way a
+                // ternary does. When an arm does not terminate — e.g. it mutates
+                // a captured local or the callback parameter and then falls
+                // through to shared trailing statements (`if (c) { value = x; }
+                // else if (d) { value = y; } ... return value;`) — the compact
+                // side-effect-free callback IR cannot model the assignment, so
+                // surface a fallback-eligible error that retries the whole arrow
+                // through full closure-body lowering (which makes parameters
+                // mutable locals and lowers `if/else if` chains natively).
+                if let Some(alternate) = &if_stmt.alternate {
+                    // The direct-conditional form requires both arms to be the
+                    // final statement (nothing after the `if/else`) and to
+                    // terminate with a value. Any other shape — trailing
+                    // statements after the `if/else`, or an arm that mutates a
+                    // local/parameter instead of returning — cannot be modeled by
+                    // the compact IR, so surface the fallback-eligible error
+                    // (`should_fallback_to_closure_body_for_callback`) that
+                    // retries the whole arrow through full closure-body lowering.
+                    let fallback_error = SmeltError::unsupported(
                         self.span(if_stmt.span.start, if_stmt.span.end),
                         "callback if/else blocks need direct conditional expression lowering",
-                    ));
+                    );
+                    if !rest.is_empty() {
+                        return Err(fallback_error);
+                    }
+                    let cond = self.callback_truthy_expression(&if_stmt.test, params, body)?;
+                    let mut then_params =
+                        self.callback_params_with_guard_narrowing(params, &if_stmt.test);
+                    let Ok(then_expr) = self.callback_terminating_statement(
+                        &if_stmt.consequent,
+                        &mut then_params,
+                        body,
+                    ) else {
+                        return Err(fallback_error);
+                    };
+                    let mut else_params = params.clone();
+                    let Ok(else_expr) =
+                        self.callback_terminating_statement(alternate, &mut else_params, body)
+                    else {
+                        return Err(fallback_error);
+                    };
+                    let (then_expr, else_expr, ty) = self.callback_unify_conditional_exprs(
+                        then_expr,
+                        else_expr,
+                        if_stmt.span.start,
+                        if_stmt.span.end,
+                    )?;
+                    return Ok(CallbackExpr {
+                        kind: CallbackExprKind::Conditional {
+                            cond: Box::new(cond),
+                            then_expr: Box::new(then_expr),
+                            else_expr: Box::new(else_expr),
+                        },
+                        ty,
+                    });
                 }
                 let cond = self.callback_truthy_expression(&if_stmt.test, params, body)?;
                 let then_expr =

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/dispatch.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/dispatch.rs
@@ -432,6 +432,14 @@ impl ModuleBuilder<'_> {
             // Full closure-body lowering supports these statements, so retry there.
             || error.message
                 == "callback block statements must be const declarations, if guards, return, or throw"
+            // A callback `if/else` (or `if/else if` chain) whose arms mutate a
+            // captured local / the callback parameter before falling through to
+            // shared trailing statements cannot be modeled by the compact
+            // side-effect-free callback IR. Full closure-body lowering makes
+            // parameters mutable locals and lowers the branch natively, so retry
+            // there.
+            || error.message
+                == "callback if/else blocks need direct conditional expression lowering"
             || error.message == "async callbacks need closure-body lowering"
             // A method/receiver call the compact callback dispatcher does not
             // model but the full method-call lowering does (e.g. `String.repeat`,

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/transforms.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/transforms.rs
@@ -244,6 +244,24 @@ impl ModuleBuilder<'_> {
     }
 
     /// Compute the result type of a callback conditional expression.
+    ///
+    /// Callback ternaries/`if`-`else` reconcile their two branch types with the
+    /// exact same rules as an ordinary (non-callback) conditional expression:
+    /// this delegates to [`Self::conditional_branch_type`] so both paths share a
+    /// single reconciliation policy (numeric widening, `List<A>`/`List<B>`
+    /// element unification into a concrete `List<A | B>`, union-contains-branch,
+    /// nullish/`Optional` folding, function-branch merging, and only widening to
+    /// `unknown` when a branch is genuinely erased). A few callback-only branch
+    /// pairs are handled first because their compact-IR types encode facts the
+    /// general path does not need to special-case:
+    ///
+    /// - `Never` (a throwing branch) collapses to the other branch's type.
+    /// - non-nullish narrowing (`opt !== undefined ? opt : fallback`) where the
+    ///   narrowed branch equals the non-optional peer keeps the optional type.
+    ///
+    /// It then forwards to the shared reconciler with no contextual type hint,
+    /// so a callback branch mismatch that the general path cannot merge surfaces
+    /// there instead of through a callback-specific error.
     pub(in crate::lowering) fn callback_conditional_type(
         &mut self,
         then_ty: smelt_hir::TypeId,
@@ -260,15 +278,6 @@ impl ModuleBuilder<'_> {
         if self.ctx.krate.types.get(else_ty) == Some(&Type::Never) {
             return Ok(then_ty);
         }
-        if self.ctx.krate.types.get(then_ty) == Some(&Type::Unknown)
-            || self.ctx.krate.types.get(else_ty) == Some(&Type::Unknown)
-            || self.type_contains_unknown(then_ty)
-            || self.type_contains_unknown(else_ty)
-            || self.erased_or_union_surface(then_ty)
-            || self.erased_or_union_surface(else_ty)
-        {
-            return Ok(self.ctx.krate.types.intern(Type::Unknown));
-        }
         if let Some(inner) = self.non_nullish_type(then_ty)
             && inner == else_ty
         {
@@ -279,16 +288,7 @@ impl ModuleBuilder<'_> {
         {
             return Ok(else_ty);
         }
-        if self.ctx.krate.types.get(else_ty) == Some(&Type::None) {
-            return Ok(self.ctx.krate.types.intern(Type::Optional(then_ty)));
-        }
-        if self.ctx.krate.types.get(then_ty) == Some(&Type::None) {
-            return Ok(self.ctx.krate.types.intern(Type::Optional(else_ty)));
-        }
-        Err(SmeltError::unsupported(
-            self.span(start, end),
-            "callback conditional expression branches must have compatible lowered types",
-        ))
+        self.conditional_branch_type(then_ty, else_ty, None, start, end)
     }
 
     /// Lower `value === undefined/null` checks inside callback expressions.

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -7710,3 +7710,164 @@ export function scaleAll(xs: number[]): number[] {
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
     Ok(())
 }
+
+#[test]
+fn lowers_callback_ternary_with_differing_list_branches() -> Result<(), String> {
+    // A `.map` callback ternary whose branches are arrays of different element
+    // types (`string[]` vs `number[]`) must reconcile to a single list type
+    // (a concrete `List<string | number>`) instead of rejecting the branches
+    // as incompatible. Mirrors es-toolkit's `fill.spec.ts`
+    // `value => (value === undefined ? ['a', 'a', 'a'] : [1, 2, 3])`.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function widen(values: (string | undefined)[]): (string | number)[][] {
+  return values.map(value => (value === undefined ? ['a', 'a', 'a'] : [1, 2, 3]));
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate.bodies.iter().any(|body| {
+            body.exprs.iter().any(|expr| {
+                matches!(&expr.kind, ExprKind::Conditional { .. })
+                    && matches!(ctx.krate.types.get(expr.ty), Some(Type::List(_)))
+            })
+        }),
+        "callback ternary with differing list branches did not unify to a list type"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_callback_ternary_with_empty_list_branch() -> Result<(), String> {
+    // A `.map` callback ternary whose alternate is an empty array literal
+    // (`['0'] : []`) must reconcile the two list branches instead of aborting,
+    // since the empty-array branch has no concrete element type. Mirrors
+    // es-toolkit's `keys.spec.ts`
+    // `value => (typeof value === 'string' ? ['0'] : [])`.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function keyEcho(values: unknown[]): string[][] {
+  return values.map(value => (typeof value === 'string' ? ['0'] : []));
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate.bodies.iter().any(|body| {
+            body.exprs.iter().any(|expr| {
+                matches!(&expr.kind, ExprKind::Conditional { .. })
+                    && matches!(ctx.krate.types.get(expr.ty), Some(Type::List(_)))
+            })
+        }),
+        "callback ternary with empty-list branch did not unify to a list type"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_callback_if_else_returning_values_as_conditional() -> Result<(), String> {
+    // A `.map` callback whose body is an `if/else` where both arms terminate
+    // with a value must lower as a direct conditional expression rather than
+    // being rejected with "callback if/else blocks need direct conditional
+    // expression lowering".
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function classify(values: number[]): string[] {
+  return values.map(value => {
+    if (value > 0) {
+      return "pos";
+    } else {
+      return "nonpos";
+    }
+  });
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate.bodies.iter().any(|body| {
+            body.exprs
+                .iter()
+                .any(|expr| matches!(&expr.kind, ExprKind::Conditional { .. }))
+        }),
+        "value-yielding if/else callback did not lower to a conditional expression"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_callback_if_else_chain_with_param_mutation_via_closure_body() -> Result<(), String> {
+    // A `.map` callback with an `if/else if` chain that mutates the callback
+    // parameter before falling through to shared trailing statements cannot be
+    // modeled by the compact side-effect-free callback IR; it must fall back to
+    // full closure-body lowering (which makes parameters mutable locals) instead
+    // of surfacing the "direct conditional expression lowering" blocker. Mirrors
+    // es-toolkit's `toFinite.spec.ts` mapper.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function normalize(values: number[]): number[][] {
+  return values.map(value => {
+    if (value === Infinity) {
+      value = 1;
+    } else if (value !== value) {
+      value = 0;
+    }
+    const neg = value === 0 ? 0 : -value;
+    return [value, neg];
+  });
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate.bodies.iter().any(|body| {
+            body.exprs
+                .iter()
+                .any(|expr| matches!(&expr.kind, ExprKind::Closure(_)))
+        }),
+        "param-mutating if/else callback did not fall back to a closure body"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_callback_final_if_else_with_mutation() -> Result<(), String> {
+    // An `if/else` that is the *final* statement of a callback (no trailing
+    // statements) but whose arms mutate a captured local instead of returning a
+    // value must still lower cleanly (through the callback side-effect path or
+    // full closure-body fallback) rather than surfacing a hard "branch must
+    // terminate" error once the alternate arm is accepted.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function tally(values: number[]): number {
+  let count = 0;
+  values.forEach(value => {
+    if (value > 0) {
+      count = count + 1;
+    } else {
+      count = count - 1;
+    }
+  });
+  return count;
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}


### PR DESCRIPTION
Closes #71

## Problem
Two es-toolkit blocker classes fired inside callback bodies whose `cond ? a : b` or `if`/`else` branches lower to different concrete Rust types:

- **`callback conditional expression branches must have compatible lowered types`** (5 files) — a callback ternary/if-else whose two branches had different concrete types was rejected instead of reconciled.
- **`callback if/else blocks need direct conditional expression lowering`** (2 files) — an `if`/`else` callback body was never lowered as a conditional and always errored.

## Fix (general, no per-library special cases)
- **`callback_conditional_type` now delegates to the shared `conditional_branch_type` reconciler**, so callback and ordinary conditionals use one policy: numeric widening, `List<A>`/`List<B>` element unification into a **concrete `List<A | B>`**, union-contains-branch, nullish/`Optional` folding, function-branch merging, and widening to `unknown` **only** for genuinely erased branches. A couple of callback-only pairs (`Never` throwing arm, non-nullish narrowing) are handled first. No blanket `SmeltUnknown`.
- **Callback `if`/`else` with an alternate lowers as a direct conditional** when both arms are the final statement and terminate with a value. Any other shape — trailing statements after the `if`/`else`, or an arm that mutates a captured local / the callback parameter — returns a fallback-eligible error so the whole arrow retries through **full closure-body lowering** (which makes parameters mutable locals and lowers `if`/`else if` chains natively).
- **Emitter:** the ignored trailing callback params (`.map`'s `index`/`array`) are now annotated with their contextual types instead of left bare, so the closure-body fallback compiles when the closure is stored behind an erased `Rc`/`dyn Fn` (fixes an `E0282` the fallback newly exposed).

## Results
- **es-toolkit blocker delta:** both target classes now **0** (were 5 + 2 files). Files with blockers **71 → 66**; blocker classes **37 → 36**. The 7 previously-blocked files now lower past these classes (several fully; the rest hit unrelated later blockers).
- **remeda gate:** `1789 passed; 0 failed` (unchanged).
- **main `cargo test`:** green (bare cargo). `cargo clippy` clean.

## Tests
- Frontend lowering regressions: callback ternary with differing list branches, callback ternary with an empty-list branch, value-yielding `if`/`else` lowered as a conditional, param-mutating `if`/`else if` chain falling back to a closure body, and a final mutating `if`/`else`.
- A `compile_corpus` case (`callback_conditional_branches`) whose emitted Rust is `cargo check`ed end-to-end.
- Updated one snapshot: ignored trailing `.map` reduce params are now typed (`_arg0: i64, _arg1: SmeltList<f64>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)