### PR TITLE
fix(ts): lower array concat/push over erased and union receivers/elements

### DIFF
--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -3407,6 +3407,93 @@ function concatImplementation<T1, T2>(arr1: T1, arr2: T2): unknown[] {
 }
 
 #[test]
+fn emits_tuple_element_push_as_concrete_tuple_value() {
+    // Pushing a bare `[value, key]` literal into an `Array<[number, string]>`
+    // emits a real `(f64, String)` tuple value rather than widening the pushed
+    // item to a `SmeltUnknown` list that could never re-type into the tuple.
+    let source = source_for(
+        r#"
+export function collect(value: number, key: string): Array<[number, string]> {
+  const result: Array<[number, string]> = [];
+  result.push([value, key]);
+  return result;
+}
+"#,
+    );
+
+    assert!(
+        source.contains("SmeltList<(f64, String)>"),
+        "tuple-element array should keep its concrete tuple element type: {source}"
+    );
+    assert!(
+        source.contains("(value.clone(), key.clone())"),
+        "pushed literal should be a concrete tuple value: {source}"
+    );
+    assert!(
+        source.contains("result.push("),
+        "the tuple value should be pushed onto the array: {source}"
+    );
+    assert!(
+        !source.contains("SmeltList<SmeltUnknown>"),
+        "tuple-element push must not widen the array to SmeltUnknown: {source}"
+    );
+}
+
+#[test]
+fn emits_union_element_push_as_concrete_union_injections() {
+    // Mixed-literal pushes into an `Array<number | string>` inject each argument
+    // into the concrete union enum instead of routing through SmeltUnknown.
+    let source = source_for(
+        r#"
+export function mixed(): Array<number | string> {
+  const xs: Array<number | string> = [];
+  xs.push(1);
+  xs.push("a");
+  return xs;
+}
+"#,
+    );
+
+    assert!(source.contains("pub enum SmeltUnion"), "{source}");
+    assert!(
+        source.contains(".push(SmeltUnion") && source.contains("::M0(1.0)"),
+        "numeric push should inject the concrete union member: {source}"
+    );
+    assert!(
+        source.contains("::M1(\"a\".to_owned())"),
+        "string push should inject the concrete union member: {source}"
+    );
+}
+
+#[test]
+fn emits_union_receiver_concat_by_extracting_to_unknown_list() {
+    // `concat` on an erased/union array-like receiver extracts the receiver to a
+    // concrete `SmeltList<SmeltUnknown>` and chains the appended values — a
+    // genuine dynamic boundary, not a silent widening of statically-typed data.
+    let source = source_for(
+        r#"
+export function widen(a: number[] | string[]): unknown[] {
+  return (a as unknown[]).concat(1, "x");
+}
+"#,
+    );
+
+    assert!(
+        source.contains("SmeltList<SmeltUnknown>"),
+        "erased concat receiver should extract to an unknown list: {source}"
+    );
+    assert!(
+        source.contains(".iter().cloned().chain("),
+        "concat should chain the appended values onto the receiver: {source}"
+    );
+    assert!(
+        source.contains("SmeltUnknown::Number(1.0")
+            && source.contains("SmeltUnknown::String(\"x\".to_owned())"),
+        "appended scalars should be boxed into the unknown element type: {source}"
+    );
+}
+
+#[test]
 fn boxes_returned_function_values_even_when_mir_types_match() {
     let source = source_for(
         r#"

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/list_ops.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/list_ops.rs
@@ -10,6 +10,19 @@ use oxc::span::GetSpan;
 
 impl ModuleBuilder<'_> {
     /// Lower direct TypeScript `Array.prototype.concat` for one same-typed array argument.
+    ///
+    /// Two shapes reach this rule. `ns.concat(collection, ...values)` on a utility
+    /// *namespace* object (a `import * as _` star import or a registered object
+    /// namespace) is the lodash free-function form: its first argument is the base
+    /// array and the rest are appended, so the receiver identifier is not a value
+    /// itself. Everything else — including an ordinary named value import that
+    /// resolves to an erased array, e.g. `import { falsey } from './falsey'` used
+    /// as `falsey.concat(true, 1)` — is real `Array.prototype.concat`, where the
+    /// member object is the receiver array and every argument is concatenated onto
+    /// it. Only genuine namespace/utility objects take the free-function path;
+    /// plain value imports flow through the erased-receiver arms of
+    /// [`Self::finish_list_concat_call`], which already coerce an `Unknown`/union
+    /// receiver into a concrete list instead of rejecting it.
     pub(in crate::lowering) fn list_concat_call(
         &mut self,
         call: &oxc::ast::ast::CallExpression<'_>,
@@ -21,10 +34,7 @@ impl ModuleBuilder<'_> {
         if member.property.name != "concat" {
             return Ok(None);
         }
-        if let Expression::Identifier(object) = &member.object
-            && (self.namespace_imports.contains(object.name.as_str())
-                || self.value_imports.contains(object.name.as_str()))
-        {
+        if self.imported_utility_object(&member.object) {
             let Some((left_argument, right_arguments)) = call.arguments.split_first() else {
                 return Err(SmeltError::unsupported(
                     self.span(call.span.start, call.span.end),
@@ -160,17 +170,38 @@ impl ModuleBuilder<'_> {
         let right_ty = Self::expr_ty(body, right);
         let right = if right_ty == ty {
             right
-        } else if let Some(Type::List(right_item_ty)) = self.ctx.krate.types.get(right_ty)
-            && (*right_item_ty == item_ty
-                || self.erased_or_union_surface(*right_item_ty)
-                || self.erased_or_union_surface(item_ty))
+        } else if let Some(Type::List(right_item_ty)) = self.ctx.krate.types.get(right_ty).cloned()
+            && (right_item_ty == item_ty
+                || self.erased_or_union_surface(right_item_ty)
+                || self.erased_or_union_surface(item_ty)
+                || self.type_assignable_to(right_item_ty, item_ty))
         {
+            // An array argument whose element type is (or is assignable to) the
+            // receiver's element type — including a concrete-union element such
+            // as `number | string` — is spread into the result. The re-type is a
+            // no-op at runtime; the emitter injects each value into the element
+            // type at use as needed.
             body.push_expr(Expr {
                 kind: ExprKind::TypeAssert { value: right },
                 ty,
                 span: self.span(right_argument.span().start, right_argument.span().end),
             })
         } else if right_ty == item_ty {
+            body.push_expr(Expr {
+                kind: ExprKind::ListLit(vec![right]),
+                ty,
+                span: self.span(right_argument.span().start, right_argument.span().end),
+            })
+        } else if self.type_assignable_to(right_ty, item_ty) {
+            // A scalar argument that is a member of the receiver's element type —
+            // e.g. concatenating a `number` onto a `Array<number | string>`.
+            // Coerce it into the element type (the emitter injects the concrete
+            // union member) and wrap it in a singleton list to append.
+            right = body.push_expr(Expr {
+                kind: ExprKind::TypeAssert { value: right },
+                ty: item_ty,
+                span: self.span(right_argument.span().start, right_argument.span().end),
+            });
             body.push_expr(Expr {
                 kind: ExprKind::ListLit(vec![right]),
                 ty,

--- a/crates/smelt-frontend-ts/src/lowering/stdlib.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib.rs
@@ -1871,7 +1871,14 @@ impl ModuleBuilder<'_> {
                     span: self.span(call.span.start, call.span.end),
                 })
             } else {
-                let mut item = self.argument(item_argument, body)?;
+                // Lower the pushed value with the array's element type as a
+                // contextual hint. This lets a bare literal argument adopt the
+                // element's concrete shape at construction time instead of
+                // defaulting to an erased surface — e.g. `result.push([value,
+                // key])` into an `Array<[number, string]>` lowers `[value, key]`
+                // as a `(Float, String)` tuple literal rather than a
+                // `List<Unknown>` that could never be re-typed into the tuple.
+                let mut item = self.argument_with_hint(item_argument, body, Some(element_ty))?;
                 let item_ty = Self::expr_ty(body, item);
                 let compatible = self.array_item_type_compatible(item_ty, element_ty)
                     || self.ctx.krate.types.get(element_ty) == Some(&Type::Unknown)

--- a/crates/smelt-frontend-ts/src/tests/part03_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part03_tests.rs
@@ -1252,6 +1252,135 @@ const length = values.push(4);
 }
 
 #[test]
+fn lowers_array_concat_on_erased_value_import_receiver() -> Result<(), String> {
+    // A named value import that resolves to an erased array (`falsey` here) used
+    // as a `concat` receiver is real `Array.prototype.concat`: the member object
+    // is the array and every argument is concatenated onto it. It must not be
+    // mistaken for the lodash `ns.concat(collection, ...values)` free-function
+    // form (which only applies to namespace/utility objects), and the erased
+    // receiver must lower rather than being rejected as "not an array receiver".
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+import { falsey } from "./falsey";
+
+export function values(): unknown[] {
+  return falsey.concat(true, 1, "a");
+}
+"#),
+        &mut ctx,
+    )?;
+    let _ = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate
+            .bodies
+            .iter()
+            .any(|body| body
+                .exprs
+                .iter()
+                .any(|expr| matches!(expr.kind, ExprKind::ListConcat { .. })))
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_array_concat_on_union_receiver() -> Result<(), String> {
+    // `number[] | string[]` receiver: the union has array members, so concat
+    // coerces it to a concrete erased list and appends the arguments instead of
+    // rejecting the non-statically-array receiver.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function widen(a: number[] | string[]): unknown[] {
+  return a.concat(1, "x");
+}
+"#),
+        &mut ctx,
+    )?;
+    let _ = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate
+            .bodies
+            .iter()
+            .any(|body| body
+                .exprs
+                .iter()
+                .any(|expr| matches!(expr.kind, ExprKind::ListConcat { .. })))
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_array_push_tuple_literal_into_tuple_element_array() -> Result<(), String> {
+    // Pushing a bare `[value, key]` literal into an `Array<[number, string]>`
+    // must adopt the element's concrete tuple shape at construction time. The
+    // literal lowers to a `(number, string)` tuple, so no re-typing of a
+    // `List<Unknown>` into the tuple destination is required.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function collect(value: number, key: string): Array<[number, string]> {
+  const result: Array<[number, string]> = [];
+  result.push([value, key]);
+  return result;
+}
+"#),
+        &mut ctx,
+    )?;
+    let _ = module(&ctx, module_id)?;
+    let function_body = ctx
+        .krate
+        .bodies
+        .iter()
+        .find(|body| {
+            body.exprs
+                .iter()
+                .any(|expr| matches!(expr.kind, ExprKind::ListPush { .. }))
+        })
+        .ok_or_else(|| "expected a ListPush in the lowered crate".to_owned())?;
+    ensure!(
+        function_body
+            .exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::TupleLit(_))),
+        "pushed array literal should lower as a tuple literal matching the element type",
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_array_push_mixed_literals_into_union_element_array() -> Result<(), String> {
+    // Mixed-literal pushes into a `Array<number | string>` coerce each argument
+    // into the union element type instead of requiring an exact match.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function mixed(): Array<number | string> {
+  const xs: Array<number | string> = [];
+  xs.push(1);
+  xs.push("a");
+  return xs;
+}
+"#),
+        &mut ctx,
+    )?;
+    let _ = module(&ctx, module_id)?;
+    let pushes = ctx
+        .krate
+        .bodies
+        .iter()
+        .flat_map(|body| body.exprs.iter())
+        .filter(|expr| matches!(expr.kind, ExprKind::ListPush { .. }))
+        .count();
+    ensure_eq!(pushes, 2);
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn lowers_array_unshift_method() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(


### PR DESCRIPTION
## Summary

Fixes the two es-toolkit blocker classes from #72 where `concat`/`push` rejected statically-reconcilable array operations.

### `array concat requires an array receiver` (5 files)
- `list_concat_call` treated **every** imported-identifier receiver as the lodash `ns.concat(collection, ...values)` free-function form (it checked `namespace_imports || value_imports`). A plain value import that resolves to an erased array — e.g. `import { falsey } from './falsey'` used as `falsey.concat(true, 1, 'a')` — had its first real argument stolen as the "base array", so a scalar landed in the receiver slot and was rejected. The free-function path is now gated on `imported_utility_object` (namespace/utility objects only); ordinary value imports flow through the receiver arms, which already coerce an erased receiver into a concrete list.
- Concat now also accepts **concrete-union element** receivers: `number[] | string[]` collapses to `List<number | string>`, and appending a `number` (or a `number[]`) matched no argument arm. Arguments assignable to the element type are now injected as a union member (scalar) or spread (member-typed array) via `type_assignable_to`.

### `array push argument must match the array element type` (3 files)
- Pushing a bare `[value, key]` literal into `Array<[number, string]>` lowered the literal to `List<Unknown>` (no contextual type), which cannot be re-typed into the concrete tuple. The pushed argument is now lowered **with the element type as a hint**, so the literal adopts the element's concrete shape (tuple literal, union-member injection) at construction time.

### SmeltUnknown discipline
Emitted Rust keeps concrete types: tuple pushes stay `(f64, String)`, union pushes/concats inject `SmeltUnion::Mn(...)`, and only genuinely erased concat receivers extract through `SmeltList<SmeltUnknown>` (via `from_smelt_unknown`). No widening of statically-typed data.

## Tests
- Frontend HIR lowering tests (`part03_tests.rs`): concat on erased value-import receiver, concat on union receiver, tuple-literal push into a tuple-element array, mixed-literal push into a union-element array.
- Codegen emitted-Rust shape tests (`part_7_tests.rs`): concrete tuple push, concrete union injection push, erased/union concat receiver extraction.

## Verification
- `cargo check`, `cargo clippy`, full `cargo test` (bare) — all green.
- **es-toolkit probe delta**: both blocker classes eliminated (`array concat requires an array receiver` 5→0, `array push argument must match the array element type` 3→0); first-abort moved `uniq.ts` → `dropWhile.ts`.
- **remeda gate: 1789 passed / 0 failed.**
- Representative cases build and `cargo check` clean in a standalone generated crate.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)