### PR TITLE
Lower negative bracket indexes as JS property lookups (#79)

### DIFF
--- a/crates/smelt-cli/tests/hir_cli_typescript_tests.rs
+++ b/crates/smelt-cli/tests/hir_cli_typescript_tests.rs
@@ -89,6 +89,61 @@ console.log(Example.label);
 }
 
 #[test]
+fn build_lowers_negative_bracket_indexes_as_property_lookups() -> TestResult {
+    // Regression for issue #79: a negative (or otherwise out-of-range) bracket
+    // index is a JavaScript property lookup, not `.at(...)`. Reads yield
+    // `undefined`; a `arr[-1] = x` write sets a string-keyed property that does
+    // not change the array's elements, so it is a no-op on the collection while
+    // still evaluating its right-hand side. This program exercises array and
+    // string reads plus a negative write and asserts the runtime values.
+    let project = TempProject::new()?;
+    let project_path = project.path();
+    fs::create_dir_all(project_path.join("src"))?;
+    fs::write(
+        project_path.join("Smelt.toml"),
+        r#"[project]
+name = "ts-negative-bracket"
+version = "0.1.0"
+
+[sources]
+entries = ["src/main.ts"]
+
+[output]
+target = "./dist"
+crate-name = "ts_negative_bracket"
+build = true
+
+[runtime]
+clone-strategy = "aggressive"
+"#,
+    )?;
+    fs::write(
+        project_path.join("src/main.ts"),
+        "const array: number[] = [1, 2, 3];\n\
+array[-1] = 99;\n\
+const readNeg = array[-1];\n\
+const text = \"hi\";\n\
+const strNeg = text[-1];\n\
+console.log(array.length);\n\
+console.log(array[0]);\n\
+console.log(readNeg === undefined);\n\
+console.log(strNeg === undefined);\n",
+    )?;
+
+    let manifest_arg = utf8_path(&project_path.join("Smelt.toml"))?;
+    smelt(&["--manifest-path", &manifest_arg, "build"])?;
+
+    let actual_stdout = cargo_run_manifest(&project_path.join("dist/Cargo.toml"))?;
+    ensure_eq(
+        &actual_stdout,
+        &"3\n1\ntrue\ntrue\n".to_owned(),
+        "unexpected stdout",
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn build_resolves_typescript_index_module_imports() -> TestResult {
     let project = TempProject::new()?;
     let project_path = project.path();

--- a/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
@@ -628,6 +628,9 @@ impl ModuleBuilder<'_> {
                     {
                         return Ok(());
                     }
+                    if self.try_lower_negative_bracket_write_statement(assign, body, block)? {
+                        return Ok(());
+                    }
                     if self.array_destructuring_assignment_statement(assign, body, block)? {
                         return Ok(());
                     }
@@ -1420,6 +1423,9 @@ impl ModuleBuilder<'_> {
         let result = match statement {
             Statement::ExpressionStatement(expr_stmt) => {
                 if let Expression::AssignmentExpression(assign) = &expr_stmt.expression {
+                    if self.try_lower_negative_bracket_write_statement(assign, body, block)? {
+                        return Ok(());
+                    }
                     if self.array_destructuring_assignment_statement(assign, body, block)? {
                         return Ok(());
                     }

--- a/crates/smelt-frontend-ts/src/lowering/stmt.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt.rs
@@ -2,3 +2,4 @@
 
 mod assignments;
 mod control_flow;
+mod negative_index;

--- a/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
@@ -955,6 +955,14 @@ impl ModuleBuilder<'_> {
                 Some(Type::Optional(_))
             );
         let access_receiver_ty = self.optional_receiver_inner_type(receiver_ty);
+        // A statically-negative bracket index on an array, string, or tuple is a
+        // JavaScript property lookup that never names an element, so the read is
+        // `undefined` regardless of whether the receiver is optional. Lower it to
+        // an honest optional `None` instead of rejecting or wrapping like `.at`.
+        // (Write targets are intercepted earlier as property-store no-ops.)
+        if self.is_negative_sequence_bracket_index(access_receiver_ty, index, body) {
+            return self.lower_negative_sequence_bracket_read(access_receiver_ty, member.span, body);
+        }
         if optional_access {
             let value_ty = self.index_type(access_receiver_ty)?;
             let ty = self.optional_chain_result_type(value_ty);
@@ -1030,7 +1038,6 @@ impl ModuleBuilder<'_> {
                 }));
             }
         }
-        self.reject_negative_bracket_index(access_receiver_ty, index, body, member.span)?;
         if self.can_lower_acknowledged_unknown_index(access_receiver_ty, member.span.start) {
             let ty = self.ctx.krate.types.intern(Type::Unknown);
             return Ok(body.push_expr(Expr {

--- a/crates/smelt-frontend-ts/src/lowering/stmt/negative_index.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/negative_index.rs
@@ -1,0 +1,158 @@
+//! JavaScript negative / out-of-range bracket-index lowering.
+//!
+//! In JavaScript an element bracket access such as `arr[-1]` or `str[-1]` is a
+//! *property* lookup, not an element lookup. A negative numeric key never names
+//! an array element or string character, so the read evaluates to `undefined`
+//! and a write (`arr[-1] = x`) stores an ordinary string-keyed property that
+//! does not change the array's elements or `length`.
+//!
+//! This is deliberately distinct from `Array.prototype.at(-1)` / `String.at`,
+//! which wrap negative offsets to count from the end. Smelt therefore does not
+//! rewrite `arr[-1]` into `.at(-1)`; it models the true JavaScript property
+//! semantics: reads become `undefined` and writes become no-ops on the
+//! collection (their right-hand side is still evaluated for side effects).
+//!
+//! Only *statically* negative literal indexes are handled here — the same class
+//! the frontend previously rejected (`-1`, `-(2)`). A fully dynamic computed
+//! index whose sign is unknown at compile time is not in scope and keeps its
+//! existing runtime lowering.
+
+use oxc::ast::ast::{AssignmentTarget, Expression};
+
+use smelt_hir::{Body, Expr, ExprKind, Literal, Stmt, Type};
+
+use crate::lowering::ModuleBuilder;
+use crate::SmeltError;
+
+impl ModuleBuilder<'_> {
+    /// Returns true when a receiver type uses fixed sequence element indexing.
+    ///
+    /// Arrays, strings, and tuples index by element position, so a negative
+    /// numeric bracket key on any of them is a JavaScript property lookup rather
+    /// than an element access. Records/maps and dynamic (`unknown`) receivers use
+    /// key lookups where a negative number is a perfectly valid key, so they are
+    /// intentionally excluded.
+    pub(in crate::lowering) fn is_sequence_indexing_receiver(
+        &self,
+        receiver_ty: smelt_hir::TypeId,
+    ) -> bool {
+        matches!(
+            self.ctx.krate.types.get(receiver_ty),
+            Some(Type::List(_) | Type::String | Type::Tuple(_))
+        )
+    }
+
+    /// Returns true when a sequence bracket access uses a statically negative
+    /// literal index and therefore has JavaScript property-lookup semantics.
+    pub(in crate::lowering) fn is_negative_sequence_bracket_index(
+        &self,
+        receiver_ty: smelt_hir::TypeId,
+        index: smelt_hir::ExprId,
+        body: &Body,
+    ) -> bool {
+        self.is_sequence_indexing_receiver(receiver_ty)
+            && Self::is_negative_numeric_expr(body, index)
+    }
+
+    /// Lower a statically-negative sequence bracket *read* to `undefined`.
+    ///
+    /// JavaScript yields `undefined` for any out-of-range property lookup, so the
+    /// value is statically known. The result is a `None` literal typed as an
+    /// optional of the collection's element type, keeping the lowered value's
+    /// type honest (undefined-able) instead of pretending the element is present.
+    pub(in crate::lowering) fn lower_negative_sequence_bracket_read(
+        &mut self,
+        receiver_ty: smelt_hir::TypeId,
+        span: oxc::span::Span,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let element_ty = self.index_type(receiver_ty)?;
+        let ty = self.optional_chain_result_type(element_ty);
+        Ok(body.push_expr(Expr {
+            kind: ExprKind::Literal(Literal::None),
+            ty,
+            span: self.span(span.start, span.end),
+        }))
+    }
+
+    /// Try to lower a statement-level assignment whose target is a statically
+    /// negative sequence bracket index.
+    ///
+    /// `arr[-1] = value` in JavaScript sets a string-keyed property on the array
+    /// object; it does not grow the array or change any element. On Smelt's
+    /// `Vec`-backed sequences there is no such property slot, so the faithful
+    /// lowering is a no-op on the collection. The right-hand side is still
+    /// lowered and emitted as a discarded expression statement so its side
+    /// effects (calls, updates) are preserved and evaluation order is unchanged.
+    ///
+    /// Returns `Ok(true)` when the target matched and a statement was emitted,
+    /// `Ok(false)` when the target is not a negative sequence bracket write and
+    /// normal assignment lowering should proceed.
+    pub(in crate::lowering) fn try_lower_negative_bracket_write_statement(
+        &mut self,
+        assign: &oxc::ast::ast::AssignmentExpression<'_>,
+        body: &mut Body,
+        block: smelt_hir::BlockId,
+    ) -> Result<bool, SmeltError> {
+        // Only a plain `=` write mirrors the property-store semantics cleanly. A
+        // compound write (`arr[-1] += x`) would first read the (undefined)
+        // property; that case is rare and left to normal lowering.
+        if assign.operator != oxc::syntax::operator::AssignmentOperator::Assign {
+            return Ok(false);
+        }
+        let Some(member) = Self::assignment_target_computed_member(&assign.left) else {
+            return Ok(false);
+        };
+        if !Self::computed_member_has_negative_literal_index(member) {
+            return Ok(false);
+        }
+        // Resolve the receiver type to confirm it is a fixed sequence before
+        // treating the negative index as a property write rather than a key.
+        let receiver = self.expression(&member.object, body)?;
+        let receiver_ty = Self::expr_ty(body, receiver);
+        let access_receiver_ty = self.optional_receiver_inner_type(receiver_ty);
+        if !self.is_sequence_indexing_receiver(access_receiver_ty) {
+            return Ok(false);
+        }
+        // Preserve right-hand-side side effects and evaluation order; the write
+        // itself is a no-op on the collection.
+        let value = self.expression(&assign.right, body)?;
+        body.push_stmt_to_block(block, Stmt::Expr(value));
+        Ok(true)
+    }
+
+    /// Extract the computed member expression from an assignment target, if any.
+    ///
+    /// `AssignmentTarget` flattens `SimpleAssignmentTarget`'s member-expression
+    /// variants, so a computed member target such as `arr[-1]` appears directly
+    /// as `AssignmentTarget::ComputedMemberExpression`.
+    fn assignment_target_computed_member<'a>(
+        target: &'a AssignmentTarget<'a>,
+    ) -> Option<&'a oxc::ast::ast::ComputedMemberExpression<'a>> {
+        match target {
+            AssignmentTarget::ComputedMemberExpression(member) => Some(member),
+            _ => None,
+        }
+    }
+
+    /// Returns true when a computed member's index is a statically negative
+    /// numeric literal (`arr[-1]`, `arr[-(2)]`).
+    fn computed_member_has_negative_literal_index(
+        member: &oxc::ast::ast::ComputedMemberExpression<'_>,
+    ) -> bool {
+        Self::source_expression_is_negative_numeric_literal(&member.expression)
+    }
+
+    /// Returns true when a source expression is a negative numeric literal,
+    /// including a unary negation of a numeric literal.
+    fn source_expression_is_negative_numeric_literal(expression: &Expression<'_>) -> bool {
+        match expression {
+            Expression::UnaryExpression(unary) => {
+                unary.operator == oxc::syntax::operator::UnaryOperator::UnaryNegation
+                    && matches!(&unary.argument, Expression::NumericLiteral(literal) if literal.value != 0.0)
+            }
+            Expression::NumericLiteral(literal) => literal.value < 0.0,
+            _ => false,
+        }
+    }
+}

--- a/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
@@ -2843,28 +2843,12 @@ return_ty: function.return_ty,
         Ok(resolved_index)
     }
 
-    /// Reject negative TypeScript bracket indexes before they reach Python-style HIR indexing.
-    pub(in crate::lowering) fn reject_negative_bracket_index(
-        &self,
-        receiver_ty: smelt_hir::TypeId,
-        index: smelt_hir::ExprId,
-        body: &Body,
-        span: oxc::span::Span,
-    ) -> Result<(), SmeltError> {
-        let uses_sequence_indexing = matches!(
-            self.ctx.krate.types.get(receiver_ty),
-            Some(Type::List(_) | Type::String | Type::Tuple(_))
-        );
-        if uses_sequence_indexing && Self::is_negative_numeric_expr(body, index) {
-            return Err(SmeltError::unsupported(
-                self.span(span.start, span.end),
-                "negative array/string bracket indexes are JavaScript property lookups; use .at(...) for negative element indexing",
-            ));
-        }
-        Ok(())
-    }
-
     /// Returns whether a lowered expression is a negative numeric literal.
+    ///
+    /// Used to recognize the JavaScript property-lookup class of bracket access
+    /// (`arr[-1]`, `arr[-(2)]`) so it can be lowered with `undefined`/no-op
+    /// semantics rather than element indexing. See the `negative_index` lowering
+    /// module for how reads and writes are lowered.
     pub(in crate::lowering) fn is_negative_numeric_expr(body: &Body, expr_id: smelt_hir::ExprId) -> bool {
         let Ok(expr_index) = usize::try_from(expr_id.0) else {
             return false;

--- a/crates/smelt-frontend-ts/src/tests/part02_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part02_tests.rs
@@ -220,7 +220,11 @@ for (let ch: string of word) {
 }
 
 #[test]
-fn lowers_array_at_and_rejects_negative_bracket_index() -> Result<(), String> {
+fn distinguishes_array_at_from_negative_bracket_index() -> Result<(), String> {
+    // `.at(-1)` wraps to count from the end and lowers to optional indexing,
+    // whereas a negative bracket index `[-1]` is a JavaScript property lookup
+    // that yields `undefined`. The two must stay distinct: bracket access must
+    // not become `.at`.
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(
         ts!(r#"
@@ -229,25 +233,47 @@ const last = values.at(-1);
 "#),
         &mut ctx,
     )?;
-    let module = module(&ctx, module_id)?;
-    let body = module_body(&ctx, module)?;
+    let at_module = module(&ctx, module_id)?;
+    let at_body = module_body(&ctx, at_module)?;
 
     ensure!(
-        body.exprs
+        at_body
+            .exprs
             .iter()
             .any(|expr| matches!(expr.kind, ExprKind::OptionalIndex { .. })),
         "array .at should lower to optional indexing"
     );
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
 
-    let errors = lowering_errors(
+    // A negative bracket index now lowers successfully to an optional `None`
+    // (undefined) rather than being rejected, and it does not emit an element
+    // `Index` access (i.e. it is not rewritten into `.at`).
+    let mut bracket_ctx = HirCtx::new();
+    let bracket_module_id = lower_ok(
         ts!(r#"
 const values: number[] = [1, 2, 3];
-const invalid = values[-1];
+const missing = values[-1];
 "#),
-        &mut HirCtx::new(),
+        &mut bracket_ctx,
     )?;
-    assert_unsupported_ts(&errors, "negative array/string bracket indexes")
+    let bracket_module = module(&bracket_ctx, bracket_module_id)?;
+    let bracket_body = module_body(&bracket_ctx, bracket_module)?;
+    ensure!(
+        bracket_body.exprs.iter().any(|expr| {
+            matches!(expr.kind, ExprKind::Literal(Literal::None))
+                && matches!(bracket_ctx.krate.types.get(expr.ty), Some(Type::Optional(_)))
+        }),
+        "negative bracket index should lower to an optional None literal",
+    );
+    ensure!(
+        !bracket_body
+            .exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Index { .. })),
+        "negative bracket index must not emit an element Index access",
+    );
+    ensure!(smelt_hir::validate(&bracket_ctx.krate).is_empty());
+    Ok(())
 }
 
 #[test]

--- a/crates/smelt-frontend-ts/src/tests/part05_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part05_tests.rs
@@ -559,6 +559,133 @@ const count = pair[1];
 }
 
 #[test]
+fn lowers_negative_array_bracket_read_to_undefined() -> Result<(), String> {
+    // `arr[-1]` is a JavaScript property lookup that never names an element, so
+    // it lowers to an honest optional `None` (undefined) instead of rejecting or
+    // wrapping like `.at(-1)`.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+const values: number[] = [1, 2, 3];
+const missing = values[-1];
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+
+    let none_index_read = body.exprs.iter().find(|expr| {
+        matches!(expr.kind, ExprKind::Literal(Literal::None))
+            && matches!(ctx.krate.types.get(expr.ty), Some(Type::Optional(_)))
+    });
+    ensure!(
+        none_index_read.is_some(),
+        "expected negative array bracket read to lower to an optional None literal",
+    );
+    // No element `Index` read should be emitted for the negative access.
+    ensure!(
+        !body
+            .exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Index { .. })),
+        "negative array bracket read must not emit an element Index access",
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_negative_string_bracket_read_to_undefined() -> Result<(), String> {
+    // `str[-1]` mirrors the array case: an out-of-range property lookup yields
+    // `undefined`, lowered to an optional `None`.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+const text = "hello";
+const missing = text[-1];
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+
+    ensure!(
+        body.exprs.iter().any(|expr| {
+            matches!(expr.kind, ExprKind::Literal(Literal::None))
+                && matches!(ctx.krate.types.get(expr.ty), Some(Type::Optional(_)))
+        }),
+        "expected negative string bracket read to lower to an optional None literal",
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_negative_tuple_bracket_read_to_undefined() -> Result<(), String> {
+    // A negative tuple bracket index is a property lookup too, so it lowers to
+    // undefined rather than a `TupleIndex` field access.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+const pair: [string, number] = ["Ada", 1];
+const missing = pair[-1];
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+
+    ensure!(
+        body.exprs.iter().any(|expr| {
+            matches!(expr.kind, ExprKind::Literal(Literal::None))
+                && matches!(ctx.krate.types.get(expr.ty), Some(Type::Optional(_)))
+        }),
+        "expected negative tuple bracket read to lower to an optional None literal",
+    );
+    ensure!(
+        !body
+            .exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::TupleIndex { .. })),
+        "negative tuple bracket read must not emit a TupleIndex field access",
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_negative_array_bracket_write_as_noop() -> Result<(), String> {
+    // `arr[-1] = value` sets a string-keyed property that does not change the
+    // array's elements, so the write is a no-op on the collection. The
+    // right-hand side is still evaluated (as a discarded expression statement)
+    // to preserve its side effects and no element assignment is produced.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+const values: number[] = [1, 2, 3];
+values[-1] = 99;
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+
+    ensure!(
+        !body.stmts.iter().any(|stmt| matches!(
+            stmt,
+            Stmt::Assign { target, .. }
+                if usize::try_from(target.0)
+                    .ok()
+                    .and_then(|index| body.exprs.get(index))
+                    .is_some_and(|expr| matches!(expr.kind, ExprKind::Index { .. }))
+        )),
+        "negative array bracket write must not emit an element assignment",
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn rejects_dynamic_tuple_index() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let errors = lowering_errors(


### PR DESCRIPTION
## Summary

Closes #79.

In JavaScript, an element bracket access such as `arr[-1]` or `str[-1]` is a **property lookup**, not element indexing — a negative numeric key never names an array element or string character. Smelt previously rejected these with a `use .at(...)` blocker, breaking source compatibility (es-toolkit and others rely on `arr[-1] = x` having no effect on the array).

This models the true JavaScript semantics, kept **distinct from `.at(-1)`** (which wraps to count from the end):

- **Reads** — `arr[-1]`, `str[-1]`, `tuple[-1]`, `arr[-(2)]` lower to an honest optional `None` (undefined) instead of an element access. The result type is `Optional<element>`.
- **Writes** — `arr[-1] = value` becomes a **no-op on the collection**: the right-hand side is still evaluated (emitted as a discarded expression statement) so side effects and evaluation order are preserved, but no element is written. A `Vec`-backed array has no string-keyed property slot, so this faithfully matches JS, where such a write does not change elements or `.length`.

The statically-negative literal class (exactly what the old gate rejected) is handled entirely in the frontend; fully dynamic computed indexes keep their existing runtime lowering. No per-library special cases.

## Design

- New focused, documented module `crates/smelt-frontend-ts/src/lowering/stmt/negative_index.rs` holding the detection + read/write lowering helpers.
- Read path: `computed_member` returns the optional `None` for a negative sequence bracket index before the tuple/optional/index branches.
- Write path: statement-level assignment handlers call `try_lower_negative_bracket_write_statement` first (alongside the existing array-destructuring hook).
- Removed the now-unused `reject_negative_bracket_index` gate; kept `is_negative_numeric_expr` (now used by the new module).

## Tests

- Frontend lowering tests: negative array/string/tuple reads lower to optional `None` (no `Index`/`TupleIndex`); negative array write emits no element assignment; updated the `.at` vs bracket test to assert the two stay distinct.
- End-to-end compile + run test (`build_lowers_negative_bracket_indexes_as_property_lookups`) building a TS module, compiling the emitted Rust, and asserting runtime values (`array.length` unchanged after `arr[-1] = 99`; `arr[-1]`/`str[-1]` read as `undefined`).

## Verification

- `cargo check`, `cargo clippy`, full `cargo test` (bare, default members): green.
- **remeda gate: 1789 passed / 0 failed** (no regression).
- **es-toolkit probe**: negative-bracket blocker eliminated; files-with-blockers dropped 53 → 50 (the 3 affected files — `nth.spec.ts`, `sortedIndexOf.spec.ts`, `sortedLastIndexOf.spec.ts` — now lower cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)