### PR TITLE
feat(ts): lower switch over enum-member and const-reference case labels

### DIFF
--- a/crates/smelt-cli/src/lowering.rs
+++ b/crates/smelt-cli/src/lowering.rs
@@ -88,6 +88,8 @@ struct FrontendLoweringState {
     ts_object_value_collections: HashMap<String, smelt_frontend_ts::ConstCollection>,
     /// TypeScript exported array/set constants visible across manifest entries.
     ts_const_collections: HashMap<String, smelt_frontend_ts::ConstCollection>,
+    /// TypeScript const-folded `enum` member values visible across manifest entries.
+    ts_enum_members: HashMap<String, HashMap<String, smelt_frontend_ts::ConstLiteral>>,
     /// TypeScript overload signatures visible across manifest entries.
     ts_overloads: HashMap<String, Vec<smelt_frontend_ts::OverloadSignature>>,
     /// TypeScript rest-parameter metadata visible across manifest entries.
@@ -649,6 +651,7 @@ fn lower_manifest_source(
                 object_consts: state.ts_object_consts,
                 object_value_collections: state.ts_object_value_collections,
                 const_collections: state.ts_const_collections,
+                enum_members: state.ts_enum_members,
                 overloads: state.ts_overloads,
                 function_rests: state.ts_function_rests,
                 date_returning_functions: state.ts_date_returning_functions,
@@ -684,6 +687,7 @@ fn lower_manifest_source(
                 ts_object_consts: ctx.object_consts,
                 ts_object_value_collections: ctx.object_value_collections,
                 ts_const_collections: ctx.const_collections,
+                ts_enum_members: ctx.enum_members,
                 ts_overloads: ctx.overloads,
                 ts_function_rests: ctx.function_rests,
                 ts_date_returning_functions: ctx.date_returning_functions,
@@ -729,6 +733,7 @@ fn lower_manifest_source(
                 ts_object_consts: state.ts_object_consts,
                 ts_object_value_collections: state.ts_object_value_collections,
                 ts_const_collections: state.ts_const_collections,
+                ts_enum_members: state.ts_enum_members,
                 ts_overloads: state.ts_overloads,
                 ts_function_rests: state.ts_function_rests,
                 ts_date_returning_functions: state.ts_date_returning_functions,

--- a/crates/smelt-codegen-rust/src/emitter/control_flow_match.rs
+++ b/crates/smelt-codegen-rust/src/emitter/control_flow_match.rs
@@ -84,7 +84,11 @@ impl FunctionEmitter<'_> {
     /// Converts a match scrutinee operand to its Rust text representation.
     pub(super) fn match_scrutinee_text(&self, operand: &Operand) -> Result<String, EmitError> {
         let operand_ty = self.operand_ty(operand)?;
-        if operand_ty == self.type_id(Type::String)? {
+        // Compare the resolved type directly rather than interning `Type::String`
+        // and comparing ids: a program that never uses a string (e.g. a switch
+        // over a purely numeric enum) may not have `Type::String` in the type
+        // table at all, and requiring it there would spuriously error.
+        if self.mir.types.get(operand_ty) == Some(&Type::String) {
             match operand {
                 Operand::Copy(place) | Operand::Move(place) => {
                     Ok(format!("{}.as_str()", self.place_text(place)?))

--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -439,6 +439,85 @@ export function sum(adder: Adder): number {
 }
 ",
         },
+        Case {
+            // Issue #78: `switch` over non-literal case labels. Enum-member and
+            // const-reference labels const-fold to the member's numeric/string
+            // literal, and the enum type resolves to its underlying primitive so
+            // the scrutinee matches the folded arms and the emitted Rust
+            // compiles.
+            name: "switch_nonliteral_case_labels",
+            area: "control_flow",
+            source: r#"
+enum Color {
+  Red = 0,
+  Green = 1,
+  Blue = 2,
+}
+
+enum Fruit {
+  Apple,
+  Banana,
+  Cherry,
+}
+
+enum Level {
+  Low = "low",
+  High = "high",
+}
+
+const OTHER_TAG = "[object Other]";
+
+export function colorName(c: Color): string {
+  switch (c) {
+    case Color.Red:
+      return "red";
+    case Color.Green:
+      return "green";
+    case Color.Blue:
+      return "blue";
+    default:
+      return "unknown";
+  }
+}
+
+export function fruitRank(f: Fruit): number {
+  switch (f) {
+    case Fruit.Apple:
+      return 10;
+    case Fruit.Banana:
+      return 20;
+    case Fruit.Cherry:
+      return 30;
+    default:
+      return 0;
+  }
+}
+
+export function levelLabel(l: Level): string {
+  switch (l) {
+    case Level.Low:
+      return "lo";
+    case Level.High:
+      return "hi";
+    default:
+      return "x";
+  }
+}
+
+export function classify(tag: string): number {
+  switch (tag) {
+    case OTHER_TAG:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+export function redValue(): number {
+  return Color.Red;
+}
+"#,
+        },
     ]
 }
 

--- a/crates/smelt-frontend-ts/src/context.rs
+++ b/crates/smelt-frontend-ts/src/context.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::lowering::{ConstCollection, RestParam};
+use crate::lowering::{ConstCollection, ConstLiteral, RestParam};
 use smelt_hir::{
     Crate as HirCrate, ExprKind, Field, FunctionType, ItemId, Literal, TypeId, TypeParamDef,
 };
@@ -102,6 +102,13 @@ pub struct HirCtx {
     pub object_value_collections: HashMap<String, ConstCollection>,
     /// Exported array/set constants that can be inlined by later modules.
     pub const_collections: HashMap<String, ConstCollection>,
+    /// Const-folded TypeScript `enum` member values visible to later modules.
+    ///
+    /// Keyed by enum name then member name. Populated when an `enum`
+    /// declaration is lowered, and read by later modules so an imported enum's
+    /// members still fold to their constant literal in `EnumName.Member` reads
+    /// and `case EnumName.Member:` labels.
+    pub enum_members: HashMap<String, HashMap<String, ConstLiteral>>,
     /// Function overload signatures visible to later TypeScript modules.
     pub overloads: HashMap<String, Vec<OverloadSignature>>,
     /// Rest-parameter metadata visible to later TypeScript modules.
@@ -136,6 +143,7 @@ impl HirCtx {
             object_consts: HashMap::new(),
             object_value_collections: HashMap::new(),
             const_collections: HashMap::new(),
+            enum_members: HashMap::new(),
             overloads: HashMap::new(),
             function_rests: HashMap::new(),
             date_returning_functions: HashSet::new(),

--- a/crates/smelt-frontend-ts/src/lib.rs
+++ b/crates/smelt-frontend-ts/src/lib.rs
@@ -70,8 +70,8 @@ pub use context::{
 pub use error::SmeltError;
 pub use ident::camel_to_snake;
 pub use lowering::{
-    ConstCollection, FrontendOptions, InterfaceHeritageRef, RestParam, to_hir, to_hir_with_options,
-    to_hir_with_path,
+    ConstCollection, ConstLiteral, FrontendOptions, InterfaceHeritageRef, RestParam, to_hir,
+    to_hir_with_options, to_hir_with_path,
 };
 
 #[cfg(test)]

--- a/crates/smelt-frontend-ts/src/lowering.rs
+++ b/crates/smelt-frontend-ts/src/lowering.rs
@@ -59,8 +59,14 @@ enum TestMatcher {
 }
 
 /// Constant expression exported from another TypeScript module.
+///
+/// Also used to carry const-folded TypeScript `enum` member values across
+/// modules (see [`HirCtx::enum_members`]): each enum member resolves to one of
+/// these so `EnumName.Member` reads and `case EnumName.Member:` labels inline
+/// the same literal. Public so the sibling [`crate::context`] module can store
+/// the cross-module enum-member map, mirroring `ConstCollection`.
 #[derive(Debug, Clone)]
-struct ConstLiteral {
+pub struct ConstLiteral {
     /// Literal expression to inline at import use sites.
     literal: Literal,
     /// HIR type of the literal.
@@ -438,6 +444,14 @@ struct ModuleBuilder<'ctx> {
     object_namespaces: HashMap<String, HashMap<String, smelt_hir::ItemId>>,
     /// Literal constant items visible from already-lowered modules.
     const_literals: HashMap<String, ConstLiteral>,
+    /// Const-folded TypeScript `enum` member values keyed by enum name then
+    /// member name.
+    ///
+    /// Populated from `enum` declarations in the current module and seeded from
+    /// [`HirCtx::enum_members`] for enums declared in earlier modules. Lets
+    /// `EnumName.Member` reads and `case EnumName.Member:` labels inline the
+    /// member's constant literal.
+    enum_member_literals: HashMap<String, HashMap<String, ConstLiteral>>,
     /// `RegExp` literal constants visible from nested function bodies.
     const_regexps: HashMap<String, (String, String, smelt_hir::TypeId)>,
     /// Object literal constants visible from current and already-lowered modules.

--- a/crates/smelt-frontend-ts/src/lowering/decls.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls.rs
@@ -1,7 +1,8 @@
 //! Declaration lowering: functions, arrow-const decls, type aliases,
-//! interfaces, and the constructor-function idiom.
+//! interfaces, enums, and the constructor-function idiom.
 
 mod arrows;
 mod constructor;
+mod enums;
 mod functions;
 mod types_iface;

--- a/crates/smelt-frontend-ts/src/lowering/decls/arrows.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/arrows.rs
@@ -923,6 +923,15 @@ return_ty: target_function.return_ty,
         &mut self,
         member: &oxc::ast::ast::StaticMemberExpression<'_>,
     ) -> Result<ConstLiteral, SmeltError> {
+        // A `case EnumName.Member:` label or an enum-member operand inside
+        // another foldable const expression resolves to the member's
+        // const-folded value.
+        if let Expression::Identifier(object) = &member.object
+            && let Some(value) =
+                self.enum_member_literal(object.name.as_str(), member.property.name.as_str())
+        {
+            return Ok(value);
+        }
         if let Expression::Identifier(object) = &member.object {
             let value = match (object.name.as_str(), member.property.name.as_str()) {
                 ("Number", "NaN") => Some(f64::NAN),

--- a/crates/smelt-frontend-ts/src/lowering/decls/enums.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/enums.rs
@@ -1,0 +1,199 @@
+//! TypeScript `enum` declaration lowering into const-folded member values.
+//!
+//! Smelt does not materialize a distinct HIR enum type. Instead it treats an
+//! `enum` as a namespace of compile-time constants: each member folds to a
+//! numeric or string [`Literal`], exactly as TypeScript itself computes enum
+//! member values. The folded values are stored in
+//! [`ModuleBuilder::enum_member_literals`] (and mirrored into
+//! [`crate::context::HirCtx::enum_members`] for later modules), so that
+//! `EnumName.Member` reads and `case EnumName.Member:` switch labels can inline
+//! the same literal a manual `const` would produce.
+//!
+//! This keeps enum usage flowing through the general const-folding rules rather
+//! than a per-enum special case: a member is registered only when its value can
+//! be resolved at compile time (an explicit literal/foldable initializer, an
+//! implicit auto-increment from the previous numeric member, or a reference to
+//! an already-folded member of the same enum). Members whose value cannot be
+//! resolved statically are simply not registered, so a later reference falls
+//! through to the honest unsupported-lowering blocker instead of silently
+//! producing a wrong value.
+//!
+//! A TypeScript `enum` also names a *type* (`function f(c: Color)`). Since an
+//! enum is lowered to its member literals, its natural underlying type is the
+//! primitive those literals share — `Float` for a numeric enum, `String` for a
+//! string enum. When every folded member shares one primitive, the enum name is
+//! registered as a HIR type alias to that primitive so `c: Color` lowers to the
+//! concrete `f64`/`String` and a `switch (c)` over folded numeric/string case
+//! labels type-checks. Mixed or unresolved enums register no alias and keep
+//! their opaque type.
+
+use oxc::ast::ast::{Expression, TSEnumDeclaration, TSEnumMemberName};
+
+use crate::lowering::{ConstLiteral, ModuleBuilder};
+use smelt_hir::{Item, Literal, Type, TypeAlias};
+
+impl ModuleBuilder<'_> {
+    /// Const-fold every statically-resolvable member of an `enum` declaration
+    /// and register the results under the enum's name.
+    ///
+    /// Mirrors TypeScript's own member-value computation:
+    /// - An explicit initializer is folded through the shared const-expression
+    ///   folder ([`Self::literal_const_expression`]); numeric results also
+    ///   advance the auto-increment counter to `value + 1`.
+    /// - A member without an initializer takes the running auto-increment value
+    ///   (starting at `0`), then advances the counter.
+    /// - A member initializer may reference an earlier member of the same enum
+    ///   (`A = 1, B = A`); those references resolve against members folded so
+    ///   far in this call.
+    ///
+    /// Registration is best-effort: any member whose value cannot be resolved
+    /// at compile time is skipped so its later use produces the ordinary
+    /// unsupported blocker rather than an incorrect constant.
+    pub(in crate::lowering) fn collect_enum_declaration(&mut self, decl: &TSEnumDeclaration<'_>) {
+        let enum_name = decl.id.name.to_string();
+        let float_ty = self.ctx.krate.types.intern(Type::Float);
+        let mut members: std::collections::HashMap<String, ConstLiteral> =
+            std::collections::HashMap::new();
+        // Running value for members declared without an initializer. TypeScript
+        // starts implicit numbering at 0 and increments after each numeric
+        // member (implicit or explicit numeric).
+        let mut next_auto = 0.0_f64;
+
+        for member in &decl.body.members {
+            let Some(member_name) = Self::enum_member_name(&member.id) else {
+                continue;
+            };
+
+            let value = if let Some(initializer) = &member.initializer {
+                // Unresolvable initializer: skip this member. A string member
+                // (or any non-numeric value) also stops implicit auto-increment
+                // in TypeScript, but since we could not fold it we leave the
+                // counter untouched and let downstream code report the gap.
+                let Some(value) = self.enum_member_initializer_literal(initializer, &members) else {
+                    continue;
+                };
+                value
+            } else {
+                let literal = ConstLiteral {
+                    literal: Literal::Float(next_auto),
+                    ty: float_ty,
+                };
+                next_auto += 1.0_f64;
+                literal
+            };
+
+            // Keep the auto-increment counter aligned after an explicit numeric
+            // member so a following implicit member continues from `value + 1`.
+            if let Literal::Float(number) = value.literal {
+                next_auto = number + 1.0_f64;
+            }
+
+            members.insert(member_name.to_owned(), value);
+        }
+
+        if members.is_empty() {
+            return;
+        }
+
+        // Register the enum name as a type alias to the primitive its members
+        // share, so `c: EnumName` annotations lower to `f64`/`String` and the
+        // switch scrutinee matches the folded case labels.
+        self.register_enum_underlying_type(decl, &enum_name, &members);
+
+        // Publish to the current module for immediate use, and to the shared
+        // context so later modules that import this enum fold its members too.
+        self.enum_member_literals
+            .insert(enum_name.clone(), members.clone());
+        self.ctx.enum_members.insert(enum_name, members);
+    }
+
+    /// Register the enum name as a HIR type alias to its underlying primitive.
+    ///
+    /// Only registers when every folded member shares one primitive literal
+    /// kind (all numeric or all string); a mixed or heterogeneous enum keeps its
+    /// opaque type so no incorrect concrete type leaks. The alias mirrors an
+    /// ordinary `type EnumName = number | string`-style declaration and is
+    /// pushed into the shared crate so later modules resolve the imported enum's
+    /// type identically.
+    fn register_enum_underlying_type(
+        &mut self,
+        decl: &TSEnumDeclaration<'_>,
+        enum_name: &str,
+        members: &std::collections::HashMap<String, ConstLiteral>,
+    ) {
+        let all_float = members
+            .values()
+            .all(|value| matches!(value.literal, Literal::Float(_)));
+        let all_string = members
+            .values()
+            .all(|value| matches!(value.literal, Literal::String(_)));
+        let underlying = if all_float {
+            Type::Float
+        } else if all_string {
+            Type::String
+        } else {
+            return;
+        };
+        let ty = self.ctx.krate.types.intern(underlying);
+        let name_text = self.qualified_type_declaration_name(enum_name);
+        let name = self.intern_type_name(&name_text);
+        let item = self.ctx.krate.push_item(Item::TypeAlias(TypeAlias {
+            name,
+            type_params: Vec::new(),
+            ty,
+            span: self.span(decl.span.start, decl.span.end),
+        }));
+        self.items.insert(name_text, item);
+    }
+
+    /// Fold an `enum` member initializer, resolving references to earlier
+    /// members of the same enum against `members`.
+    ///
+    /// Returns `None` when the initializer is not a compile-time constant so the
+    /// caller can skip registering the member.
+    fn enum_member_initializer_literal(
+        &mut self,
+        initializer: &Expression<'_>,
+        members: &std::collections::HashMap<String, ConstLiteral>,
+    ) -> Option<ConstLiteral> {
+        // `A = 1, B = A`: a bare identifier that names an earlier member folds
+        // to that member's value. Checked before the general folder so an
+        // enum-local name shadows any module const with the same spelling.
+        if let Expression::Identifier(ident) = initializer
+            && let Some(value) = members.get(ident.name.as_str())
+        {
+            return Some(value.clone());
+        }
+        self.literal_const_expression(initializer).ok()
+    }
+
+    /// Return the source spelling of a supported enum member name.
+    ///
+    /// Only plain identifier and string-literal member names have a stable
+    /// runtime key that a `case EnumName.Member:` label or `EnumName.Member`
+    /// read can reference; computed names are not lowered.
+    fn enum_member_name<'a>(name: &'a TSEnumMemberName<'a>) -> Option<&'a str> {
+        match name {
+            TSEnumMemberName::Identifier(ident) => Some(ident.name.as_str()),
+            TSEnumMemberName::String(string) => Some(string.value.as_str()),
+            TSEnumMemberName::ComputedString(_) | TSEnumMemberName::ComputedTemplateString(_) => {
+                None
+            }
+        }
+    }
+
+    /// Resolve `EnumName.Member` to its const-folded member value, if known.
+    ///
+    /// Shared by the switch-label folder and the ordinary static-member reader
+    /// so both inline the identical literal for an enum member reference.
+    pub(in crate::lowering) fn enum_member_literal(
+        &self,
+        enum_name: &str,
+        member_name: &str,
+    ) -> Option<ConstLiteral> {
+        self.enum_member_literals
+            .get(enum_name)
+            .and_then(|members| members.get(member_name))
+            .cloned()
+    }
+}

--- a/crates/smelt-frontend-ts/src/lowering/module_init.rs
+++ b/crates/smelt-frontend-ts/src/lowering/module_init.rs
@@ -37,6 +37,7 @@ impl<'ctx> ModuleBuilder<'ctx> {
     ) -> Self {
         let (items, classes, interfaces) = Self::visible_items(ctx);
         let const_literals = Self::visible_const_literals(ctx);
+        let enum_member_literals = ctx.enum_members.clone();
         let const_objects = ctx.object_consts.clone();
         let const_object_value_collections = ctx.object_value_collections.clone();
         let const_collections = ctx.const_collections.clone();
@@ -91,6 +92,7 @@ impl<'ctx> ModuleBuilder<'ctx> {
             date_fns_timezone_factories: HashSet::new(),
             object_namespaces,
             const_literals,
+            enum_member_literals,
             const_regexps: HashMap::new(),
             const_objects,
             const_collections,
@@ -214,6 +216,7 @@ impl<'ctx> ModuleBuilder<'ctx> {
         let implemented_functions = implemented_function_names(program);
         self.shadow_cross_module_overloads(&implemented_functions);
         self.predeclare_type_alias_items(program);
+        self.collect_module_enums(program);
         self.collect_module_globals(program);
         self.pending_class_names = Self::program_class_names(program);
         self.collect_overload_signatures(program, &implemented_functions);
@@ -409,6 +412,10 @@ impl<'ctx> ModuleBuilder<'ctx> {
                     | Statement::TSInterfaceDeclaration(_)
                     | Statement::TSModuleDeclaration(_)
                     | Statement::TSTypeAliasDeclaration(_)
+                    // Enums are consumed during the collection phase
+                    // (`collect_module_enums`): their members are const-folded
+                    // rather than lowered into a statement, so skip them here.
+                    | Statement::TSEnumDeclaration(_)
                     | Statement::ImportDeclaration(_)
                     | Statement::ExportNamedDeclaration(_)
                     | Statement::ExportAllDeclaration(_)
@@ -504,6 +511,29 @@ impl<'ctx> ModuleBuilder<'ctx> {
     pub(super) fn shadow_cross_module_overloads(&mut self, implemented_functions: &HashSet<String>) {
         for name in implemented_functions {
             self.function_overloads.insert(name.clone(), Vec::new());
+        }
+    }
+
+    /// Const-fold every top-level `enum` declaration so member references and
+    /// `case EnumName.Member:` labels can inline the member's literal.
+    ///
+    /// Runs during the collection phase, before function bodies and switch
+    /// statements are lowered, because TypeScript hoists enum declarations: a
+    /// member may be referenced textually before the `enum` appears. Handles
+    /// both bare `enum E {}` and `export enum E {}` forms.
+    pub(super) fn collect_module_enums(&mut self, program: &Program<'_>) {
+        for statement in &program.body {
+            match statement {
+                Statement::TSEnumDeclaration(decl) => {
+                    self.collect_enum_declaration(decl);
+                }
+                Statement::ExportNamedDeclaration(export) => {
+                    if let Some(Declaration::TSEnumDeclaration(decl)) = &export.declaration {
+                        self.collect_enum_declaration(decl);
+                    }
+                }
+                _ => {}
+            }
         }
     }
 

--- a/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
@@ -242,6 +242,9 @@ impl ModuleBuilder<'_> {
         if let Some(expr) = self.global_alias_member_read(member, body)? {
             return Ok(expr);
         }
+        if let Some(expr) = self.enum_member_read(member, body) {
+            return Ok(expr);
+        }
         if let Some(expr) = self.symbol_static_member(member, body) {
             return Ok(expr);
         }
@@ -387,6 +390,33 @@ impl ModuleBuilder<'_> {
         Ok(body.push_expr(Expr {
             kind: ExprKind::Field { receiver, field },
             ty,
+            span: self.span(member.span.start, member.span.end),
+        }))
+    }
+
+    /// Lower an `EnumName.Member` read to the member's const-folded literal.
+    ///
+    /// TypeScript enums have no distinct Smelt runtime representation; each
+    /// member is a compile-time constant collected by `collect_module_enums`.
+    /// A read of a known member therefore inlines the same numeric or string
+    /// literal a manual `const` would, so ordinary enum usage compiles without a
+    /// dedicated enum type. Returns `None` for a non-enum receiver or an
+    /// unknown member so the caller continues with the general member paths.
+    pub(in crate::lowering) fn enum_member_read(
+        &self,
+        member: &oxc::ast::ast::StaticMemberExpression<'_>,
+        body: &mut Body,
+    ) -> Option<smelt_hir::ExprId> {
+        if member.optional {
+            return None;
+        }
+        let Expression::Identifier(object) = &member.object else {
+            return None;
+        };
+        let value = self.enum_member_literal(object.name.as_str(), member.property.name.as_str())?;
+        Some(body.push_expr(Expr {
+            kind: ExprKind::Literal(value.literal),
+            ty: value.ty,
             span: self.span(member.span.start, member.span.end),
         }))
     }

--- a/crates/smelt-frontend-ts/src/tests/enum_switch_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/enum_switch_tests.rs
@@ -1,0 +1,229 @@
+//! TypeScript `enum` lowering tests (issue #78).
+//!
+//! Covers const-folding of enum members into literals, the enum name resolving
+//! to its underlying primitive type, and `switch` statements whose case labels
+//! reference enum members lowering to a `Match` over the folded values.
+
+use super::*;
+
+/// Collect every `Match`-arm label across all bodies in the crate.
+fn match_arm_labels(ctx: &HirCtx) -> Vec<Literal> {
+    let mut labels = Vec::new();
+    for body in &ctx.krate.bodies {
+        for stmt in &body.stmts {
+            if let Stmt::Match { arms, .. } = stmt {
+                for arm in arms {
+                    labels.push(arm.label.clone());
+                }
+            }
+        }
+    }
+    labels
+}
+
+/// Return whether any body has a `Match` arm whose label equals `literal`.
+fn has_match_arm_label(ctx: &HirCtx, literal: &Literal) -> bool {
+    match_arm_labels(ctx).iter().any(|label| label == literal)
+}
+
+#[test]
+fn switch_over_numeric_enum_members_folds_labels() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+enum Color {
+  Red = 0,
+  Green = 1,
+  Blue = 2,
+}
+
+export function colorName(c: Color): string {
+  switch (c) {
+    case Color.Red:
+      return "red";
+    case Color.Green:
+      return "green";
+    case Color.Blue:
+      return "blue";
+    default:
+      return "unknown";
+  }
+}
+"#),
+        &mut ctx,
+    )?;
+    // Case labels resolve to the folded numeric member values.
+    for value in [0.0, 1.0, 2.0] {
+        ensure!(
+            has_match_arm_label(&ctx, &Literal::Float(value)),
+            "missing match arm for enum member value {value}"
+        );
+    }
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn numeric_enum_param_type_lowers_to_float() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+
+export function colorRank(c: Color): number {
+  switch (c) {
+    case Color.Red:
+      return 10;
+    case Color.Green:
+      return 20;
+    default:
+      return 0;
+  }
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    // Function names are interned in snake_case.
+    let function = named_function_item(&ctx, module, "color_rank")?;
+    let param = function
+        .params
+        .first()
+        .ok_or_else(|| "color_rank has no parameter".to_owned())?;
+    ensure_eq!(ctx.krate.types.get(param.ty), Some(&Type::Float));
+    // Implicit members auto-increment from 0.
+    for value in [0.0, 1.0] {
+        ensure!(has_match_arm_label(&ctx, &Literal::Float(value)));
+    }
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn switch_over_string_enum_members_folds_labels() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+enum Level {
+  Low = "low",
+  High = "high",
+}
+
+export function levelLabel(l: Level): string {
+  switch (l) {
+    case Level.Low:
+      return "lo";
+    case Level.High:
+      return "hi";
+    default:
+      return "x";
+  }
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = named_function_item(&ctx, module, "level_label")?;
+    let param = function
+        .params
+        .first()
+        .ok_or_else(|| "level_label has no parameter".to_owned())?;
+    // A string enum's underlying type is `String`.
+    ensure_eq!(ctx.krate.types.get(param.ty), Some(&Type::String));
+    for value in ["low", "high"] {
+        ensure!(
+            has_match_arm_label(&ctx, &Literal::String(value.to_owned())),
+            "missing match arm for string enum member `{value}`"
+        );
+    }
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn enum_member_read_folds_to_member_literal() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+enum Status {
+  Ok = 200,
+  NotFound = 404,
+}
+
+export function okStatus(): number {
+  return Status.Ok;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = named_function_item(&ctx, module, "ok_status")?;
+    let body = function_body(&ctx, function)?;
+    // `Status.Ok` inlines its folded numeric value instead of a field read.
+    ensure!(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Literal(Literal::Float(v)) if v == 200.0)),
+        "enum member read did not fold to its literal"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn enum_member_initializer_references_earlier_member() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+enum Flag {
+  First = 1,
+  Alias = First,
+}
+
+export function aliasValue(): number {
+  return Flag.Alias;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = named_function_item(&ctx, module, "alias_value")?;
+    let body = function_body(&ctx, function)?;
+    ensure!(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Literal(Literal::Float(v)) if v == 1.0)),
+        "enum member referencing an earlier member did not fold"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn exported_enum_is_consumed_without_error() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+export enum Direction {
+  Up,
+  Down,
+}
+
+export function isUp(d: Direction): boolean {
+  switch (d) {
+    case Direction.Up:
+      return true;
+    default:
+      return false;
+  }
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}

--- a/crates/smelt-frontend-ts/src/tests/mod.rs
+++ b/crates/smelt-frontend-ts/src/tests/mod.rs
@@ -224,3 +224,4 @@ mod specialization_tests;
 mod part07_tests;
 mod estk6_coverage_tests;
 mod class_module_tests;
+mod enum_switch_tests;


### PR DESCRIPTION
Closes #78

## Problem
A `switch` whose `case` labels are non-literal (enum members, imported/module const references) was rejected with `switch case labels must be string, number, boolean, or null literals`. This blocks es-toolkit (4 files) and is a general switch-lowering gap.

Const-reference labels (e.g. es-toolkit's `case stringTag:` where `stringTag` is an imported const) already folded through the shared const-expression folder once imports resolved. The remaining gap was TypeScript `enum` declarations, which were not lowered at all (`statement kind is not lowered yet: TSEnumDeclaration`), so `case Color.Red:` could never resolve.

## What landed
Enums now lower as a namespace of const-folded members plus an underlying primitive type, mirroring the Python frontend's `IntEnum` handling (`HirCtx::enum_members`):

- **`decls/enums.rs`** (new module) const-folds every statically resolvable enum member — explicit literal/foldable initializer, implicit auto-increment from the previous numeric member, or a reference to an earlier member of the same enum (`A = 1, B = A`). Values are stored per-module and mirrored into `HirCtx::enum_members` for cross-module visibility (threaded through the CLI lowering state).
- When every folded member shares one primitive, the enum name is registered as a HIR **type alias** to `Float`/`String`, so `c: EnumName` lowers to concrete `f64`/`String` and a `switch (c)` over folded numeric/string case labels type-checks and compiles.
- `member_literal_const_expression` resolves `EnumName.Member` for switch case labels; `static_member` resolves it for ordinary reads. Both inline the same literal a manual `const` would.
- `TSEnumDeclaration` statements are consumed during a collection phase instead of erroring.
- Hardened `match_scrutinee_text`: compares the resolved scrutinee type directly instead of interning `Type::String`, so a switch over a purely numeric enum (a program that never uses a string) no longer errors because `Type::String` is absent from the type table.

No per-library special cases — everything flows through the general const-folding and type-alias rules.

## Tests
- New `enum_switch_tests` frontend module: member folding, underlying-type resolution (numeric→`Float`, string→`String`), string enums, member reads, self-referential members, exported enums.
- New `switch_nonliteral_case_labels` compile-corpus case verifying the emitted Rust actually compiles (numeric + string enums + const-reference label).

## Gates
- `cargo check`, `cargo clippy`, full bare `cargo test`: all green.
- Compile-corpus (`--ignored`): green.
- Remeda gate: **1789 passed, 0 failed**.

## es-toolkit delta
The 4 es-toolkit switch-blocker files (`object/cloneDeepWith.ts`, `predicate/isEqualWith.ts`, `compat/object/cloneDeepWith.ts`, `compat/object/clone.ts`) all use imported-const `Tag` case labels. Verified end-to-end that a cross-module tag switch of this exact shape lowers and compiles in a full build. The probe still lists 4 occurrences because it lowers files in isolation and cannot resolve the `./tags.ts` import — a known probe artifact, not a real blocker. Enum-member switch labels (e.g. ts-pattern's `TSEnumDeclaration`) are now generally supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)