### PR TITLE
Accept coercible index types for array/string .at()

### DIFF
--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -361,6 +361,23 @@ export function containsWhole(haystack: string, needle: string): boolean {
 }
 ",
         },
+        Case {
+            // Issue #87: `.at(index)` accepts statically numeric-compatible index
+            // types beyond an exact `number`. An optional-numeric index
+            // (`number | undefined`) is coerced to the runtime `Float` the
+            // optional-index path expects, and the emitted normalized-index
+            // arithmetic must compile for both array and string receivers.
+            name: "at_index_coercion",
+            area: "collections",
+            source: r"
+export function pickOptional(values: number[], index: number | undefined): number | undefined {
+  return values.at(index);
+}
+export function pickChar(text: string, index: number | undefined): string | undefined {
+  return text.at(index);
+}
+",
+        },
         // --- async / Promise lowering ----------------------------------------
         Case {
             name: "async_await",

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/transforms.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/transforms.rs
@@ -4,7 +4,7 @@
 use crate::lowering::{
     Argument, BinOp, BinaryOperator, BindingPattern, Body, CallbackCallArg, CallbackExpr,
     CallbackExprKind, Expr, ExprKind, Expression, HashMap, ListSearchOp, Literal, ModuleBuilder,
-    SmeltError, Type, UnaryOp, UnaryOperator, UnknownKind, unknown_kind_from_typeof,
+    PrimitiveCastOp, SmeltError, Type, UnaryOp, UnaryOperator, UnknownKind, unknown_kind_from_typeof,
 };
 use oxc::span::GetSpan;
 
@@ -646,17 +646,52 @@ impl ModuleBuilder<'_> {
             _ => return Ok(None),
         };
         let index = self.argument(index_argument, body)?;
-        if self.ctx.krate.types.get(Self::expr_ty(body, index)) != Some(&Type::Float) {
-            return Err(SmeltError::unsupported(
-                self.span(call.span.start, call.span.end),
-                "array/string at index must be a number",
-            ));
-        }
+        let index = self.coerce_at_index_operand(index, call.span.start, call.span.end, body)?;
         let ty = self.ctx.krate.types.intern(Type::Optional(item_ty));
         Ok(Some(body.push_expr(Expr {
             kind: ExprKind::OptionalIndex { receiver, index },
             ty,
             span: self.span(call.span.start, call.span.end),
         })))
+    }
+
+    /// Coerce a `.at(index)` argument to the `Float` runtime type the optional
+    /// indexing path expects, or reject a genuinely non-numeric index.
+    ///
+    /// JavaScript's `Array.prototype.at`/`String.prototype.at` run `ToInteger`
+    /// on the argument, so any statically numeric-compatible index is valid even
+    /// when its Smelt type is not exactly `Float`. An index already typed `Float`
+    /// is returned unchanged (the common case). A numeric-like index (`Int`, a
+    /// numeric type-parameter constraint, or a union whose arms are all numeric),
+    /// or an optional-numeric surface (`number | undefined`), is converted with a
+    /// JS `Number(...)` cast so the emitted normalized-index arithmetic sees a
+    /// concrete `f64`. Anything else stays an explicit error: `.at` on a genuinely
+    /// non-numeric index (a string, object, or opaque `unknown`) is unsupported.
+    fn coerce_at_index_operand(
+        &mut self,
+        index: smelt_hir::ExprId,
+        span_start: u32,
+        span_end: u32,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let index_ty = Self::expr_ty(body, index);
+        if self.ctx.krate.types.get(index_ty) == Some(&Type::Float) {
+            return Ok(index);
+        }
+        if self.is_numeric_like_type(index_ty) || self.optional_numeric_surface(index_ty) {
+            let float_ty = self.ctx.krate.types.intern(Type::Float);
+            return Ok(body.push_expr(Expr {
+                kind: ExprKind::PrimitiveCast {
+                    op: PrimitiveCastOp::ToJsNumber,
+                    operand: index,
+                },
+                ty: float_ty,
+                span: self.span(span_start, span_end),
+            }));
+        }
+        Err(SmeltError::unsupported(
+            self.span(span_start, span_end),
+            "array/string at index must be a number",
+        ))
     }
 }

--- a/crates/smelt-frontend-ts/src/tests/part02_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part02_tests.rs
@@ -277,6 +277,100 @@ const missing = values[-1];
 }
 
 #[test]
+fn coerces_optional_numeric_at_index() -> Result<(), String> {
+    // `.at(index)` where `index` is `number | undefined` is statically
+    // numeric-compatible: JavaScript runs `ToInteger` on the argument, treating
+    // `undefined` as `0`. The frontend must coerce such an optional-numeric index
+    // to the runtime `Float` the optional-indexing path expects (via a
+    // `Number(...)` primitive cast) instead of rejecting it.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function pick(values: number[], index: number | undefined): number | undefined {
+  return values.at(index);
+}
+"#),
+        &mut ctx,
+    )?;
+    // The `.at` call lives in the `pick` function body, so scan every body.
+    let _ = module_id;
+    let has_optional_index = ctx
+        .krate
+        .bodies
+        .iter()
+        .any(|body| body.exprs.iter().any(|expr| {
+            matches!(expr.kind, ExprKind::OptionalIndex { .. })
+        }));
+    ensure!(
+        has_optional_index,
+        "array .at with optional-numeric index should lower to optional indexing"
+    );
+    let has_number_cast = ctx.krate.bodies.iter().any(|body| {
+        body.exprs.iter().any(|expr| {
+            matches!(
+                expr.kind,
+                ExprKind::PrimitiveCast {
+                    op: PrimitiveCastOp::ToJsNumber,
+                    ..
+                }
+            )
+        })
+    });
+    ensure!(
+        has_number_cast,
+        "optional-numeric .at index should be coerced with a Number(...) cast"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn coerces_numeric_type_param_at_index() -> Result<(), String> {
+    // A generic index constrained to `number` is numeric-like through its type
+    // parameter constraint, so `.at` must coerce rather than reject it.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function pickAt<T extends number>(values: string[], index: T): string | undefined {
+  return values.at(index);
+}
+"#),
+        &mut ctx,
+    )?;
+    // Lowering succeeded (`lower_ok`); confirm the `.at` call became optional
+    // indexing across the lowered function bodies.
+    let _ = module_id;
+    let has_optional_index = ctx
+        .krate
+        .bodies
+        .iter()
+        .any(|body| body.exprs.iter().any(|expr| {
+            matches!(expr.kind, ExprKind::OptionalIndex { .. })
+        }));
+    ensure!(
+        has_optional_index,
+        "array .at with a numeric type-param index should lower to optional indexing"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn rejects_non_numeric_at_index() -> Result<(), String> {
+    // A genuinely non-numeric index (here a string) is not coercible and must
+    // stay an explicit unsupported diagnostic rather than being silently coerced.
+    let errors = lowering_errors(
+        ts!(r#"
+function pick(values: number[], key: string): number | undefined {
+  return values.at(key);
+}
+"#),
+        &mut HirCtx::new(),
+    )?;
+    assert_unsupported_ts(&errors, "array/string at index must be a number")
+}
+
+#[test]
 fn lowers_math_abs_call() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(


### PR DESCRIPTION
## Summary

`Array.prototype.at` / `String.prototype.at` previously rejected any index whose Smelt type was not exactly `Float`, emitting `array/string at index must be a number`. This is an es-toolkit blocker, where the index commonly arrives as `number | undefined` or a numeric type-parameter constraint rather than a plain `number`.

JavaScript runs `ToInteger` on the `.at` argument, so any statically numeric-compatible index is valid. `collection_at_call` (in `crates/smelt-frontend-ts/src/lowering/callbacks/transforms.rs`) now coerces such an index to the runtime `Float` the optional-index path expects, via a JS `Number(...)` cast (`PrimitiveCastOp::ToJsNumber`), instead of rejecting it.

The coercion decision reuses the existing numeric predicates (`is_numeric_like_type`, `optional_numeric_surface`) so it stays general — no per-library special cases:

- **`Float` index** — unchanged (the common case; no cast inserted).
- **numeric-like index** (`Int`, an all-numeric union arm, a numeric type-parameter constraint) or **optional-numeric surface** (`number | undefined`) — coerced with a `Number(...)` cast.
- **genuinely non-numeric index** (string, object, opaque `unknown`) — still an explicit unsupported diagnostic.

The downstream codegen (`optional_normalized_index_text` / `value_at_type` / `primitive_cast_text`) already handles the coerced `Float` operand for every numeric-compatible source type, so no emitter change was needed for the common path.

## Tests

- HIR regression tests in `crates/smelt-frontend-ts/src/tests/part02_tests.rs`:
  - `coerces_optional_numeric_at_index` — `number | undefined` index lowers to optional indexing with a `Number(...)` cast.
  - `coerces_numeric_type_param_at_index` — `<T extends number>` index is accepted.
  - `rejects_non_numeric_at_index` — a string index still errors.
  - Existing `.at` tests remain green (no regression).
- Compile-corpus case `at_index_coercion` (array + string `.at(number | undefined)`) — emitted Rust compiles (`cargo test -p smelt-codegen-rust --test compile_corpus -- --ignored` passes).

## Verification

`cargo check` and `cargo clippy` clean on the touched crate libraries; targeted unit tests and the compile-corpus tier pass.

## Deferred

A generic `<T extends number>` `.at` case was dropped from the compile-corpus: a numeric type-parameter parameter is emitted as `SmeltUnknown` in a `Program` crate whose prelude does not import `SmeltUnknown`, so the function *signature* fails to compile independently of `.at`. This is a pre-existing program-crate/type-param codegen gap, orthogonal to this issue; the frontend coercion itself is exercised by the `coerces_numeric_type_param_at_index` HIR test.

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)