### PR TITLE
frontend: lower array literal elements that are function/this/class expressions

### DIFF
--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -559,6 +559,32 @@ export function unionMethod(value: string | number): number {
 }
 "#,
         },
+        // --- array literals with function / this / class elements ------------
+        Case {
+            name: "array_literal_expr_elements",
+            area: "array_elements",
+            // Array literal elements that are function expressions, `this`, and
+            // class expressions (named and anonymous) route through the shared
+            // expression lowering path. Function expressions become closure
+            // values, `this` resolves to the method receiver, and class
+            // expressions register a class and yield a class value.
+            source: r"
+export function funcElements(): unknown[] {
+  return [function () { return 1; }, function () { return 2; }];
+}
+
+export function classElements(): unknown[] {
+  return [class Named { value: number = 0; }, class { flag: boolean = false; }];
+}
+
+class Registry {
+  id: number = 0;
+  entries(): unknown[] {
+    return [function () { return 0; }, this, class Entry { key: number = 0; }];
+  }
+}
+",
+        },
     ]
 }
 
@@ -631,7 +657,16 @@ fn corpus_emitted_rust_compiles() {
 
     let mut failures: Vec<CorpusFailure> = Vec::new();
 
+    // Optional single-case filter for local verification of one corpus entry
+    // without checking the whole corpus. Unset in CI, which runs everything.
+    let only = std::env::var("SMELT_CORPUS_ONLY").ok();
+
     for case in corpus() {
+        if let Some(only_name) = &only
+            && case.name != only_name
+        {
+            continue;
+        }
         if KNOWN_COMPILE_FAILURES.contains(&case.name) {
             continue;
         }

--- a/crates/smelt-frontend-ts/src/lowering/decls/functions.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/functions.rs
@@ -789,18 +789,35 @@ impl ModuleBuilder<'_> {
         })))
     }
 
+    /// Build a deterministic synthetic name for an anonymous class expression.
+    ///
+    /// Anonymous classes have no source identifier, but the rest of the class
+    /// lowering pipeline keys every class on a name (`self.classes`, the interned
+    /// `Type::Class` symbol, field/method metadata). The class span start offset
+    /// is unique within a module, so `__smelt_anon_class_<offset>` gives a stable,
+    /// collision-free name without threading a mutable counter through lowering.
+    fn anonymous_class_name(class: &oxc::ast::ast::Class<'_>) -> String {
+        format!("__smelt_anon_class_{}", class.span.start)
+    }
+
     /// Lower a class declaration to HIR.
+    ///
+    /// Anonymous classes (`class {}` in an expression position) are named with a
+    /// deterministic synthetic identifier so they register like a declared class
+    /// and can be referenced as a class value; see [`Self::anonymous_class_name`].
     pub(in crate::lowering) fn class_declaration(
         &mut self,
         class: &oxc::ast::ast::Class<'_>,
     ) -> Result<smelt_hir::ItemId, SmeltError> {
-        let id = class.id.as_ref().ok_or_else(|| {
-            SmeltError::unsupported(
-                self.span(class.span.start, class.span.end),
-                "anonymous classes are not lowered yet",
-            )
-        })?;
-        let class_text = id.name.as_str();
+        // Named classes use their source identifier; anonymous class expressions
+        // fall back to a synthetic name so the class still registers and can be
+        // referenced as a value. The name is owned here and borrowed as
+        // `class_text` for the rest of lowering.
+        let class_name_owned = class.id.as_ref().map_or_else(
+            || Self::anonymous_class_name(class),
+            |id| id.name.to_string(),
+        );
+        let class_text = class_name_owned.as_str();
         let class_span = self.span(class.span.start, class.span.end);
         let materialized = self.materialized_class(class_text).cloned();
         if !class.decorators.is_empty() && materialized.is_none() {
@@ -1261,6 +1278,40 @@ impl ModuleBuilder<'_> {
         self.classes.insert(class_text.to_owned(), item);
         self.validate_implements(item)?;
         Ok(item)
+    }
+
+    /// Lower a class *expression* used in value position into a class value.
+    ///
+    /// A class expression (`class Foo {}` or anonymous `class {}` used as an
+    /// operand, e.g. an array element `[class {}]`) evaluates to the class
+    /// constructor. We lower it through the same [`Self::class_declaration`]
+    /// pipeline so the class is registered (fields, methods, constructor, and a
+    /// `Type::Class` symbol) exactly like a declared class, then materialize the
+    /// class value the same way a bare class-name identifier does in
+    /// `identifier_expression`: a `Literal::None` placeholder typed as the class
+    /// so downstream code carries the class identity through the type.
+    pub(in crate::lowering) fn class_expression_value(
+        &mut self,
+        class: &oxc::ast::ast::Class<'_>,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let item = self.class_declaration(class)?;
+        let Item::Class(lowered) = self.item_ref(item) else {
+            return Err(SmeltError::unsupported(
+                self.span(class.span.start, class.span.end),
+                "class expression did not lower to a class item",
+            ));
+        };
+        let name = lowered.name;
+        let ty = self.ctx.krate.types.intern(Type::Class {
+            name,
+            args: Vec::new(),
+        });
+        Ok(body.push_expr(Expr {
+            kind: ExprKind::Literal(smelt_hir::Literal::None),
+            ty,
+            span: self.span(class.span.start, class.span.end),
+        }))
     }
 
     /// Collect class method signatures before lowering method bodies.

--- a/crates/smelt-frontend-ts/src/lowering/expr/operators.rs
+++ b/crates/smelt-frontend-ts/src/lowering/expr/operators.rs
@@ -1099,10 +1099,20 @@ impl ModuleBuilder<'_> {
             ArrayExpressionElement::ArrowFunctionExpression(arrow) => {
                 self.arrow_function_expression(arrow, body)
             }
-            _ => Err(SmeltError::unsupported(
-                self.span(element.span().start, element.span().end),
-                format!("array element kind is not lowered yet: {element:?}"),
-            )),
+            // `ArrayExpressionElement` inherits every `Expression` variant, so any
+            // element we do not special-case above (function expressions, `this`,
+            // class expressions, etc.) is lowered through the shared expression
+            // path. `as_expression` returns `Some` for exactly the inherited
+            // variants; only `SpreadElement`/`Elision` fall through to the error.
+            other => {
+                if let Some(expression) = other.as_expression() {
+                    return self.expression(expression, body);
+                }
+                Err(SmeltError::unsupported(
+                    self.span(element.span().start, element.span().end),
+                    format!("array element kind is not lowered yet: {element:?}"),
+                ))
+            }
         }
     }
 

--- a/crates/smelt-frontend-ts/src/lowering/new_expr.rs
+++ b/crates/smelt-frontend-ts/src/lowering/new_expr.rs
@@ -2060,6 +2060,7 @@ impl ModuleBuilder<'_> {
                 function.span,
                 body,
             ),
+            Expression::ClassExpression(class) => self.class_expression_value(class, body),
             Expression::ChainExpression(chain) => self.chain_expression(chain, body),
             Expression::TSAsExpression(as_expr) => self.type_assertion_expression(
                 &as_expr.expression,

--- a/crates/smelt-frontend-ts/src/tests/array_literal_expr_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/array_literal_expr_tests.rs
@@ -1,0 +1,137 @@
+//! Regression tests for array literals whose elements are function, `this`, or
+//! class expressions.
+//!
+//! Array literal element lowering historically rejected any element that was not
+//! one of an explicit set of expression kinds, so `[function () {}]`,
+//! `[this]`, and `[class {}]` all bailed with "array element kind is not lowered
+//! yet" / "expression kind is not lowered yet: ClassExpression". These elements
+//! now route through the shared expression lowering path, matching how the same
+//! constructs lower everywhere else.
+
+use super::*;
+
+/// Return whether any body in the crate contains an expression matching `pred`.
+fn crate_has_expr(ctx: &HirCtx, pred: impl Fn(&ExprKind) -> bool) -> bool {
+    ctx.krate
+        .bodies
+        .iter()
+        .any(|body| body.exprs.iter().any(|expr| pred(&expr.kind)))
+}
+
+#[test]
+fn lowers_array_element_function_expression_to_closure() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function handlers(): unknown[] {
+  return [function () { return 1; }];
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    // The function expression element lowers to a closure value, not an error.
+    ensure!(crate_has_expr(&ctx, |kind| matches!(
+        kind,
+        ExprKind::Closure(_)
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_array_element_this_expression() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    // `this` is only meaningful with a receiver, so exercise it inside a method
+    // where the current receiver is in scope.
+    let module_id = lower_ok(
+        ts!(r#"
+class Box {
+  value: number;
+  constructor(value: number) {
+    this.value = value;
+  }
+  selves(): unknown[] {
+    return [this];
+  }
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_array_element_named_class_expression() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function classes(): unknown[] {
+  return [class Named { value: number = 0; }];
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_array_element_anonymous_class_expression() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function classes(): unknown[] {
+  return [class { value: number = 0; }];
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_class_expression_in_value_position() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    // A class expression bound to a `const` exercises the general expression
+    // path (not the array-element path) reaching `class_expression_value`.
+    let module_id = lower_ok(
+        ts!(r#"
+export function make(): unknown {
+  const ctor = class { field: number = 1; };
+  return ctor;
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_array_with_mixed_function_this_and_class_elements() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+class Registry {
+  build(): unknown[] {
+    return [function () { return 0; }, this, class Entry { id: number = 0; }];
+  }
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(crate_has_expr(&ctx, |kind| matches!(
+        kind,
+        ExprKind::Closure(_)
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}

--- a/crates/smelt-frontend-ts/src/tests/mod.rs
+++ b/crates/smelt-frontend-ts/src/tests/mod.rs
@@ -225,3 +225,4 @@ mod part07_tests;
 mod estk6_coverage_tests;
 mod class_module_tests;
 mod enum_switch_tests;
+mod array_literal_expr_tests;


### PR DESCRIPTION
## Summary

Array literals whose elements were function expressions, `this`, or class expressions were rejected during lowering (`array element kind is not lowered yet: FunctionExpression(...)/ThisExpression(...)` and `expression kind is not lowered yet: ClassExpression(...)`), blocking ~6 es-toolkit files.

These now lower through the same general expression path used everywhere else, with no per-library special cases.

## What changed

- **`array_element` catch-all** (`expr/operators.rs`): delegates any element that is an inherited `Expression` variant (via oxc's `as_expression()`) to the shared `expression` lowering. This covers function expressions (→ closure values), `this` (→ the current receiver), class expressions, and any future variant in one general rule. Only `SpreadElement`/`Elision` still fall through to the unsupported error.
- **`ClassExpression` in the general path** (`new_expr.rs` + `decls/functions.rs`): a new `class_expression_value` helper lowers a class expression through the existing `class_declaration` pipeline (registering fields/methods/constructor and a `Type::Class` symbol), then yields the class value the same way a bare class identifier does in `identifier_expression` (a `Literal::None` placeholder typed as the class).
- **Anonymous classes** (`decls/functions.rs`): `class_declaration` now falls back to a deterministic synthetic name (`__smelt_anon_class_<span-start>`) so `class {}` in expression position registers like a declared class instead of erroring.

## Tests

- Frontend regression tests (`tests/array_literal_expr_tests.rs`): function element → closure, `this` element (in a method), named + anonymous class elements, mixed array, and a class expression in `const` value position.
- Compile-corpus case `array_literal_expr_elements` proving the emitted Rust type-checks (`cargo test -p smelt-codegen-rust --test compile_corpus -- --ignored`).
- Added an optional `SMELT_CORPUS_ONLY` env filter to the compile-corpus test for single-case local verification (unset in CI).

## Verification

- `cargo check` + `cargo clippy` clean on both touched crates.
- 741 `smelt-frontend-ts` lib tests pass (6 new).
- Compile-corpus case compiles.

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)