### PR TITLE
frontend: accept non-arrow array-method callbacks (function exprs, local-var callbacks, method refs)

### DIFF
--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -5875,3 +5875,107 @@ function opt(record: Record<string, unknown>): boolean | number {
         "an erased value flowing into a concrete-union sink must be reconstructed: {source}"
     );
 }
+
+#[test]
+fn lowers_function_expression_array_callback() {
+    // A `function (...) { ... }` expression callback (issue #86) must lower into
+    // the array method's callback closure just like the equivalent arrow, rather
+    // than being rejected with "array callback methods currently require arrow
+    // function callbacks". `source_for` panics on any blocker, so reaching
+    // codegen proves the non-arrow form was accepted.
+    let source = source_for(
+        r#"
+function increment(values: number[]): number[] {
+  return values.map(function (value) {
+    return value + 1;
+  });
+}
+"#,
+    );
+
+    assert!(source.contains(".map("), "{source}");
+}
+
+#[test]
+fn falls_back_to_closure_body_for_function_expression_callback() {
+    // A `function`-expression callback whose body uses a statement form the
+    // compact callback IR cannot represent (here `try`/`catch`) must retry
+    // through full closure-body lowering, exactly as the arrow form does. Before
+    // issue #86 the closure-body fallback was gated on the argument being an
+    // arrow, so this rejected the file.
+    let source = source_for(
+        r#"
+function run(values: string[]): Array<string | undefined> {
+  return values.map(function (value) {
+    try {
+      return value;
+    } catch (error) {
+      return undefined;
+    }
+  });
+}
+"#,
+    );
+
+    assert!(source.contains(".map("), "{source}");
+}
+
+#[test]
+fn lowers_named_function_item_array_callback() {
+    // A bare identifier naming a module-level function item (`values.map(square)`)
+    // must lower into the callback closure by calling the function by name, with
+    // its typed signature preserved (issue #86).
+    let source = source_for(
+        r#"
+function square(value: number): number {
+  return value * value;
+}
+
+function squares(values: number[]): number[] {
+  return values.map(square);
+}
+"#,
+    );
+
+    assert!(source.contains(".map("), "{source}");
+    assert!(source.contains("square"), "{source}");
+}
+
+#[test]
+fn lowers_local_function_variable_array_callback() {
+    // A local/parameter binding whose static type is a `Type::Function`, handed
+    // to an array method by name (`values.map(transform)`), must lower into the
+    // callback closure by calling the captured local (issue #86).
+    let source = source_for(
+        r#"
+function scale(values: number[]): number[] {
+  const transform = (value: number): number => value * 3;
+  return values.map(transform);
+}
+"#,
+    );
+
+    assert!(source.contains(".map("), "{source}");
+}
+
+#[test]
+fn lowers_asserted_identifier_array_callback() {
+    // A named callback wrapped in an erased TypeScript assertion
+    // (`values.map(square as (value: number) => number)`) must resolve through
+    // the same named-reference path as the unwrapped form, so the assertion is
+    // transparent instead of hitting the arrow-only gate (issue #86).
+    let source = source_for(
+        r#"
+function square(value: number): number {
+  return value * value;
+}
+
+function squares(values: number[]): number[] {
+  return values.map(square as (value: number) => number);
+}
+"#,
+    );
+
+    assert!(source.contains(".map("), "{source}");
+    assert!(source.contains("square"), "{source}");
+}

--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -219,6 +219,49 @@ function normalize(values: number[]): number[][] {
 }
 "#,
         },
+        Case {
+            name: "non_arrow_array_callbacks",
+            area: "closures",
+            // Array methods must accept non-arrow callback forms (issue #86):
+            // a `function` expression callback (`mapped`), a `function`
+            // expression whose body needs full closure-body lowering because it
+            // uses a statement form the compact callback IR cannot model
+            // (`fallback`, a `try/catch`), a named function-item reference
+            // (`byRef` calling `square`), and a local function-typed variable
+            // handed to the method (`byLocal`). Each must lower into the callback
+            // closure with its typed signature preserved, and the emitted Rust
+            // must compile.
+            source: r#"
+function square(value: number): number {
+  return value * 2;
+}
+
+function mapped(values: number[]): number[] {
+  return values.map(function (value) {
+    return value + 1;
+  });
+}
+
+function fallback(values: string[]): Array<string | undefined> {
+  return values.map(function (value) {
+    try {
+      return value;
+    } catch (error) {
+      return undefined;
+    }
+  });
+}
+
+function byRef(values: number[]): number[] {
+  return values.map(square);
+}
+
+function byLocal(values: number[]): number[] {
+  const transform = (value: number): number => value * 3;
+  return values.map(transform);
+}
+"#,
+        },
         // --- string / list operations ----------------------------------------
         Case {
             name: "list_collection",

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/body_lowering.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/body_lowering.rs
@@ -11,6 +11,24 @@ use crate::lowering::{
 };
 use oxc::span::GetSpan;
 
+/// The body form of a callback lowered through a real HIR closure body.
+///
+/// Selects how [`ModuleBuilder::closure_body_expr_from_parts`] lowers the
+/// callback body: an arrow expression body (`x => x + 1`) whose single
+/// expression becomes the closure's return, or a statement block (`{ ... }`)
+/// shared by block-bodied arrows and `function` expression callbacks.
+///
+/// The variants hold only borrowed AST references, so the enum is `Copy` and is
+/// passed by value.
+#[derive(Clone, Copy)]
+enum ClosureBodyKind<'a, 'src> {
+    /// An expression-bodied arrow; its return expression is lowered with a
+    /// contextual type hint and may drive return-type inference.
+    ArrowExpression(&'a oxc::ast::ast::ArrowFunctionExpression<'src>),
+    /// A statement block, used by block-bodied arrows and function expressions.
+    Statements(&'a [Statement<'src>]),
+}
+
 impl ModuleBuilder<'_> {
     /// Lower a terminating block-bodied callback into a nested callback expression.
     pub(in crate::lowering) fn callback_block_expression<'a>(
@@ -913,6 +931,10 @@ impl ModuleBuilder<'_> {
     /// closure body is lowered with `current_async` enabled, receives the
     /// contextual return type for return-expression hints, and records async
     /// state metadata after await expressions have been collected.
+    ///
+    /// This is a thin wrapper over [`Self::closure_body_expr_from_parts`], which
+    /// carries the shared parameter-binding, capture-collection and closure-
+    /// emission logic used by both arrow and `function` expression callbacks.
     pub(in crate::lowering) fn arrow_closure_body_expr(
         &mut self,
         arrow: &oxc::ast::ast::ArrowFunctionExpression<'_>,
@@ -921,12 +943,92 @@ impl ModuleBuilder<'_> {
         outer_body: &mut Body,
     ) -> Result<smelt_hir::ExprId, SmeltError> {
         let span = self.span(arrow.span.start, arrow.span.end);
+        let body_kind = if arrow.expression {
+            ClosureBodyKind::ArrowExpression(arrow)
+        } else {
+            ClosureBodyKind::Statements(&arrow.body.statements)
+        };
+        self.closure_body_expr_from_parts(
+            &arrow.params,
+            body_kind,
+            arrow.r#async,
+            span,
+            param_tys,
+            return_ty,
+            outer_body,
+        )
+    }
+
+    /// Lower a `function (...) { ... }` expression callback through a real HIR
+    /// closure body.
+    ///
+    /// Function expressions are the non-arrow sibling of the callback surface
+    /// accepted by array methods. They always have a block body (never an
+    /// expression body) and reuse the same shared closure-body machinery as
+    /// arrow callbacks, so a `function`-form callback whose body needs full
+    /// closure lowering (e.g. a method call the compact callback IR cannot
+    /// model) is lowered identically to the equivalent arrow. The callback's
+    /// own `arguments` binding is not modeled here; array-method callbacks that
+    /// reference `arguments` are rejected by the general body lowering as usual.
+    pub(in crate::lowering) fn function_closure_body_expr(
+        &mut self,
+        function: &oxc::ast::ast::Function<'_>,
+        param_tys: &[smelt_hir::TypeId],
+        return_ty: smelt_hir::TypeId,
+        outer_body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let span = self.span(function.span.start, function.span.end);
+        let Some(function_body) = &function.body else {
+            return Err(SmeltError::unsupported(
+                span,
+                "function expression callbacks must have a body",
+            ));
+        };
+        self.closure_body_expr_from_parts(
+            &function.params,
+            ClosureBodyKind::Statements(&function_body.statements),
+            function.r#async,
+            span,
+            param_tys,
+            return_ty,
+            outer_body,
+        )
+    }
+
+    /// Lower a callback closure body from its constituent parts.
+    ///
+    /// Shared implementation behind [`Self::arrow_closure_body_expr`] and
+    /// [`Self::function_closure_body_expr`]. It binds the formal parameters into
+    /// closure locals, collects the captured outer locals referenced by the
+    /// body, lowers the body (an arrow expression body or a statement block) and
+    /// emits the closure expression with the inferred/annotated return type.
+    ///
+    /// `body_kind` selects the body form: [`ClosureBodyKind::ArrowExpression`]
+    /// lowers the single expression through the return-expression hint path (and
+    /// may infer the return type when it is left `Unknown`), while
+    /// [`ClosureBodyKind::Statements`] lowers a statement block — the form used
+    /// by block-bodied arrows and by `function` expression callbacks.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "shared closure-body lowering threads the params, body form, async flag, span and both contextual types through one call"
+    )]
+    fn closure_body_expr_from_parts(
+        &mut self,
+        params: &oxc::ast::ast::FormalParameters<'_>,
+        body_kind: ClosureBodyKind<'_, '_>,
+        is_async: bool,
+        span: Span,
+        param_tys: &[smelt_hir::TypeId],
+        return_ty: smelt_hir::TypeId,
+        outer_body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let is_expression_body = matches!(body_kind, ClosureBodyKind::ArrowExpression(_));
         let mut closure_body = Body::new(None, span);
         let mut closure_params = Vec::new();
         let mut param_names = HashSet::new();
         let mut saved_locals = Vec::new();
 
-        for (index, param) in arrow.params.items.iter().enumerate() {
+        for (index, param) in params.items.iter().enumerate() {
             let ty = param_tys.get(index).copied().ok_or_else(|| {
                 SmeltError::unsupported(
                     self.span(param.span.start, param.span.end),
@@ -989,7 +1091,7 @@ impl ModuleBuilder<'_> {
             }
         }
 
-        if let Some(rest) = &arrow.params.rest {
+        if let Some(rest) = &params.rest {
             let BindingPattern::BindingIdentifier(binding) = &rest.rest.argument else {
                 return Err(SmeltError::unsupported(
                     self.span(rest.span.start, rest.span.end),
@@ -1024,16 +1126,23 @@ impl ModuleBuilder<'_> {
         }
 
         let mut capture_names = Vec::new();
-        if arrow.expression {
-            let return_expression = self.arrow_return_expression(arrow)?;
-            self.collect_expression_capture_names(
-                return_expression,
-                &param_names,
-                &mut capture_names,
-            );
-        } else {
-            for statement in &arrow.body.statements {
-                self.collect_statement_capture_names(statement, &param_names, &mut capture_names);
+        match body_kind {
+            ClosureBodyKind::ArrowExpression(arrow) => {
+                let return_expression = self.arrow_return_expression(arrow)?;
+                self.collect_expression_capture_names(
+                    return_expression,
+                    &param_names,
+                    &mut capture_names,
+                );
+            }
+            ClosureBodyKind::Statements(statements) => {
+                for statement in statements {
+                    self.collect_statement_capture_names(
+                        statement,
+                        &param_names,
+                        &mut capture_names,
+                    );
+                }
             }
         }
         capture_names.sort();
@@ -1076,46 +1185,51 @@ impl ModuleBuilder<'_> {
         let saved_async = self.current_async;
         let saved_return_ty = self.current_return_ty;
         let saved_narrowed_locals = std::mem::take(&mut self.narrowed_locals);
-        let infer_expression_return =
-            arrow.expression && matches!(self.ctx.krate.types.get(return_ty), Some(Type::Unknown));
-        self.current_async = arrow.r#async;
+        let infer_expression_return = is_expression_body
+            && matches!(self.ctx.krate.types.get(return_ty), Some(Type::Unknown));
+        self.current_async = is_async;
         self.current_return_ty = Some(return_ty);
         let mut actual_return_ty = return_ty;
-        let predeclare_result = if arrow.expression {
-            Ok(())
-        } else {
-            self.predeclare_local_function_declarations(&arrow.body.statements, &mut closure_body)
+        let predeclare_result = match body_kind {
+            ClosureBodyKind::ArrowExpression(_) => Ok(()),
+            ClosureBodyKind::Statements(statements) => self
+                .predeclare_local_function_declarations(statements, &mut closure_body)
                 .and_then(|()| {
-                    self.predeclare_local_arrow_callbacks(&arrow.body.statements, &mut closure_body)
-                })
+                    self.predeclare_local_arrow_callbacks(statements, &mut closure_body)
+                }),
         };
         let lowering_result = if let Err(error) = predeclare_result {
             Err(error)
-        } else if arrow.expression {
-            match self.arrow_return_expression(arrow) {
-                Ok(return_expression) => {
-                    let hint = (!infer_expression_return).then_some(return_ty);
-                    self.expression_with_hint(return_expression, &mut closure_body, hint)
-                        .map(|value| {
-                            if infer_expression_return {
-                                actual_return_ty = Self::expr_ty(&closure_body, value);
-                            }
-                            closure_body.push_stmt(Stmt::Return(Some(value)));
-                        })
-                }
-                Err(error) => Err(error),
-            }
         } else {
-            let mut result = Ok(());
-            for statement in &arrow.body.statements {
-                if let Err(error) = self.statement(statement, &mut closure_body) {
-                    result = Err(error);
-                    break;
+            match body_kind {
+                ClosureBodyKind::ArrowExpression(arrow) => {
+                    match self.arrow_return_expression(arrow) {
+                        Ok(return_expression) => {
+                            let hint = (!infer_expression_return).then_some(return_ty);
+                            self.expression_with_hint(return_expression, &mut closure_body, hint)
+                                .map(|value| {
+                                    if infer_expression_return {
+                                        actual_return_ty = Self::expr_ty(&closure_body, value);
+                                    }
+                                    closure_body.push_stmt(Stmt::Return(Some(value)));
+                                })
+                        }
+                        Err(error) => Err(error),
+                    }
+                }
+                ClosureBodyKind::Statements(statements) => {
+                    let mut result = Ok(());
+                    for statement in statements {
+                        if let Err(error) = self.statement(statement, &mut closure_body) {
+                            result = Err(error);
+                            break;
+                        }
+                    }
+                    result
                 }
             }
-            result
         };
-        if arrow.r#async {
+        if is_async {
             closure_body.build_async_state_machine();
         }
         self.current_async = saved_async;
@@ -1131,19 +1245,20 @@ impl ModuleBuilder<'_> {
         lowering_result?;
         let may_throw = Self::body_contains_uncaught_throw(&closure_body);
         let body_id = self.ctx.krate.push_body(closure_body);
+        let rest_index = params.rest.as_ref().map(|_| params.items.len());
         let closure_ty = self.ctx.krate.types.intern(Type::Function(FunctionType {
             params: param_tys.to_vec(),
-            rest: arrow.params.rest.as_ref().map(|_| arrow.params.items.len()),
+            rest: rest_index,
             required_params: None,
             mutable_params: Vec::new(),
             return_ty: actual_return_ty,
-            is_async: arrow.r#async,
+            is_async,
             may_throw,
         }));
         Ok(outer_body.push_expr(Expr {
             kind: ExprKind::Closure(smelt_hir::ClosureExpr {
                 params: closure_params,
-                rest: arrow.params.rest.as_ref().map(|_| arrow.params.items.len()),
+                rest: rest_index,
                 required_params: None,
                 return_ty: actual_return_ty,
                 captures,

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs
@@ -489,85 +489,15 @@ impl ModuleBuilder<'_> {
                 return self.function_callback_from_params(function, expected_param_tys, body);
             }
             if let Argument::Identifier(identifier) = argument
-                && let Some(item) = self.items.get(identifier.name.as_str()).copied()
+                && let Some(callback) = self.named_callback_reference(
+                    identifier.name.as_str(),
+                    identifier.span.start,
+                    identifier.span.end,
+                    expected_param_tys,
+                    body,
+                )?
             {
-                let span = self.span(identifier.span.start, identifier.span.end);
-                let Item::Function(function) = self.item_ref(item) else {
-                    return Err(SmeltError::unsupported(
-                        span,
-                        "array callback function references must resolve to functions",
-                    ));
-                };
-                let function_name = function.name;
-                let function_params_len = function.params.len();
-                let function_return_ty = function.return_ty;
-                let function_ty = self.item_expr_type(item, span)?;
-                if function_params_len < expected_param_tys.len().min(1) {
-                    return Err(SmeltError::unsupported(
-                        span,
-                        "array callback function reference has too few parameters",
-                    ));
-                }
-                let args = expected_param_tys
-                    .iter()
-                    .copied()
-                    .take(function_params_len)
-                    .enumerate()
-                    .map(|(index, ty)| CallbackCallArg {
-                        expr: CallbackExpr {
-                            kind: CallbackExprKind::Param(index),
-                            ty,
-                        },
-                        spread: false,
-                    })
-                    .collect();
-                return Ok(CallbackExpr {
-                    kind: CallbackExprKind::Call {
-                        callee: Box::new(CallbackExpr {
-                            kind: CallbackExprKind::Function(function_name),
-                            ty: function_ty,
-                        }),
-                        args,
-                    },
-                    ty: function_return_ty,
-                });
-            }
-            if let Argument::Identifier(identifier) = argument
-                && let Some(local) = self.locals.get(identifier.name.as_str()).copied()
-            {
-                let local_ty = Self::local_ty(body, local);
-                if let Some(Type::Function(function)) = self.ctx.krate.types.get(local_ty).cloned()
-                {
-                    if function.params.len() < expected_param_tys.len().min(1) {
-                        return Err(SmeltError::unsupported(
-                            self.span(identifier.span.start, identifier.span.end),
-                            "array callback function reference has too few parameters",
-                        ));
-                    }
-                    let args = expected_param_tys
-                        .iter()
-                        .copied()
-                        .take(function.params.len())
-                        .enumerate()
-                        .map(|(index, ty)| CallbackCallArg {
-                            expr: CallbackExpr {
-                                kind: CallbackExprKind::Param(index),
-                                ty,
-                            },
-                            spread: false,
-                        })
-                        .collect();
-                    return Ok(CallbackExpr {
-                        kind: CallbackExprKind::Call {
-                            callee: Box::new(CallbackExpr {
-                                kind: CallbackExprKind::Capture(local),
-                                ty: local_ty,
-                            }),
-                            args,
-                        },
-                        ty: function.return_ty,
-                    });
-                }
+                return Ok(callback);
             }
             if let Argument::StaticMemberExpression(_member) = argument {
                 return Ok(self.opaque_member_callback(expected_param_tys));
@@ -584,11 +514,6 @@ impl ModuleBuilder<'_> {
             ) {
                 return Ok(self.opaque_member_callback(expected_param_tys));
             }
-            if let Argument::Identifier(identifier) = argument
-                && self.is_opaque_callback_value(identifier.name.as_str())
-            {
-                return Ok(self.opaque_member_callback(expected_param_tys));
-            }
             return Err(SmeltError::unsupported(
                 self.span(argument.span().start, argument.span().end),
                 "array callback methods currently require arrow function callbacks",
@@ -601,6 +526,111 @@ impl ModuleBuilder<'_> {
             ));
         }
         self.arrow_callback_from_params(arrow, expected_param_tys, body)
+    }
+
+    /// Resolve a bare identifier callback (`xs.map(fn)`) to a typed callback
+    /// expression tree, if the name statically names a callable value.
+    ///
+    /// Handles, in resolution order:
+    /// - a module-level function item, called by name through
+    ///   [`CallbackExprKind::Function`];
+    /// - a local/parameter binding whose static type is a `Type::Function`,
+    ///   called through a captured [`CallbackExprKind::Capture`];
+    /// - an opaque callable value — an import or forward-declared function whose
+    ///   body is not visible here — modeled as an [`Self::opaque_member_callback`].
+    ///
+    /// Returns `Ok(None)` when the name is not a resolvable callable so the
+    /// caller can fall through to its remaining forms (or raise its own error).
+    /// Typed function signatures and receiver element arguments are preserved so
+    /// the generated call keeps its concrete parameter/return types.
+    pub(in crate::lowering) fn named_callback_reference(
+        &mut self,
+        name: &str,
+        start: u32,
+        end: u32,
+        expected_param_tys: &[smelt_hir::TypeId],
+        body: &Body,
+    ) -> Result<Option<CallbackExpr>, SmeltError> {
+        if let Some(item) = self.items.get(name).copied() {
+            let span = self.span(start, end);
+            let Item::Function(function) = self.item_ref(item) else {
+                return Err(SmeltError::unsupported(
+                    span,
+                    "array callback function references must resolve to functions",
+                ));
+            };
+            let function_name = function.name;
+            let function_params_len = function.params.len();
+            let function_return_ty = function.return_ty;
+            let function_ty = self.item_expr_type(item, span)?;
+            if function_params_len < expected_param_tys.len().min(1) {
+                return Err(SmeltError::unsupported(
+                    span,
+                    "array callback function reference has too few parameters",
+                ));
+            }
+            let args = expected_param_tys
+                .iter()
+                .copied()
+                .take(function_params_len)
+                .enumerate()
+                .map(|(index, ty)| CallbackCallArg {
+                    expr: CallbackExpr {
+                        kind: CallbackExprKind::Param(index),
+                        ty,
+                    },
+                    spread: false,
+                })
+                .collect();
+            return Ok(Some(CallbackExpr {
+                kind: CallbackExprKind::Call {
+                    callee: Box::new(CallbackExpr {
+                        kind: CallbackExprKind::Function(function_name),
+                        ty: function_ty,
+                    }),
+                    args,
+                },
+                ty: function_return_ty,
+            }));
+        }
+        if let Some(local) = self.locals.get(name).copied() {
+            let local_ty = Self::local_ty(body, local);
+            if let Some(Type::Function(function)) = self.ctx.krate.types.get(local_ty).cloned() {
+                if function.params.len() < expected_param_tys.len().min(1) {
+                    return Err(SmeltError::unsupported(
+                        self.span(start, end),
+                        "array callback function reference has too few parameters",
+                    ));
+                }
+                let args = expected_param_tys
+                    .iter()
+                    .copied()
+                    .take(function.params.len())
+                    .enumerate()
+                    .map(|(index, ty)| CallbackCallArg {
+                        expr: CallbackExpr {
+                            kind: CallbackExprKind::Param(index),
+                            ty,
+                        },
+                        spread: false,
+                    })
+                    .collect();
+                return Ok(Some(CallbackExpr {
+                    kind: CallbackExprKind::Call {
+                        callee: Box::new(CallbackExpr {
+                            kind: CallbackExprKind::Capture(local),
+                            ty: local_ty,
+                        }),
+                        args,
+                    },
+                    ty: function.return_ty,
+                }));
+            }
+        }
+        if self.is_opaque_callback_value(name) {
+            return Ok(Some(self.opaque_member_callback(expected_param_tys)));
+        }
+        Ok(None)
     }
 
     /// Lower common lodash/fp predicate factories when they are passed as array callbacks.
@@ -813,6 +843,24 @@ impl ModuleBuilder<'_> {
             Expression::ConditionalExpression(_) | Expression::LogicalExpression(_) => {
                 Ok(self.opaque_member_callback(expected_param_tys))
             }
+            // A bare identifier inside an assertion (`(fn as Fn)`, `fn!`) that
+            // statically names a function item, a function-typed local, or an
+            // opaque imported callable. Resolve it the same way the unwrapped
+            // `xs.map(fn)` form does so the assertion is transparent.
+            Expression::Identifier(identifier) => self
+                .named_callback_reference(
+                    identifier.name.as_str(),
+                    identifier.span.start,
+                    identifier.span.end,
+                    expected_param_tys,
+                    body,
+                )?
+                .ok_or_else(|| {
+                    SmeltError::unsupported(
+                        self.span(identifier.span.start, identifier.span.end),
+                        "array callback methods currently require arrow function callbacks",
+                    )
+                }),
             _ => Err(SmeltError::unsupported(
                 self.span(expression.span().start, expression.span().end),
                 "array callback methods currently require arrow function callbacks",

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/dispatch.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/dispatch.rs
@@ -255,13 +255,10 @@ impl ModuleBuilder<'_> {
             }
             Err(error)
                 if Self::should_fallback_to_closure_body_for_callback(&error)
-                    && matches!(argument, Argument::ArrowFunctionExpression(_)) =>
+                    && Self::is_closure_body_fallback_argument(argument) =>
             {
-                let Argument::ArrowFunctionExpression(arrow) = argument else {
-                    return Err(error);
-                };
                 let expr =
-                    self.arrow_closure_body_expr(arrow, expected_param_tys, bool_ty, body)?;
+                    self.callback_closure_body_expr(argument, expected_param_tys, bool_ty, body)?;
                 Ok(ClosureCallback {
                     expr,
                     return_ty: bool_ty,
@@ -391,13 +388,10 @@ impl ModuleBuilder<'_> {
             Ok(callback) => Ok(callback),
             Err(error)
                 if Self::should_fallback_to_closure_body_for_callback(&error)
-                    && matches!(argument, Argument::ArrowFunctionExpression(_)) =>
+                    && Self::is_closure_body_fallback_argument(argument) =>
             {
-                let Argument::ArrowFunctionExpression(arrow) = argument else {
-                    return Err(error);
-                };
-                let expr = self.arrow_closure_body_expr(
-                    arrow,
+                let expr = self.callback_closure_body_expr(
+                    argument,
                     expected_param_tys,
                     fallback_return_ty,
                     body,
@@ -409,6 +403,49 @@ impl ModuleBuilder<'_> {
                 Ok(ClosureCallback { expr, return_ty })
             }
             Err(error) => Err(error),
+        }
+    }
+
+    /// Return whether an argument is a callback literal (arrow or `function`
+    /// expression) whose body can be retried through full closure-body lowering.
+    ///
+    /// Both inline callback forms carry a body the compact callback IR may fail
+    /// to model; when that happens the caller retries via
+    /// [`Self::callback_closure_body_expr`]. Named/opaque callback identifiers
+    /// have no local body to retry, so they are excluded here.
+    pub(in crate::lowering) fn is_closure_body_fallback_argument(argument: &Argument<'_>) -> bool {
+        matches!(
+            argument,
+            Argument::ArrowFunctionExpression(_) | Argument::FunctionExpression(_)
+        )
+    }
+
+    /// Lower an inline callback literal through a real HIR closure body.
+    ///
+    /// Dispatches to the arrow or `function` expression closure-body lowering
+    /// depending on the callback form, so both are retried identically when the
+    /// compact callback IR rejects a body it cannot model.
+    pub(in crate::lowering) fn callback_closure_body_expr(
+        &mut self,
+        argument: &Argument<'_>,
+        expected_param_tys: &[smelt_hir::TypeId],
+        fallback_return_ty: smelt_hir::TypeId,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        match argument {
+            Argument::ArrowFunctionExpression(arrow) => {
+                self.arrow_closure_body_expr(arrow, expected_param_tys, fallback_return_ty, body)
+            }
+            Argument::FunctionExpression(function) => self.function_closure_body_expr(
+                function,
+                expected_param_tys,
+                fallback_return_ty,
+                body,
+            ),
+            _ => Err(SmeltError::unsupported(
+                self.span(argument.span().start, argument.span().end),
+                "callback closure-body lowering requires an arrow or function expression",
+            )),
         }
     }
 


### PR DESCRIPTION
## Summary

Array methods (`map`/`filter`/`reduce`/etc.) previously required arrow-function callbacks in several TypeScript lowering paths. This extends the callback surface to accept the remaining non-arrow forms, lowering each into the callback closure while preserving typed signatures and receiver ownership. General rules only — no per-library special cases.

Clears the es-toolkit blocker classes from the issue:
- `array callback methods currently require arrow function callbacks` (x2)
- `array callback local callback X is not defined` (the named/opaque local paths)
- residual `callback method X is not lowered into closure bodies yet` for non-arrow callbacks

## What changed

- **`callbacks/body_lowering.rs`** — extracted the shared closure-body machinery out of `arrow_closure_body_expr` into `closure_body_expr_from_parts` (driven by a new `ClosureBodyKind` enum) and added `function_closure_body_expr`. A `function (...) { ... }` callback whose body needs full closure lowering (a method the compact callback IR cannot model, `try`/`catch`, parameter reassignment, etc.) is now lowered identically to the equivalent arrow.
- **`callbacks/dispatch.rs`** — generalized the closure-body fallback in `callback_argument_with_body_fallback` and `truthy_callback_argument_with_body_fallback` to accept function expressions too, via new `is_closure_body_fallback_argument` / `callback_closure_body_expr` helpers, instead of gating the retry on the argument being an arrow.
- **`callbacks/classify.rs`** — extracted the bare-identifier callback resolution (module-level function item, function-typed local/param, opaque imported callable) into `named_callback_reference`, reused from both `arrow_callback` and the assertion-wrapped `arrow_callback_expression`, so a named callback inside a TypeScript assertion (`xs.map(fn as Fn)`) resolves transparently.

Function-item and function-typed-local callbacks were already accepted in the unwrapped compact path (prior #64 work); this change closes the remaining gaps: function-expression bodies that need closure-body fallback, and assertion-wrapped named callbacks.

## Tests

- Five codegen regressions in `part_7_tests.rs`: `lowers_function_expression_array_callback`, `falls_back_to_closure_body_for_function_expression_callback`, `lowers_named_function_item_array_callback`, `lowers_local_function_variable_array_callback`, `lowers_asserted_identifier_array_callback`.
- A `non_arrow_array_callbacks` case added to the compile-corpus tier, so the emitted Rust for all four non-arrow forms is `cargo check`-compiled.

## Verification (touched crates only)

- `cargo check` + `cargo clippy` clean on the `smelt-frontend-ts` library.
- `cargo check --tests` clean on `smelt-codegen-rust`.
- The five new tests pass; the compile-corpus tier passes with `-- --ignored`.
- Existing 85 `*callback*` frontend-ts tests still pass (the closure-body refactor is behavior-preserving).

Full `cargo test` + the remeda/es-toolkit gate run centrally.

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)
