### PR TITLE
codegen: lower field access on erased iterator results (issue #83)

### DIFF
--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -559,6 +559,29 @@ export function unionMethod(value: string | number): number {
 }
 "#,
         },
+        Case {
+            // Issue #83: field access beyond Record/class/interface. Driving an
+            // erased `Iterable<unknown>` through the manual iterator protocol
+            // reads `.done`/`.value` off the dynamic iterator result
+            // (`iterator.next()`), whose element type is never statically
+            // resolved. These reads route through the erased object-field
+            // boundary rather than the field-access gate, and the emitted Rust
+            // must compile (es-toolkit `fp/pipe.ts` shape).
+            name: "erased_iterator_field_access",
+            area: "field_access",
+            source: r"
+export function drive(data: Iterable<unknown>): unknown[] {
+  const result: unknown[] = [];
+  const iterator = data[Symbol.iterator]();
+  let step = iterator.next();
+  while (!step.done) {
+    result.push(step.value);
+    step = iterator.next();
+  }
+  return result;
+}
+",
+        },
     ]
 }
 

--- a/crates/smelt-frontend-ts/src/lowering/stdlib.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib.rs
@@ -950,10 +950,14 @@ impl ModuleBuilder<'_> {
         }
         let receiver = self.expression(&member.object, body)?;
         let receiver_ty = self.optional_receiver_inner_type(Self::expr_ty(body, receiver));
-        if !matches!(
-            self.ctx.krate.types.get(receiver_ty),
-            Some(Type::Class { .. } | Type::Unknown)
-        ) {
+        // Only claim these method names on an actual Sinon fake-timers clock
+        // (`sinon.useFakeTimers()` yields a `SinonFakeTimers` class value, read
+        // directly or through an `Optional` `clock?`). Matching any class or —
+        // more dangerously — any `Unknown` receiver used to mis-claim ordinary
+        // JavaScript methods that share a name, most notably the iterator
+        // protocol's `iterator.next()` on an erased `Iterable`, forcing its
+        // result to `None` and rejecting the subsequent `.done`/`.value` reads.
+        if !self.is_sinon_fake_timers_class(receiver_ty) {
             return Ok(None);
         }
         for argument in &call.arguments {
@@ -965,6 +969,25 @@ impl ModuleBuilder<'_> {
             ty,
             span: self.span(call.span.start, call.span.end),
         })))
+    }
+
+    /// Return whether `receiver_ty` is the synthetic `SinonFakeTimers` clock
+    /// class emitted by [`Self::sinon_fake_timers_call`] for
+    /// `sinon.useFakeTimers()`.
+    ///
+    /// The comparison resolves the class symbol back to its source spelling so
+    /// the check does not depend on interning identity, which can differ between
+    /// the declaration site and later member reads.
+    fn is_sinon_fake_timers_class(&self, receiver_ty: smelt_hir::TypeId) -> bool {
+        let Some(Type::Class { name, .. }) = self.ctx.krate.types.get(receiver_ty) else {
+            return false;
+        };
+        self.ctx
+            .krate
+            .names
+            .get(*name)
+            .or_else(|| self.ctx.krate.symbols.get(*name))
+            == Some("SinonFakeTimers")
     }
 
     /// Lower TypeScript `JSON.stringify(value)` calls for JSON-compatible values.

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -7957,3 +7957,133 @@ export function tally(values: number[]): number {
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
     Ok(())
 }
+
+#[test]
+fn lowers_erased_iterator_next_done_value_loop() -> Result<(), String> {
+    // Driving an erased `Iterable<unknown>` through the manual iterator protocol
+    // — `data[Symbol.iterator]().next()` then `while (!step.done)` reading
+    // `step.value` — is the es-toolkit `fp/pipe.ts` shape. The iterator element
+    // type is never statically resolved, so `.next()` yields the dynamic
+    // boundary and the `.done`/`.value` reads must route through the erased
+    // object-field path instead of hitting the "field access is only lowered
+    // for Record/class/interface" gate on a unit-typed value.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function drive(data: Iterable<unknown>): unknown[] {
+  const result: unknown[] = [];
+  const iterator = data[Symbol.iterator]();
+  let step = iterator.next();
+  while (!step.done) {
+    result.push(step.value);
+    step = iterator.next();
+  }
+  return result;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let drive = named_function_item(&ctx, module, "drive")?;
+    let body = function_body(&ctx, drive)?;
+    // The erased iterator loop variable must carry the dynamic-boundary
+    // `Unknown` type, not `None`, so the `.done`/`.value` reads lower against a
+    // real `SmeltUnknown` object.
+    let has_unknown_step = body.locals.iter().any(|local| {
+        local
+            .name
+            .is_some_and(|name| ctx.krate.symbols.get(name) == Some("step"))
+            && matches!(ctx.krate.types.get(local.ty), Some(Type::Unknown))
+    });
+    ensure!(
+        has_unknown_step,
+        "erased iterator `step` should lower to the Unknown dynamic boundary"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_erased_iterator_field_reads() -> Result<(), String> {
+    // The `.done`/`.value` reads on an erased iterator result are plain dynamic
+    // object-field accesses; confirm they lower to `Field` reads (rather than
+    // hard-erroring) so codegen can emit the erased `smelt_get_object_field`
+    // path.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function firstValue(data: Iterable<unknown>): unknown {
+  const step = data[Symbol.iterator]().next();
+  if (step.done) {
+    return undefined;
+  }
+  return step.value;
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    let has_field_read = ctx.krate.bodies.iter().any(|body| {
+        body.exprs.iter().any(|expr| {
+            matches!(&expr.kind, ExprKind::Field { field, .. }
+                if matches!(ctx.krate.symbols.get(*field), Some("done" | "value")))
+        })
+    });
+    ensure!(
+        has_field_read,
+        "erased iterator `.done`/`.value` should lower to dynamic Field reads"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn erased_receiver_next_is_not_swallowed_by_sinon_helper() -> Result<(), String> {
+    // The Sinon fake-timers helper claims method names like `next`/`reset` on a
+    // clock value. It must only fire for an actual `SinonFakeTimers` receiver:
+    // matching any erased `unknown` receiver used to force ordinary same-named
+    // methods to a unit `None`, breaking downstream field access. Here
+    // `iterator.next()` on an erased iterator must survive as a dynamic value so
+    // `.value` still reads.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function head(data: Iterable<unknown>): unknown {
+  const iterator = data[Symbol.iterator]();
+  return iterator.next().value;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let head = named_function_item(&ctx, module, "head")?;
+    ensure!(
+        matches!(ctx.krate.types.get(head.return_ty), Some(Type::Unknown)),
+        "erased iterator `.next().value` should return the Unknown dynamic boundary"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn sinon_fake_timers_clock_methods_still_lower() -> Result<(), String> {
+    // Regression guard for the Sinon receiver restriction: methods invoked on an
+    // actual `sinon.SinonFakeTimers` clock (read directly or through an optional
+    // `clock?`) must still lower through the fake-timers helper.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function useClock(): void {
+  let clock: sinon.SinonFakeTimers | undefined;
+  clock = sinon.useFakeTimers(0);
+  clock.tick(10);
+  clock?.next();
+  clock?.restore();
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}


### PR DESCRIPTION
## What

Fixes the es-toolkit blocker `field access is only lowered for Record<string, T>, class, and interface values for now` (receiver `None`), reproduced minimally from `es-toolkit/src/fp/pipe.ts`:

```ts
const iterator = data[Symbol.iterator]();   // erased Iterable<unknown>
let step = iterator.next();
while (!step.done) {                          // <- field access on `None`
  result.push(step.value);
  step = iterator.next();
}
```

## Root cause

The Sinon fake-timers helper (`sinon_fake_timers_call`) claimed method names like `next`/`reset`/`tick`/`runAll` on **any** `Type::Class` or — more dangerously — **any** `Type::Unknown` receiver. An erased `iterator.next()` matched the `Unknown` arm and was forced to `Type::None` (a unit value), so the subsequent `.done`/`.value` reads then rejected the unit receiver at the field-access gate.

## Fix

Narrow the helper to fire only on an actual `SinonFakeTimers` clock receiver (read directly or through an `Optional` `clock?`), via a new documented `is_sinon_fake_timers_class` helper. Erased `iterator.next()` now survives as the `Unknown` dynamic boundary, and its `.done`/`.value` reads route through the ordinary erased object-field path — emitting Rust that compiles.

This narrows an over-broad per-library special case rather than widening one; ordinary iterator code no longer flows through the Sinon path, and nothing is newly routed through `SmeltUnknown` to silence an error (the erased boundary is the genuine dynamic shape of an `IteratorResult` on an unresolved iterable).

## Blockers addressed

- **`field access is only lowered for Record<string, T>, class, and interface values for now`** — gone for the es-toolkit `fp/pipe.ts` (and any erased-iterator) shape. A full single-file scan of es-toolkit's `src/` now reports **zero** occurrences of this blocker (and zero of `unknown class or interface field ...`).

## Deferred / notes

- The `unknown class or interface field X on X` gate fires only on a **concrete** class with a closed field set (no base, non-`id`, non-interface) — a genuinely absent field, which is not statically reconcilable and where returning `Unknown` would emit non-compiling `base.field`. Resolving it would require class index-signature support (currently a separate, deliberate `class index signatures are not lowered yet` error), so that gate is left intact. It does not appear in es-toolkit's single-file scan.

## Tests

- Frontend regression tests in `part04_tests.rs`: erased-iterator `.next()`/`.done`/`.value` loop, dynamic `Field` reads, the non-swallowed erased receiver, and a Sinon fake-timers clock guard.
- Compile-corpus case `erased_iterator_field_access` (area `field_access`); `cargo test -p smelt-codegen-rust --test compile_corpus -- --ignored` passes (emitted Rust `cargo check`s clean).
- `cargo check` + `cargo clippy --lib` clean on the touched crates.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)