### PR TITLE
frontend-ts: lower statically-resolvable computed property names

### DIFF
--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -522,6 +522,50 @@ export function readMixed(bag: MixedBag, key: string): number | undefined {
 "#,
         },
         Case {
+            // Issue #96: statically-resolvable computed property names. A
+            // `const`-keyed class field (`[TAG]`) folds to the const's string
+            // value as a named field; an enum-member-keyed interface field
+            // (`[Kind.First]`) folds to the enum member's value; a well-known
+            // `[Symbol.iterator]` interface method resolves to the stable
+            // synthetic member spelling. All three become ordinary named
+            // members so the emitted Rust compiles, and reading the folded
+            // class field back through its concrete member type stays concrete.
+            name: "computed_property_names",
+            area: "interfaces",
+            source: r#"
+const TAG = "tag";
+
+enum Kind {
+  First = "first",
+}
+
+class Tagged {
+  [TAG]: string = "leaf";
+  value: number = 0;
+}
+
+interface ByKind {
+  [Kind.First]: number;
+}
+
+interface Seq {
+  [Symbol.iterator](): number;
+}
+
+export function makeTagged(): Tagged {
+  return new Tagged();
+}
+
+export function taggedValue(node: Tagged): number {
+  return node.value;
+}
+
+export function firstOf(record: ByKind): number {
+  return record.first;
+}
+"#,
+        },
+        Case {
             name: "interface_method_call",
             area: "interfaces",
             source: r"

--- a/crates/smelt-frontend-ts/src/lowering.rs
+++ b/crates/smelt-frontend-ts/src/lowering.rs
@@ -10,9 +10,7 @@ use std::{
     collections::{HashMap, HashSet},
     path::Path,
 };
-use support::{
-    is_static_property_key, unknown_kind_from_typeof,
-};
+use support::unknown_kind_from_typeof;
 
 use crate::{
     HirCtx, ObjectConst,
@@ -71,6 +69,28 @@ pub struct ConstLiteral {
     literal: Literal,
     /// HIR type of the literal.
     ty: smelt_hir::TypeId,
+}
+
+impl ConstLiteral {
+    /// Return the JavaScript property-member name this constant would name when
+    /// used as a computed key (`{ [K]: v }` / `class C { [K]: T }`).
+    ///
+    /// JavaScript coerces a computed key to a string member name, so only string
+    /// and numeric constants resolve to a stable static identifier here. A whole
+    /// finite number is rendered without a fractional part (`0` -> "0") to match
+    /// the numeric-literal key spelling. Boolean/null/symbol constants have no
+    /// well-defined static member spelling for Smelt's named-field model and
+    /// return `None`, leaving genuinely dynamic keys on the runtime-keyed path.
+    fn computed_member_name(&self) -> Option<String> {
+        match &self.literal {
+            Literal::String(value) => Some(value.clone()),
+            Literal::Int(value) => Some(value.to_string()),
+            Literal::Float(value) => {
+                Some(ModuleBuilder::numeric_property_key_name(*value))
+            }
+            Literal::Bool(_) | Literal::Symbol(_) | Literal::Undefined | Literal::None => None,
+        }
+    }
 }
 
 /// Constant collection element visible to nested function bodies.

--- a/crates/smelt-frontend-ts/src/lowering/decls/functions.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/functions.rs
@@ -3,10 +3,7 @@
 
 use std::collections::HashSet;
 
-use crate::lowering::support::{
-    is_static_property_key,
-    visibility,
-};
+use crate::lowering::support::visibility;
 use crate::lowering::{
     AssertionNarrowing, GeneratorYieldAccumulator,
     ModuleBuilder, RestParam, specialization,
@@ -869,7 +866,7 @@ impl ModuleBuilder<'_> {
                             class_text,
                         ));
                     }
-                    if property.computed && !is_static_property_key(&property.key) {
+                    if property.computed && !self.is_resolvable_property_key(&property.key) {
                         return Err(SmeltError::unsupported(
                             self.span(property.span.start, property.span.end),
                             "dynamic computed property names are not lowered yet",
@@ -935,7 +932,7 @@ impl ModuleBuilder<'_> {
                             class_text,
                         ));
                     }
-                    if method.computed && !is_static_property_key(&method.key) {
+                    if method.computed && !self.is_resolvable_property_key(&method.key) {
                         return Err(SmeltError::unsupported(
                             self.span(method.span.start, method.span.end),
                             "dynamic computed method names are not lowered yet",
@@ -1105,7 +1102,7 @@ impl ModuleBuilder<'_> {
                             "getters and setters are not lowered yet",
                         ));
                     }
-                    if method.computed && !is_static_property_key(&method.key) {
+                    if method.computed && !self.is_resolvable_property_key(&method.key) {
                         return Err(SmeltError::unsupported(
                             self.span(method.span.start, method.span.end),
                             "dynamic computed method names are not lowered yet",

--- a/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
@@ -1,7 +1,7 @@
 //! `ModuleBuilder` lowering methods (part 04): type-declaration name qualification
 //! and related HIR construction helpers split out of `lowering.rs`.
 
-use crate::lowering::support::{is_static_property_key, statement_terminates};
+use crate::lowering::support::statement_terminates;
 use crate::lowering::{InterfaceHeritageRef, ModuleBuilder};
 use crate::SmeltError;
 use oxc::ast::ast::{
@@ -108,7 +108,11 @@ impl ModuleBuilder<'_> {
             for sig in &interface.body.body {
                 match sig {
                     TSSignature::TSPropertySignature(prop) => {
-                        if prop.computed && !is_static_property_key(&prop.key) {
+                        // A computed property signature keeps its declared field
+                        // when the key statically resolves (`[K]`, `[E.Member]`,
+                        // `[Symbol.iterator]`); a genuinely dynamic key has no
+                        // named field to record and is skipped.
+                        if prop.computed && !self.is_resolvable_property_key(&prop.key) {
                             continue;
                         }
                         let ty = prop
@@ -136,7 +140,7 @@ impl ModuleBuilder<'_> {
                         });
                     }
                     TSSignature::TSMethodSignature(method) => {
-                        if (method.computed && !is_static_property_key(&method.key))
+                        if (method.computed && !self.is_resolvable_property_key(&method.key))
                             || method.this_param.is_some()
                         {
                             return Err(SmeltError::unsupported(

--- a/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
@@ -19,7 +19,7 @@ use smelt_hir::{
 
 impl ModuleBuilder<'_> {
     /// Runtime key used for JavaScript's well-known `Symbol.iterator` value.
-    const SYMBOL_ITERATOR_KEY: &'static str = "__smelt_symbol_iterator";
+    pub(in crate::lowering) const SYMBOL_ITERATOR_KEY: &'static str = "__smelt_symbol_iterator";
 
     /// Lower supported namespace member calls into the matching HIR operation.
     pub(in crate::lowering) fn namespace_member_call(

--- a/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::lowering::{ModuleBuilder, is_static_property_key};
+use crate::lowering::ModuleBuilder;
 use crate::SmeltError;
 use oxc::ast::ast::{
     Expression, TSSignature, TSTupleElement, TSType, TSTypeName, TSTypeQueryExprName,
@@ -627,7 +627,10 @@ return_ty: function.return_ty,
             let TSSignature::TSPropertySignature(prop) = member else {
                 continue;
             };
-            if prop.computed && !is_static_property_key(&prop.key) {
+            // A computed field keeps its declared name when the key statically
+            // resolves (`[K]`, `[E.Member]`, `[Symbol.iterator]`); a genuinely
+            // dynamic key names no static field and is skipped.
+            if prop.computed && !self.is_resolvable_property_key(&prop.key) {
                 continue;
             }
             let Ok(name) = self.property_key_symbol(&prop.key) else {

--- a/crates/smelt-frontend-ts/src/lowering/ty/interface_lookup.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/interface_lookup.rs
@@ -33,11 +33,133 @@ impl ModuleBuilder<'_> {
                     .as_ref().map_or_else(|| Self::numeric_property_key_name(lit.value), ToString::to_string);
                 Ok(self.intern_source_name(&name))
             }
-            _ => Err(SmeltError::unsupported(
-                self.span(key.span().start, key.span().end),
-                "property names must be static identifiers or string literals",
-            )),
+            // A computed key such as `[SOME_CONST]`, `[MyEnum.Member]`, or a
+            // well-known `[Symbol.iterator]` names a *static* member once the
+            // constant/enum/symbol is resolved. Fold it to that member name so
+            // it lowers exactly like the equivalent spelled-out key instead of
+            // being rejected. Genuinely dynamic keys still fail below and stay
+            // on the explicit runtime-keyed path.
+            _ => {
+                if let Some((name, is_symbol)) = self.resolve_static_computed_key_name(key) {
+                    // Well-known symbol keys use a stable synthetic spelling
+                    // (`__smelt_symbol_iterator`) that member access already
+                    // reads, so intern it verbatim; folded string/numeric keys
+                    // follow the ordinary source-name interning path.
+                    return Ok(if is_symbol {
+                        self.intern_exact_source_name(&name)
+                    } else {
+                        self.intern_source_name(&name)
+                    });
+                }
+                Err(SmeltError::unsupported(
+                    self.span(key.span().start, key.span().end),
+                    "property names must be static identifiers or string literals",
+                ))
+            }
         }
+    }
+
+    /// Resolve a computed property key to its static string member name.
+    ///
+    /// Returns `Some((name, is_well_known_symbol))` when the key is a
+    /// statically-resolvable computed key:
+    /// * a const reference whose value folds to a string/number literal
+    ///   (`const K = "id"; { [K]: v }`),
+    /// * an enum member (`enum E { A = "a" }; { [E.A]: v }`) or a foldable
+    ///   `Number`/`Math` numeric constant, or
+    /// * a well-known symbol member (`[Symbol.iterator]`), which maps to a stable
+    ///   synthetic member spelling that member access already understands.
+    ///
+    /// Returns `None` for genuinely dynamic keys (arbitrary expressions, opaque
+    /// `Symbol(...)` brands, boolean/null constants), leaving them on the
+    /// explicit runtime-keyed path.
+    pub(in crate::lowering) fn resolve_static_computed_key_name(
+        &mut self,
+        key: &PropertyKey<'_>,
+    ) -> Option<(String, bool)> {
+        match key {
+            // A well-known `Symbol.<name>` key names a stable synthetic member.
+            PropertyKey::StaticMemberExpression(member) => {
+                if let Expression::Identifier(object) = &member.object
+                    && object.name == "Symbol"
+                    && member.property.name == "iterator"
+                {
+                    return Some((Self::SYMBOL_ITERATOR_KEY.to_owned(), true));
+                }
+                let literal = self.member_literal_const_expression(member).ok()?;
+                literal.computed_member_name().map(|name| (name, false))
+            }
+            // A bare identifier reference folds to its const value when known.
+            PropertyKey::Identifier(identifier) => self
+                .resolve_const_literal_by_name(identifier.name.as_str())
+                .and_then(|literal| literal.computed_member_name())
+                .map(|name| (name, false)),
+            // Erased type-level wrappers around any of the above still name the
+            // inner static key (`[K as const]`, `[(K)]`, `[K!]`).
+            PropertyKey::ParenthesizedExpression(inner) => {
+                self.resolve_static_computed_key_name_expr(&inner.expression)
+            }
+            PropertyKey::TSAsExpression(inner) => {
+                self.resolve_static_computed_key_name_expr(&inner.expression)
+            }
+            PropertyKey::TSSatisfiesExpression(inner) => {
+                self.resolve_static_computed_key_name_expr(&inner.expression)
+            }
+            PropertyKey::TSNonNullExpression(inner) => {
+                self.resolve_static_computed_key_name_expr(&inner.expression)
+            }
+            _ => None,
+        }
+    }
+
+    /// Resolve a computed-key expression (after unwrapping erased assertions) to
+    /// its static string member name, mirroring
+    /// [`Self::resolve_static_computed_key_name`] for bare `Expression`s.
+    fn resolve_static_computed_key_name_expr(
+        &mut self,
+        expression: &Expression<'_>,
+    ) -> Option<(String, bool)> {
+        match expression {
+            Expression::StaticMemberExpression(member) => {
+                if let Expression::Identifier(object) = &member.object
+                    && object.name == "Symbol"
+                    && member.property.name == "iterator"
+                {
+                    return Some((Self::SYMBOL_ITERATOR_KEY.to_owned(), true));
+                }
+                let literal = self.member_literal_const_expression(member).ok()?;
+                literal.computed_member_name().map(|name| (name, false))
+            }
+            Expression::Identifier(identifier) => self
+                .resolve_const_literal_by_name(identifier.name.as_str())
+                .and_then(|literal| literal.computed_member_name())
+                .map(|name| (name, false)),
+            Expression::StringLiteral(literal) => Some((literal.value.to_string(), false)),
+            Expression::ParenthesizedExpression(inner) => {
+                self.resolve_static_computed_key_name_expr(&inner.expression)
+            }
+            Expression::TSAsExpression(inner) => {
+                self.resolve_static_computed_key_name_expr(&inner.expression)
+            }
+            Expression::TSSatisfiesExpression(inner) => {
+                self.resolve_static_computed_key_name_expr(&inner.expression)
+            }
+            Expression::TSNonNullExpression(inner) => {
+                self.resolve_static_computed_key_name_expr(&inner.expression)
+            }
+            _ => None,
+        }
+    }
+
+    /// Return whether a computed property key resolves to a static member name.
+    ///
+    /// Combines the plain static-key check (`is_static_property_key`) with the
+    /// const/enum/symbol folding of [`Self::resolve_static_computed_key_name`],
+    /// so class/interface member gates route resolvable computed keys through the
+    /// named-member path instead of rejecting them as dynamic.
+    pub(in crate::lowering) fn is_resolvable_property_key(&mut self, key: &PropertyKey<'_>) -> bool {
+        crate::lowering::support::is_static_property_key(key)
+            || self.resolve_static_computed_key_name(key).is_some()
     }
 
     /// Render a numeric property-key value as the string member name JavaScript

--- a/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
@@ -265,6 +265,182 @@ export function isEnabled(flags: Flags): boolean {
     Ok(())
 }
 
+/// Find a class item by source name in a lowered module.
+fn class_named<'a>(
+    ctx: &'a HirCtx,
+    module: &'a smelt_hir::Module,
+    name: &str,
+) -> Result<&'a smelt_hir::Class, String> {
+    module
+        .items
+        .iter()
+        .find_map(|item| match ctx.krate.items.get(item.0 as usize)? {
+            Item::Class(class) if ctx.krate.names.get(class.name) == Some(name) => Some(class),
+            _ => None,
+        })
+        .ok_or_else(|| format!("missing class `{name}`"))
+}
+
+/// Find an interface item by source name in a lowered module.
+fn interface_named<'a>(
+    ctx: &'a HirCtx,
+    module: &'a smelt_hir::Module,
+    name: &str,
+) -> Result<&'a smelt_hir::Interface, String> {
+    module
+        .items
+        .iter()
+        .find_map(|item| match ctx.krate.items.get(item.0 as usize)? {
+            Item::Interface(interface) if ctx.krate.names.get(interface.name) == Some(name) => {
+                Some(interface)
+            }
+            _ => None,
+        })
+        .ok_or_else(|| format!("missing interface `{name}`"))
+}
+
+/// A `const`-keyed computed interface field (`{ [KEY]: T }`) resolves to the
+/// const's string value as a static named member (issue #96), instead of being
+/// rejected as a dynamic property name.
+#[test]
+fn lowers_const_keyed_computed_interface_field() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+const KEY = "id";
+
+export interface Keyed {
+  [KEY]: number;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    let keyed = interface_named(&ctx, module, "Keyed")?;
+    ensure!(
+        keyed
+            .fields
+            .iter()
+            .any(|field| ctx.krate.symbols.get(field.name) == Some("id")
+                && matches!(ctx.krate.types.get(field.ty), Some(Type::Float))),
+        "expected const-keyed field `id: Float`, got {:?}",
+        keyed.fields
+    );
+    Ok(())
+}
+
+/// An enum-member-keyed computed interface field (`{ [E.A]: T }`) folds to the
+/// enum member's string value as a static named member (issue #96).
+#[test]
+fn lowers_enum_keyed_computed_interface_field() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+enum Kind {
+  First = "first",
+}
+
+export interface ByKind {
+  [Kind.First]: number;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    let by_kind = interface_named(&ctx, module, "ByKind")?;
+    ensure!(
+        by_kind
+            .fields
+            .iter()
+            .any(|field| ctx.krate.symbols.get(field.name) == Some("first")
+                && matches!(ctx.krate.types.get(field.ty), Some(Type::Float))),
+        "expected enum-keyed field `first: Float`, got {:?}",
+        by_kind.fields
+    );
+    Ok(())
+}
+
+/// A `const`-keyed computed class field resolves to the const's string value as
+/// a static named class field (issue #96).
+#[test]
+fn lowers_const_keyed_computed_class_field() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+const TAG = "tag";
+
+class Node {
+  [TAG]: string = "leaf";
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    let node = class_named(&ctx, module, "Node")?;
+    ensure!(
+        node.fields
+            .iter()
+            .any(|field| ctx.krate.symbols.get(field.name) == Some("tag")
+                && matches!(ctx.krate.types.get(field.ty), Some(Type::String))),
+        "expected const-keyed class field `tag: String`, got {:?}",
+        node.fields
+    );
+    Ok(())
+}
+
+/// A well-known `[Symbol.iterator]` interface method resolves to the stable
+/// synthetic member spelling so it lowers to a named method (issue #96) rather
+/// than being silently dropped or rejected as a dynamic key.
+#[test]
+fn lowers_symbol_iterator_computed_interface_method() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export interface Seq {
+  [Symbol.iterator](): number;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    let seq = interface_named(&ctx, module, "Seq")?;
+    ensure!(
+        seq.methods
+            .iter()
+            .any(|method| ctx.krate.symbols.get(method.name)
+                == Some("__smelt_symbol_iterator")),
+        "expected a `__smelt_symbol_iterator` method, got {:?}",
+        seq.methods
+    );
+    Ok(())
+}
+
+/// A genuinely dynamic computed class property name (a runtime call) is not a
+/// statically-resolvable key, so it still reports the dynamic-property-name
+/// diagnostic (issue #96 folds only static keys; it does not silence honest
+/// dynamic ones).
+#[test]
+fn rejects_dynamic_computed_class_property_name() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let class_errors = lowering_errors(
+        ts!(r#"
+class Dynamic {
+  [Math.random()]: number = 0;
+}
+"#),
+        &mut ctx,
+    )?;
+    assert_unsupported_ts(
+        &class_errors,
+        "dynamic computed property names are not lowered yet",
+    )?;
+    Ok(())
+}
+
 /// A class string index signature also supports keyed writes (`bag[key] = v`):
 /// the assignment lowers cleanly and the emitted program validates.
 #[test]


### PR DESCRIPTION
## Summary

Lowers computed / non-identifier property names (`[expr]: v`) that statically resolve, instead of always rejecting them at the `property names must be static identifiers or string literals` gate. This unblocks the cross-library TS blocker (neverthrow, ts-pattern — 4 occ) called out in issue #96.

A computed key now folds to its member name and lowers exactly like the spelled-out key when it resolves at compile time:

- **const references** (`const K = "id"; { [K]: v }`) — folded via the existing `ConstLiteral` machinery (`resolve_const_literal_by_name`).
- **enum members** (`enum E { A = "a" }; { [E.A]: v }`) and foldable `Number`/`Math` numeric constants — folded via `member_literal_const_expression`.
- **well-known `[Symbol.iterator]`** — resolves to the stable synthetic member key (`__smelt_symbol_iterator`) that member access already reads.

Genuinely dynamic keys (arbitrary expressions, opaque `Symbol(...)` brands, boolean/null constants) still fail and stay on the explicit runtime-keyed path — no `SmeltUnknown` shortcut is introduced. The folding reuses the shared const/enum resolution engine, so there are **no per-library special cases**.

## Implementation

- New `resolve_static_computed_key_name` / `is_resolvable_property_key` helpers in `ty/interface_lookup.rs`, plus a `ConstLiteral::computed_member_name` accessor.
- `property_key_symbol` folds resolvable computed keys before erroring.
- Class fields/methods, interface property/method signatures, and inline type-literal fields all route computed keys through `is_resolvable_property_key`, so resolvable keys become named members instead of being rejected or silently dropped.

## Tests

- Frontend regression tests in `class_module_tests.rs`: const-keyed / enum-keyed interface fields, const-keyed class field, `[Symbol.iterator]` interface method, and a dynamic-key rejection. All pass.
- `computed_property_names` compile-corpus case proving the emitted Rust compiles (`cargo test -p smelt-codegen-rust --test compile_corpus -- --ignored`, run scoped via `SMELT_CORPUS_ONLY` — passes).
- `cargo check` + `cargo clippy` clean on `smelt-frontend-ts` and `smelt-codegen-rust` (lib profile, matching the CI gate).

Full `cargo test` + the remeda gate are validated centrally.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)