### PR TITLE
object model (#97): optional class/data fields as Option<T> with explicit construction

### DIFF
--- a/crates/smelt-cli/tests/hir_cli_typescript_tests.rs
+++ b/crates/smelt-cli/tests/hir_cli_typescript_tests.rs
@@ -218,6 +218,75 @@ console.log(counters.total);
 }
 
 #[test]
+fn build_round_trips_optional_class_field() -> TestResult {
+    // Issue #97 / #18: an optional class field (`y?: number`) lowers to a real
+    // `Option<T>` slot with explicit construction. Constructing with the field
+    // present stores `Some(value)`; omitting it stores `None`. Reading the field
+    // back through `??` observes the stored value or the fallback. The required
+    // field stays concrete. This program builds and RUNS the emitted crate,
+    // asserting the runtime values rather than only that the code compiles.
+    let project = TempProject::new()?;
+    let project_path = project.path();
+    fs::create_dir_all(project_path.join("src"))?;
+    fs::write(
+        project_path.join("Smelt.toml"),
+        r#"[project]
+name = "ts-optional-class-field"
+version = "0.1.0"
+
+[sources]
+entries = ["src/main.ts"]
+
+[output]
+target = "./dist"
+crate-name = "ts_optional_class_field"
+build = true
+
+[runtime]
+clone-strategy = "aggressive"
+"#,
+    )?;
+    fs::write(
+        project_path.join("src/main.ts"),
+        r#"class Point {
+  x: number;
+  y?: number;
+  constructor(x: number, y?: number) {
+    this.x = x;
+    this.y = y;
+  }
+  readY(): number {
+    return this.y ?? -1;
+  }
+}
+
+const present = new Point(1, 2);
+const absent = new Point(3);
+console.log(present.x);
+console.log(present.readY());
+console.log(absent.x);
+console.log(absent.readY());
+"#,
+    )?;
+
+    let manifest_arg = utf8_path(&project_path.join("Smelt.toml"))?;
+    smelt(&["--manifest-path", &manifest_arg, "build"])?;
+
+    let actual_stdout = cargo_run_manifest(&project_path.join("dist/Cargo.toml"))?;
+    // 1. required field stays concrete: present.x === 1
+    // 2. present optional field round-trips: present.y ?? -1 === 2
+    // 3. required field on the field-omitting instance: absent.x === 3
+    // 4. absent optional field reads as the `??` fallback: absent.y ?? -1 === -1
+    ensure_eq(
+        &actual_stdout,
+        &"1\n2\n3\n-1\n".to_owned(),
+        "optional class field did not round-trip at runtime",
+    )?;
+
+    Ok(())
+}
+
+#[test]
 fn build_resolves_typescript_index_module_imports() -> TestResult {
     let project = TempProject::new()?;
     let project_path = project.path();

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -6046,3 +6046,77 @@ function squares(values: number[]): number[] {
     assert!(source.contains(".map("), "{source}");
     assert!(source.contains("square"), "{source}");
 }
+
+#[test]
+fn lowers_optional_class_field_to_option_with_explicit_construction() {
+    // An optional TypeScript class field (`y?: number`) must lower to a concrete
+    // `Option<f64>` struct slot. Construction that supplies the field passes
+    // `Some(..)`; construction that omits it passes `None::<f64>`, mirroring how
+    // optional interface fields already lower. The named non-optional field
+    // (`x: number`) stays concrete `f64` with no `Option` wrapper.
+    let source = source_for(
+        r#"
+class Point {
+  x: number;
+  y?: number;
+  constructor(x: number, y?: number) {
+    this.x = x;
+    this.y = y;
+  }
+  total(): number {
+    return this.x + (this.y ?? 0);
+  }
+}
+
+function make(): number {
+  const a = new Point(1, 2);
+  const b = new Point(3);
+  return a.total() + b.total();
+}
+"#,
+    );
+
+    assert!(source.contains("struct Point"), "{source}");
+    assert!(source.contains("x: f64,"), "{source}");
+    assert!(source.contains("y: Option<f64>,"), "{source}");
+    // Construction with the field present wraps the value in `Some(..)`.
+    assert!(source.contains("Point::new(1.0, Some(2.0))"), "{source}");
+    // Construction that omits the trailing optional field supplies a typed `None`.
+    assert!(source.contains("Point::new(3.0, None::<f64>)"), "{source}");
+    // Reading the field through `??` consumes the `Option<f64>` directly.
+    assert!(source.contains("unwrap_or(0.0)"), "{source}");
+}
+
+#[test]
+fn lowers_optional_dataclass_field_to_option_with_explicit_construction() {
+    // A Python dataclass field annotated `Optional[int]` (with a `None` default)
+    // must lower to a concrete `Option<i64>` struct slot, and construction that
+    // omits the field must synthesize the typed `None` default while a present
+    // argument is wrapped as `Some(..)`. The required `int` field stays concrete.
+    let source = source_for_py(
+        r#"
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Point:
+    x: int
+    y: Optional[int] = None
+
+
+def make() -> Optional[int]:
+    a = Point(1, 2)
+    b = Point(3)
+    return a.y
+"#,
+    );
+
+    assert!(source.contains("struct Point"), "{source}");
+    assert!(source.contains("x: i64,"), "{source}");
+    assert!(source.contains("y: Option<i64>,"), "{source}");
+    assert!(source.contains("Point::new(1, Some(2))"), "{source}");
+    assert!(source.contains("Point::new(3, None::<i64>)"), "{source}");
+    // Reading the optional field yields the `Option<i64>` value unchanged.
+    assert!(source.contains("a.y.clone()"), "{source}");
+}

--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -522,6 +522,40 @@ export function readMixed(bag: MixedBag, key: string): number | undefined {
 "#,
         },
         Case {
+            // Issue #97 / #18: optional class/data fields lower to `Option<T>`
+            // with explicit construction. The optional field (`y?: number`)
+            // becomes an `Option<f64>` struct slot; construction that supplies
+            // the field passes `Some(..)` and construction that omits it passes
+            // `None`, while the required field (`x`) stays concrete. Reading the
+            // optional field through `??` consumes the `Option` directly. The
+            // emitted Rust must compile. (The runtime round-trip is asserted
+            // end-to-end by the CLI test `build_round_trips_optional_class_field`
+            // and by the frontend/codegen regression tests.)
+            name: "optional_class_field",
+            area: "classes",
+            source: r"
+class Point {
+  x: number;
+  y?: number;
+  constructor(x: number, y?: number) {
+    this.x = x;
+    this.y = y;
+  }
+  readY(): number {
+    return this.y ?? -1;
+  }
+}
+
+export function makePresent(): number {
+  return new Point(1, 2).readY();
+}
+
+export function makeAbsent(): number {
+  return new Point(3).readY();
+}
+",
+        },
+        Case {
             name: "interface_method_call",
             area: "interfaces",
             source: r"

--- a/crates/smelt-frontend-py/src/lowering/class.rs
+++ b/crates/smelt-frontend-py/src/lowering/class.rs
@@ -271,11 +271,22 @@ impl ModuleBuilder<'_> {
                     let field_name_str = target_name.id.as_str();
                     let field_ty = self.annotation_to_hir(&ann.annotation)?;
                     let field_sym = self.intern_name(field_name_str);
+                    // A Python data field is optional when its annotation lowers to
+                    // `Optional[T]` / `T | None`. Those spellings already intern a
+                    // `Type::Optional`, which is what Rust codegen turns into
+                    // `Option<T>`; recording the flag here keeps the HIR field
+                    // metadata honest so downstream shape checks (interface
+                    // satisfaction, dynamic-field wrapping) see the same optionality
+                    // TypeScript class fields carry for the `?` spelling.
+                    let field_optional = matches!(
+                        self.ctx.krate.types.get(field_ty),
+                        Some(Type::Optional(_))
+                    );
                     let field = Field {
                         name: field_sym,
                         ty: field_ty,
                         visibility: Visibility::Public,
-                        optional: false,
+                        optional: field_optional,
                         span: self.span(ann.range),
                     };
                     self.class_fields

--- a/crates/smelt-frontend-py/src/lowering/specialization.rs
+++ b/crates/smelt-frontend-py/src/lowering/specialization.rs
@@ -296,6 +296,11 @@ impl ModuleBuilder<'_> {
         for field in materialized.fields.iter().filter(|field| !field.is_static) {
             let name = self.intern_name(&field.name);
             let ty = self.materialized_static_type(&field.ty);
+            // Keep the optional flag in sync with the interned type: a
+            // materialized field whose type is `Type::Optional` is an optional
+            // data field, matching how the ordinary `AnnAssign` path records
+            // `Optional[T]` / `T | None` fields.
+            let optional = matches!(self.ctx.krate.types.get(ty), Some(Type::Optional(_)));
             let lowered = Field {
                 name,
                 ty,
@@ -304,7 +309,7 @@ impl ModuleBuilder<'_> {
                 } else {
                     Visibility::Public
                 },
-                optional: false,
+                optional,
                 span,
             };
             if let Some(existing) = fields.iter_mut().find(|existing| existing.name == name) {

--- a/crates/smelt-frontend-py/src/tests/class_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/class_tests.rs
@@ -443,6 +443,95 @@ class Immutable:
 }
 
 #[test]
+fn optional_dataclass_field_lowers_as_optional() -> TestResult {
+    // A dataclass field annotated `Optional[int]` (or `int | None`) must record
+    // `optional: true` and intern its type as `Type::Optional`, while a plain
+    // required field stays non-optional. This mirrors how TypeScript class fields
+    // carry the `?` spelling and lets Rust codegen emit `Option<T>` for the
+    // optional slot only.
+    let source = py!(r#"
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass
+class Point:
+    x: int
+    y: Optional[int] = None
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let class_item_id = module
+        .items
+        .last()
+        .copied()
+        .ok_or_else(|| "expected class item".to_owned())?;
+    if let Item::Class(c) = item(&ctx, class_item_id)? {
+        ensure_eq(&c.fields.len(), &2, "field count")?;
+        let x = c
+            .fields
+            .iter()
+            .find(|field| symbol(&ctx, field.name) == Ok("x"))
+            .ok_or_else(|| "missing field x".to_owned())?;
+        let y = c
+            .fields
+            .iter()
+            .find(|field| symbol(&ctx, field.name) == Ok("y"))
+            .ok_or_else(|| "missing field y".to_owned())?;
+        ensure(!x.optional, "required field x must stay non-optional")?;
+        ensure(
+            !matches!(ctx.krate.types.get(x.ty), Some(Type::Optional(_))),
+            "required field x must not be Type::Optional",
+        )?;
+        ensure(y.optional, "field y must be marked optional")?;
+        ensure(
+            matches!(ctx.krate.types.get(y.ty), Some(Type::Optional(_))),
+            "field y must intern as Type::Optional",
+        )?;
+    } else {
+        return Err("expected Class item".to_owned());
+    }
+    Ok(())
+}
+
+#[test]
+fn pep604_optional_dataclass_field_lowers_as_optional() -> TestResult {
+    // The PEP 604 `int | None` spelling must lower the same way as
+    // `Optional[int]`: the field is optional and its type is `Type::Optional`.
+    let source = py!(r#"
+from dataclasses import dataclass
+
+@dataclass
+class Config:
+    name: str
+    retries: int | None = None
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let class_item_id = module
+        .items
+        .last()
+        .copied()
+        .ok_or_else(|| "expected class item".to_owned())?;
+    if let Item::Class(c) = item(&ctx, class_item_id)? {
+        let retries = c
+            .fields
+            .iter()
+            .find(|field| symbol(&ctx, field.name) == Ok("retries"))
+            .ok_or_else(|| "missing field retries".to_owned())?;
+        ensure(retries.optional, "field retries must be marked optional")?;
+        ensure(
+            matches!(ctx.krate.types.get(retries.ty), Some(Type::Optional(_))),
+            "field retries must intern as Type::Optional",
+        )?;
+    } else {
+        return Err("expected Class item".to_owned());
+    }
+    Ok(())
+}
+
+#[test]
 fn int_enum_members_lower_as_integer_constants() -> TestResult {
     let source = py!(r#"
 from enum import IntEnum

--- a/crates/smelt-frontend-ts/src/tests/part06_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part06_tests.rs
@@ -103,15 +103,51 @@ class User implements Named {
 
 #[test]
 fn lowers_optional_class_fields() -> Result<(), String> {
+    // An optional class field (`name?: string`) records `optional: true` and
+    // interns its type as `Type::Optional`, while a required field stays
+    // concrete. Rust codegen relies on the `Type::Optional` wrapper to emit
+    // `Option<T>` for the optional slot only.
     let mut ctx = HirCtx::new();
     lower_ok(
         ts!("class User {
+  id: string;
   name?: string;
-  constructor() {}
+  constructor(id: string) {
+    this.id = id;
+  }
 }
 "),
         &mut ctx,
     )?;
+    let class = ctx
+        .krate
+        .items
+        .iter()
+        .find_map(|item| match item {
+            Item::Class(class) => Some(class),
+            _ => None,
+        })
+        .ok_or_else(|| "missing class item".to_owned())?;
+    let id_field = class
+        .fields
+        .iter()
+        .find(|field| ctx.krate.symbols.get(field.name) == Some("id"))
+        .ok_or_else(|| "missing field id".to_owned())?;
+    let name_field = class
+        .fields
+        .iter()
+        .find(|field| ctx.krate.symbols.get(field.name) == Some("name"))
+        .ok_or_else(|| "missing field name".to_owned())?;
+    ensure!(!id_field.optional);
+    ensure!(!matches!(
+        ctx.krate.types.get(id_field.ty),
+        Some(Type::Optional(_))
+    ));
+    ensure!(name_field.optional);
+    ensure!(matches!(
+        ctx.krate.types.get(name_field.ty),
+        Some(Type::Optional(_))
+    ));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Closes #97. Part of the #18 object-model roadmap.

Optional class/data fields now lower to `Option<T>` with **explicit construction**:

- **TypeScript** `y?: number` and **Python** `Optional[int]` / `int | None` become a concrete `Option<T>` struct slot.
- Construction that supplies the field wraps the value in `Some(..)`; omitting a trailing optional field defaults to a typed `None`.
- Field reads yield the `Option<T>` value, integrating with the existing nullish (`??`) and optional-chaining handling.
- Named non-optional fields stay concrete (`f64`, `i64`, …). **No `SmeltUnknown` erasure.**

This mirrors how optional **interface** fields already lower and how the #84 class field/index-store work structured class fields.

## What was already in place vs. what this changes

The TypeScript ES6-class path and the Rust codegen already carried the `Type::Optional` wrapper end-to-end (optional field → `Option<T>` slot, `Some`/`None::<T>` construction, `??` read), because optionality is encoded in the field's interned `TypeId` — the same mechanism optional interface fields use.

The remaining correctness gap was the **Python frontend**, which hard-coded `optional: false` on class/data fields even when the annotation interned a `Type::Optional`. Both Python field-construction sites now derive the flag from the interned type:

- `crates/smelt-frontend-py/src/lowering/class.rs` — the ordinary `AnnAssign` field path.
- `crates/smelt-frontend-py/src/lowering/specialization.rs` — the materialized-field path.

This keeps HIR field metadata honest so downstream shape checks (interface satisfaction, dynamic-field wrapping) see the same optionality TypeScript carries for the `?` spelling. The type was already `Type::Optional`, so codegen was unaffected; this makes the flag truthful rather than routing anything through a dynamic tag.

## Tests

- **Frontend (TS)** — `lowers_optional_class_fields` now asserts the optional field is `optional` + `Type::Optional` while the required field stays concrete.
- **Frontend (Py)** — new `optional_dataclass_field_lowers_as_optional` and `pep604_optional_dataclass_field_lowers_as_optional`.
- **Codegen** — emitted-Rust regression tests for TS and Python: `Option<T>` slot, `Some(..)` / `None::<T>` construction, `??` read.
- **Compile-corpus** — `optional_class_field` case (emitted Rust compiles).
- **CLI runtime round-trip** — `build_round_trips_optional_class_field` builds and runs the emitted crate, asserting present vs. absent optional-field values (`1\n2\n3\n-1\n`).

## Verification

- `cargo check` + `cargo clippy` (library) clean on touched crates.
- All new frontend/codegen tests pass; full `smelt-frontend-py` lib suite green (165 tests).
- Single compile-corpus case passes via `--ignored`; CLI runtime round-trip passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)