### PR TITLE
feat(generics): lower generic class/interface use sites to typed Rust (part of #99)

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/call.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call.rs
@@ -425,6 +425,7 @@ impl FunctionEmitter<'_> {
                     .ok_or_else(|| EmitError::new("call references an unknown function"))?;
                 if let HirOrigin::ClassConstructor { class, .. } = function.origin {
                     let class_name = sanitize_ident(self.symbol_name(class)?);
+                    let class_type_params = self.callee_class_type_params(function);
                     let mut rendered_args = args
                         .iter()
                         .enumerate()
@@ -433,7 +434,12 @@ impl FunctionEmitter<'_> {
                                 return self.operand_text(arg);
                             };
                             let target_ty = self.function_local_decl(function, param)?.ty;
-                            self.value_at_type(arg, target_ty)
+                            self.callee_generic_argument_text(
+                                arg,
+                                function,
+                                target_ty,
+                                &class_type_params,
+                            )
                         })
                         .collect::<Result<Vec<_>, _>>()?;
                     for param in function.params.iter().skip(args.len()) {
@@ -486,6 +492,7 @@ impl FunctionEmitter<'_> {
                         };
                         return self.list_concat_text(receiver, first_rest);
                     }
+                    let class_type_params = self.callee_class_type_params(function);
                     let arg_values = rest
                         .iter()
                         .enumerate()
@@ -497,7 +504,12 @@ impl FunctionEmitter<'_> {
                                 return self.operand_text(arg);
                             };
                             let target_ty = self.function_local_decl(function, param)?.ty;
-                            self.value_at_type(arg, target_ty)
+                            self.callee_generic_argument_text(
+                                arg,
+                                function,
+                                target_ty,
+                                &class_type_params,
+                            )
                         })
                         .collect::<Result<Vec<_>, _>>()?
                         .join(", ");
@@ -727,6 +739,77 @@ impl FunctionEmitter<'_> {
             .map(|rendered_args| rendered_args.join(", "))
     }
 
+    /// Return the generic type parameters declared by the class that owns
+    /// `function`, when `function` is a class method or constructor.
+    ///
+    /// Methods and constructors of a generic class are emitted inside an
+    /// `impl<T> Class<T>` block, so their signatures reference the class type
+    /// parameters `T` directly. Callers use this to detect arguments whose
+    /// target parameter is one of those class-level type parameters.
+    fn callee_class_type_params(&self, function: &MirFunction) -> HashSet<Symbol> {
+        let class_name = match function.origin {
+            HirOrigin::ClassConstructor { class, .. } | HirOrigin::ClassMethod { class, .. } => {
+                class
+            }
+            HirOrigin::Body(_) => return HashSet::new(),
+        };
+        self.mir
+            .classes
+            .iter()
+            .find(|class| class.name == class_name)
+            .map(|class| class.type_params.iter().map(|param| param.name).collect())
+            .unwrap_or_default()
+    }
+
+    /// Return whether `function`'s declared return type is a generic type
+    /// parameter of the class that owns it.
+    ///
+    /// Used to detect method calls such as `Box<number>::get(): T`, whose result
+    /// is the receiver's concrete class argument at the call site rather than an
+    /// erased `SmeltUnknown`. Nested shapes built from the parameter (for example
+    /// `T[]`) are intentionally excluded here; only a bare `TypeParam` return is
+    /// handled, matching the argument pass-through rule and keeping the concrete
+    /// increment narrow and correct.
+    fn method_returns_class_type_param(&self, function: &MirFunction) -> bool {
+        matches!(
+            self.mir.types.get(function.return_ty),
+            Some(Type::TypeParam { name }) if self.callee_class_type_params(function).contains(name)
+        )
+    }
+
+    /// Render a constructor or method argument against a callee parameter type,
+    /// keeping the value concrete when the parameter is one of the callee
+    /// class's own generic type parameters.
+    ///
+    /// A call such as `new Box<number>(3)` monomorphizes the emitted
+    /// `impl<T> Box<T>` to `Box<f64>`, so the constructor parameter `value: T`
+    /// resolves to `f64` at this site. Coercing the argument against the bare
+    /// `TypeParam` target would erase it to `SmeltUnknown` (the calling function
+    /// has no `T` in scope), producing a type mismatch against the generic
+    /// parameter. Instead the argument is passed through at its own concrete
+    /// type and Rust infers the class type argument from the value, which is the
+    /// point of emitting real generics rather than erasing them.
+    fn callee_generic_argument_text(
+        &self,
+        arg: &Operand,
+        function: &MirFunction,
+        target_ty: TypeId,
+        class_type_params: &HashSet<Symbol>,
+    ) -> Result<String, EmitError> {
+        if let Some(Type::TypeParam { name }) = self.mir.types.get(target_ty)
+            && class_type_params.contains(name)
+        {
+            let source_ty = self.operand_ty(arg)?;
+            // A `TypeParam` source is already the class generic itself (e.g. one
+            // generic method forwarding to another); pass it straight through.
+            // Any concrete source is bound to the class type argument by Rust
+            // inference, so rendering it at its own type keeps it concrete.
+            let _ = function;
+            return self.value_at_type(arg, source_ty);
+        }
+        self.value_at_type(arg, target_ty)
+    }
+
     /// Emits an optional first-class function call as an optional return value.
     fn optional_indirect_call_text_for_dest(
         &self,
@@ -828,6 +911,18 @@ impl FunctionEmitter<'_> {
                     .get(id_index(func.0, "function index does not fit usize")?)
                     .ok_or_else(|| EmitError::new("call references an unknown function"))?;
                 if matches!(function.origin, HirOrigin::ClassConstructor { .. }) {
+                    dest_ty
+                } else if matches!(function.origin, HirOrigin::ClassMethod { .. })
+                    && self.method_returns_class_type_param(function)
+                {
+                    // A method of a generic class whose declared return type is
+                    // one of the class type parameters (e.g. `get(): T`) returns
+                    // the receiver's concrete instantiation at this call site
+                    // (`Box<f64>::get` yields `f64`). The dest local already
+                    // carries that substituted type from the frontend, so use it
+                    // as the source type: the call value is concrete and needs no
+                    // `SmeltUnknown` extraction. Erasing here would emit an
+                    // extraction match against a value that is not `SmeltUnknown`.
                     dest_ty
                 } else if function.is_async {
                     self.type_id(Type::Future(function.return_ty))?

--- a/crates/smelt-codegen-rust/src/stdlib.rs
+++ b/crates/smelt-codegen-rust/src/stdlib.rs
@@ -192,10 +192,24 @@ pub(crate) fn needs_unknown_type(mir: &Mir) -> bool {
     // is present. A union-valued `Map`/dict literal is exactly such a case: the
     // dict-literal emitter erases each entry inline without materializing a
     // `Type::Unknown` in the table. Emit the carrier for unions too.
-    mir.types
-        .all()
+    // A generic class or interface emits inherent/impl blocks whose type
+    // parameters are bounded by `IntoSmeltUnknown + SmeltFromUnknown` (see
+    // `classes::class_impl_generics_text`). Those bounds reference the erasure
+    // traits, so the carrier and its traits must be emitted even when a program
+    // has no explicit `unknown`/union value of its own — otherwise the generic
+    // `impl` block names traits that were never declared.
+    mir.classes
         .iter()
-        .any(|ty| matches!(ty, Type::Unknown | Type::Never | Type::Union(_)))
+        .any(|class| !class.type_params.is_empty())
+        || mir
+            .interfaces
+            .iter()
+            .any(|interface| !interface.type_params.is_empty())
+        || mir
+            .types
+            .all()
+            .iter()
+            .any(|ty| matches!(ty, Type::Unknown | Type::Never | Type::Union(_)))
         || mir.functions.iter().any(|function| {
             function.blocks.iter().any(|block| {
                 block.statements.iter().any(|statement| {

--- a/crates/smelt-codegen-rust/src/tests/generics_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/generics_tests.rs
@@ -1,0 +1,109 @@
+//! Codegen regression tests for generic classes and interfaces (issue #99).
+//!
+//! These assert that generic class/interface declarations lower to real Rust
+//! generics (`struct Container<T>`, `impl<T: ...> Container<T>`) and that use
+//! sites (`new Container<number>(...)`, `b.get()`) keep the instantiation
+//! concrete instead of erasing the generic arguments to `SmeltUnknown`.
+
+use super::*;
+
+#[test]
+fn emits_generic_class_struct_and_impl() {
+    let source = source_for(
+        r"
+class Container<T> {
+  value: T;
+  constructor(value: T) { this.value = value; }
+  get(): T { return this.value; }
+  set(value: T): void { this.value = value; }
+}
+",
+    );
+
+    // Struct carries the generic parameter and a PhantomData over it.
+    assert!(source.contains("struct Container<T>"));
+    assert!(source.contains("value: T,"));
+    assert!(source.contains("_smelt_phantom: ::std::marker::PhantomData<(T)>"));
+    // Inherent impl block declares bounded generics and returns the parameter.
+    assert!(source.contains("impl<T: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'static> Container<T>"));
+    assert!(source.contains("fn get(&self) -> T"));
+    assert!(source.contains("fn set(&mut self, value: T) -> ()"));
+}
+
+#[test]
+fn instantiates_generic_class_with_concrete_arguments() {
+    let source = source_for(
+        r"
+class Container<T> {
+  value: T;
+  constructor(value: T) { this.value = value; }
+  get(): T { return this.value; }
+  set(value: T): void { this.value = value; }
+}
+function useBox(): number {
+  const b = new Container<number>(3);
+  b.set(5);
+  return b.get();
+}
+",
+    );
+
+    // The instantiation is `Container<f64>`, not an erased `SmeltUnknown`.
+    assert!(source.contains("Container<f64>"));
+    // Constructor and method arguments pass the concrete value through so Rust
+    // monomorphizes; they are NOT wrapped in `SmeltUnknown::Number(..)`.
+    assert!(source.contains("Container::new(3.0)"));
+    assert!(source.contains("b.set(5.0)"));
+    // The method result is typed with the concrete instantiation and needs no
+    // `SmeltUnknown` extraction match.
+    assert!(source.contains("let _smelt_tmp_3: f64 = b.get();"));
+    assert!(!source.contains("Container::new(SmeltUnknown"));
+}
+
+#[test]
+fn emits_two_parameter_generic_class() {
+    let source = source_for(
+        r#"
+class Pair<A, B> {
+  first: A;
+  second: B;
+  constructor(first: A, second: B) { this.first = first; this.second = second; }
+  getFirst(): A { return this.first; }
+  getSecond(): B { return this.second; }
+}
+function usePair(): string {
+  const p = new Pair<number, string>(1, "x");
+  return p.getSecond();
+}
+"#,
+    );
+
+    assert!(source.contains("struct Pair<A, B>"));
+    assert!(source.contains("impl<A: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'static, B: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'static> Pair<A, B>"));
+    // Both concrete arguments are passed through; the receiver is `Pair<f64, String>`.
+    assert!(source.contains("Pair<f64, String>"));
+    assert!(source.contains(r#"Pair::new(1.0, "x".to_owned())"#));
+    // `getSecond(): B` on `Pair<f64, String>` returns `String`, not `SmeltUnknown`.
+    assert!(source.contains("let _smelt_tmp_2: String = p.get_second();"));
+}
+
+#[test]
+fn emits_generic_interface_type_params() {
+    let source = source_for(
+        r#"
+interface Outcome<T, E> {
+  ok: boolean;
+  value: T;
+  error: E;
+}
+function makeOk(v: number): Outcome<number, string> {
+  return { ok: true, value: v, error: "" };
+}
+"#,
+    );
+
+    // The interface storage keeps its generic parameters and instantiates
+    // concretely at the return position.
+    assert!(source.contains("struct Outcome<T, E>"));
+    assert!(source.contains("-> Outcome<f64, String>"));
+}

--- a/crates/smelt-codegen-rust/src/tests/mod.rs
+++ b/crates/smelt-codegen-rust/src/tests/mod.rs
@@ -61,5 +61,6 @@ mod part_4_tests;
 mod part_5_tests;
 mod part_6_tests;
 mod part_7_tests;
+mod generics_tests;
 mod snapshot_tests;
 mod snapshot_tests_part_2;

--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -543,6 +543,56 @@ export function sum(adder: Adder): number {
 ",
         },
         Case {
+            // Issue #99: generic classes and interfaces lower to real Rust
+            // generics rather than erasing their instantiations to
+            // `SmeltUnknown`. `Container<T>` emits `struct Container<T>` with an
+            // `impl<T: ..> Container<T>` whose methods return the parameter;
+            // `Pair<A, B>` exercises multi-parameter generics; `Outcome<T, E>`
+            // is a generic interface used at a concrete return position. The use
+            // sites (`new Container<number>(3)`, `b.get()`, `p.getSecond()`)
+            // must instantiate the class concretely (`Container<f64>`) and pass
+            // arguments through so Rust monomorphizes, all of which must compile.
+            name: "generic_classes_and_interfaces",
+            area: "generics",
+            source: r#"
+class Container<T> {
+  value: T;
+  constructor(value: T) { this.value = value; }
+  get(): T { return this.value; }
+  set(value: T): void { this.value = value; }
+}
+
+class Pair<A, B> {
+  first: A;
+  second: B;
+  constructor(first: A, second: B) { this.first = first; this.second = second; }
+  getFirst(): A { return this.first; }
+  getSecond(): B { return this.second; }
+}
+
+interface Outcome<T, E> {
+  ok: boolean;
+  value: T;
+  error: E;
+}
+
+export function useContainer(): number {
+  const b = new Container<number>(3);
+  b.set(5);
+  return b.get();
+}
+
+export function usePair(): string {
+  const p = new Pair<number, string>(1, "x");
+  return p.getSecond();
+}
+
+export function makeOk(v: number): Outcome<number, string> {
+  return { ok: true, value: v, error: "" };
+}
+"#,
+        },
+        Case {
             // Issue #78: `switch` over non-literal case labels. Enum-member and
             // const-reference labels const-fold to the member's numeric/string
             // literal, and the enum type resolves to its underlying primitive so

--- a/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
@@ -2447,12 +2447,34 @@ return_ty: function.return_ty,
             if let Item::Function(function) = self.item_ref(*item)
                 && function.name == method
             {
-                return Ok((function.return_ty, *item));
+                // A generic class receiver such as `Box<number>` instantiates the
+                // method's declared type parameters. `get(): T` on `Box<number>`
+                // returns `number`, not the bare parameter `T`, so the call
+                // expression is typed with the receiver's concrete arguments
+                // substituted in. Without this, the method result stays a
+                // `TypeParam` and erases to `SmeltUnknown` at use sites even
+                // though the emitted `impl<T> Box<T>` method already returns `T`.
+                let return_ty = function.return_ty;
+                let item_id = *item;
+                let substitutions = self.type_argument_substitution(
+                    &class.type_params,
+                    &args,
+                    self.span(span.start, span.end),
+                )?;
+                let substituted_return = self.substitute_type_params(return_ty, &substitutions);
+                return Ok((substituted_return, item_id));
             }
         }
         for abstract_method in &class.abstract_methods {
             if abstract_method.name == method {
-                return Ok((abstract_method.return_ty, smelt_hir::ItemId(u32::MAX)));
+                let return_ty = abstract_method.return_ty;
+                let substitutions = self.type_argument_substitution(
+                    &class.type_params,
+                    &args,
+                    self.span(span.start, span.end),
+                )?;
+                let substituted_return = self.substitute_type_params(return_ty, &substitutions);
+                return Ok((substituted_return, smelt_hir::ItemId(u32::MAX)));
             }
         }
         if let Some(base) = class.base {

--- a/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
@@ -82,6 +82,52 @@ export interface RecursiveArray<T> extends Array<T | RecursiveArray<T>> {}
 }
 
 #[test]
+fn lowers_generic_class_with_type_param_methods() -> Result<(), String> {
+    // Issue #99: a generic class carries its declared type parameters into HIR,
+    // and a call to a method whose declared return type is the class parameter
+    // resolves to the receiver's concrete argument (`Container<number>::get()`
+    // is `number`), so the whole program lowers and validates.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r"
+class Container<T> {
+  value: T;
+  constructor(value: T) { this.value = value; }
+  get(): T { return this.value; }
+  set(value: T): void { this.value = value; }
+}
+
+export function useContainer(): number {
+  const b = new Container<number>(3);
+  b.set(5);
+  return b.get();
+}
+"),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+
+    // The lowered class retains exactly one declared type parameter.
+    let container = ctx.krate.items.iter().find_map(|item| match item {
+        Item::Class(class)
+            if ctx.krate.symbols.get(class.name) == Some("Container") =>
+        {
+            Some(class)
+        }
+        _ => None,
+    });
+    let container = container.ok_or_else(|| "Container class not lowered".to_owned())?;
+    let type_param = container
+        .type_params
+        .first()
+        .ok_or_else(|| "Container has no type parameter".to_owned())?;
+    ensure_eq!(container.type_params.len(), 1);
+    ensure_eq!(ctx.krate.symbols.get(type_param.name), Some("T"));
+    Ok(())
+}
+
+#[test]
 fn lowers_numeric_property_keys() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-mir/src/lib.rs
+++ b/crates/smelt-mir/src/lib.rs
@@ -358,4 +358,37 @@ async function run(): Promise<number> {
             "a returned parameter must remain a copy:\n{output}"
         );
     }
+
+    #[test]
+    fn propagates_generic_class_type_params_into_mir() {
+        // Issue #99: HIR generic class type parameters survive into `MirClass`
+        // so codegen can emit `struct Container<T>` and `impl<T> Container<T>`.
+        let mut ctx = HirCtx::new();
+        ok_or_panic(
+            to_hir(
+                "class Container<T> {\n  value: T;\n  constructor(value: T) { this.value = value; }\n  get(): T { return this.value; }\n}\n",
+                FileId(0),
+                &mut ctx,
+            ),
+            "HIR",
+        );
+
+        let mir = ok_or_panic(lower_hir(&ctx.krate), "MIR");
+        let container = mir
+            .classes
+            .iter()
+            .find(|class| mir.symbols.get(class.name) == Some("Container"))
+            .unwrap_or_else(|| {
+                std::panic::resume_unwind(Box::new("Container class lowered to MIR".to_owned()))
+            });
+        assert_eq!(container.type_params.len(), 1);
+        let type_param = container.type_params.first().unwrap_or_else(|| {
+            std::panic::resume_unwind(Box::new("Container has a type parameter".to_owned()))
+        });
+        assert_eq!(
+            mir.symbols.get(type_param.name),
+            Some("T"),
+            "the class type parameter name is preserved in MIR"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Makes **generic classes and generic interfaces** usable end to end, lowering both definitions and use sites to real, monomorphizable Rust generics — **no erasure of the generic instantiations to `SmeltUnknown`**.

Generic class/interface *definitions* already emitted real generics on `main` (`struct Container<T>`, `impl<T: bounds> Container<T>`, generic fields/methods/constructor, `PhantomData`). But their *use sites* erased the instantiation, so the emitted crate did not compile:
- constructor/method arguments were wrapped as `SmeltUnknown::Number(..)` against a generic `T` parameter (type mismatch);
- a method returning a class type parameter (`get(): T`) was typed and extracted as `SmeltUnknown` even though the emitted method returns `T`.

## What changed

- **Frontend** (`resolve_method`, `ty/annotations.rs`): substitute a concrete-class method's declared return type with the receiver's class type arguments, so `Container<number>::get()` is typed `number` instead of bare `T`. The interface and base-class method paths already substituted; the direct concrete-class path did not.
- **Codegen** (`emitter/call.rs`):
  - constructor/method arguments whose target is one of the callee class's own type parameters are passed through concretely (`Container::new(3.0)`), so Rust infers/monomorphizes the class argument, instead of erasing to `SmeltUnknown`;
  - a method whose return type is a class type parameter uses the dest's substituted concrete type as the source type, so no `SmeltUnknown` extraction match is emitted around an already-concrete value.
- **Codegen** (`stdlib.rs`): a generic class/interface always emits impl bounds referencing `IntoSmeltUnknown`/`SmeltFromUnknown`, so `needs_unknown_type` now returns true whenever any class/interface declares type parameters, ensuring those traits are in scope.

Emitted Rust for `Container<T>`, `Pair<A, B>`, and generic interface `Outcome<T, E>` now `cargo check`s clean:

```rust
fn use_box() -> f64 {
    let mut b: Container<f64>;
    let mut _t: Container<f64> = Container::new(3.0);
    b = _t;
    let _ = b.set(5.0);
    let _r: f64 = b.get();
    return _r;
}
impl<T: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'static> Container<T> {
    fn new(value: T) -> Self { /* ... */ }
    fn get(&self) -> T { self.value.clone() }
    fn set(&mut self, value: T) -> () { self.value = value.clone(); }
}
```

## Tests

- Frontend: HIR type-param retention on a generic class + method call (`class_module_tests.rs`).
- MIR: type-param propagation into `MirClass` (`smelt-mir` lib tests).
- Codegen: struct/impl/instantiation + two-parameter class + generic interface regression tests (`tests/generics_tests.rs`).
- Compile-corpus: new `generic_classes_and_interfaces` case that `cargo check`s the emitted crate (verified green via `SMELT_CORPUS_ONLY`).

`cargo check` + `cargo clippy` clean on the touched lib targets; full `smelt-frontend-ts` (753), `smelt-mir` (11), and `smelt-codegen-rust` (478) lib suites pass.

## Scope covered vs deferred

**Covered:** generic classes (single- and multi-parameter) with generic fields, methods, and constructors; generic interfaces; concrete instantiation and method dispatch at use sites — all as typed Rust, no `SmeltUnknown` shortcut.

**Deferred (out of this increment):** generic **free functions** (`function identity<T>(x: T): T`). HIR/MIR `Function` do not yet carry a `type_params` field (the TS frontend currently drops them at `function_declaration_named`), so a generic free function's signature still lowers to `SmeltUnknown`. That is an orthogonal piece of the same roadmap — it needs `type_params` threaded through `Function`/`MirFunction` and the free-function call sites — and is intentionally left for a follow-up so this change stays a correct, green increment.

Part of #99 (object model / #18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)