### PR TITLE
object model (#98): static methods and static class constants/vars

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/call.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call.rs
@@ -513,6 +513,34 @@ impl FunctionEmitter<'_> {
                         ))
                     };
                 }
+                if let HirOrigin::ClassStaticMethod { class, method, .. } = function.origin {
+                    // `Class.staticMethod(args)` lowers to the receiver-free
+                    // associated function `Class::staticMethod(args)`. Arguments
+                    // are coerced to the emitted parameter types like any other
+                    // static call, and missing trailing parameters default.
+                    let class_name = sanitize_ident(self.symbol_name(class)?);
+                    let method_name = sanitize_ident(self.symbol_name(method)?);
+                    let mut rendered_args = args
+                        .iter()
+                        .enumerate()
+                        .map(|(index, arg)| {
+                            let Some(param) = function.params.get(index).copied() else {
+                                return self.operand_text(arg);
+                            };
+                            let target_ty = self.function_local_decl(function, param)?.ty;
+                            self.value_at_type(arg, target_ty)
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    for param in function.params.iter().skip(args.len()) {
+                        let target_ty = self.function_local_decl(function, *param)?.ty;
+                        rendered_args.push(self.default_value(target_ty)?);
+                    }
+                    let arg_values = rendered_args.join(", ");
+                    return Ok(format!(
+                        "{class_name}::{method_name}({arg_values}){}",
+                        self.throwing_call_suffix(function)
+                    ));
+                }
                 let rust_function_name = self.function_rust_name(function)?;
                 let emitted_params = self.emitted_function_param_types(&rust_function_name)?;
                 if function.params.len() == 1 {

--- a/crates/smelt-codegen-rust/src/emitter/core.rs
+++ b/crates/smelt-codegen-rust/src/emitter/core.rs
@@ -2436,6 +2436,34 @@ impl<'mir> FunctionEmitter<'mir> {
                     self.return_type_text(self.function.return_ty)?
                 ));
             }
+            HirOrigin::ClassStaticMethod { method, .. } => {
+                // A static method takes no receiver: emit every parameter and no
+                // `self`, producing an associated function `Class::name(..)`.
+                let name = sanitize_ident(self.symbol_name(method)?);
+                let method_params = self
+                    .function
+                    .params
+                    .iter()
+                    .map(|param| {
+                        let mutability = if self.local_binding_needs_mut(*param) {
+                            "mut "
+                        } else {
+                            ""
+                        };
+                        Ok(format!(
+                            "{mutability}{}: {}",
+                            self.local_name(*param)?,
+                            self.parameter_decl_type_text(*param)?
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, EmitError>>()?
+                    .join(", ");
+                out.push_str(&format!(
+                    "    {}fn {name}({method_params}) -> {} {{\n",
+                    if self.function.is_async { "async " } else { "" },
+                    self.return_type_text(self.function.return_ty)?
+                ));
+            }
             HirOrigin::Body(_) => return self.emit(out),
         }
         self.emit_block(self.entry_block()?, out)?;

--- a/crates/smelt-codegen-rust/src/emitter/types.rs
+++ b/crates/smelt-codegen-rust/src/emitter/types.rs
@@ -589,9 +589,9 @@ impl FunctionEmitter<'_> {
     /// Return type parameters declared by the current class function scope.
     fn current_function_type_params(&self) -> HashSet<Symbol> {
         let class_name = match self.function.origin {
-            HirOrigin::ClassConstructor { class, .. } | HirOrigin::ClassMethod { class, .. } => {
-                class
-            }
+            HirOrigin::ClassConstructor { class, .. }
+            | HirOrigin::ClassMethod { class, .. }
+            | HirOrigin::ClassStaticMethod { class, .. } => class,
             HirOrigin::Body(_) => return HashSet::new(),
         };
         self.mir

--- a/crates/smelt-codegen-rust/src/lib.rs
+++ b/crates/smelt-codegen-rust/src/lib.rs
@@ -2096,7 +2096,9 @@ fn emit_source_with_free_function_router(
     for function in &mir.functions {
         if matches!(
             function.origin,
-            HirOrigin::ClassConstructor { .. } | HirOrigin::ClassMethod { .. }
+            HirOrigin::ClassConstructor { .. }
+                | HirOrigin::ClassMethod { .. }
+                | HirOrigin::ClassStaticMethod { .. }
         ) {
             continue;
         }
@@ -2163,6 +2165,15 @@ fn emit_source_with_free_function_router(
                 .functions
                 .get(id_index(method.0, "method index does not fit usize")?)
             {
+                let mut emitter = FunctionEmitter::new(mir, &context, function)?;
+                emitter.emit_method(&mut out)?;
+            }
+        }
+        for static_method in &class.static_methods {
+            if let Some(function) = mir.functions.get(id_index(
+                static_method.0,
+                "static method index does not fit usize",
+            )?) {
                 let mut emitter = FunctionEmitter::new(mir, &context, function)?;
                 emitter.emit_method(&mut out)?;
             }

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -6046,3 +6046,92 @@ function squares(values: number[]): number[] {
     assert!(source.contains(".map("), "{source}");
     assert!(source.contains("square"), "{source}");
 }
+
+/// Issue #98: a TypeScript `static` method lowers to a receiver-free associated
+/// function and a qualified static call resolves to `Class::method(..)`.
+#[test]
+fn emits_typescript_static_method_as_associated_function() {
+    let source = source_for(
+        r#"
+class MathUtils {
+  static square(value: number): number {
+    return value * value;
+  }
+}
+export function area(radius: number): number {
+  return MathUtils.square(radius);
+}
+"#,
+    );
+
+    // The static method is emitted inside the class impl with no `self`.
+    assert!(source.contains("fn square(value: f64) -> f64"), "{source}");
+    assert!(
+        !source.contains("fn square(&self") && !source.contains("fn square(&mut self"),
+        "static method must not take a receiver: {source}"
+    );
+    // The qualified call resolves to the associated function.
+    assert!(source.contains("MathUtils::square("), "{source}");
+}
+
+/// Issue #98: a TypeScript `static` class constant lowers to a materialized
+/// static field and a qualified read resolves to its concrete literal value.
+#[test]
+fn emits_typescript_static_const_read() {
+    let source = source_for(
+        r#"
+class Config {
+  static readonly LIMIT: number = 42;
+  static readonly NAME: string = "smelt";
+}
+export function limit(): number {
+  return Config.LIMIT;
+}
+export function label(): string {
+  return Config.NAME;
+}
+"#,
+    );
+
+    // Static constants become receiver-free associated accessors.
+    assert!(
+        source.contains("fn __smelt_static_limit() -> f64"),
+        "{source}"
+    );
+    assert!(
+        source.contains("fn __smelt_static_name() -> String"),
+        "{source}"
+    );
+    // Qualified reads resolve to the concrete literal values.
+    assert!(source.contains("return 42"), "{source}");
+    assert!(source.contains(r#""smelt".to_owned()"#), "{source}");
+}
+
+/// Issue #98: a Python `@staticmethod` lowers to a receiver-free associated
+/// function and a class-level variable lowers to a static field read.
+#[test]
+fn emits_python_static_method_and_class_var() {
+    let source = source_for_py(
+        r#"
+class MathUtils:
+    PI = 3
+
+    @staticmethod
+    def square(value: float) -> float:
+        return value * value
+
+def area(radius: float) -> float:
+    return MathUtils.square(radius) * MathUtils.PI
+"#,
+    );
+
+    assert!(source.contains("fn square(value: f64) -> f64"), "{source}");
+    assert!(
+        !source.contains("fn square(&self") && !source.contains("fn square(&mut self"),
+        "static method must not take a receiver: {source}"
+    );
+    assert!(source.contains("MathUtils::square("), "{source}");
+    // The class variable `PI = 3` reads back as its concrete integer literal.
+    assert!(source.contains("fn __smelt_static_PI"), "{source}");
+    assert!(source.contains(" 3"), "{source}");
+}

--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -522,6 +522,45 @@ export function readMixed(bag: MixedBag, key: string): number | undefined {
 "#,
         },
         Case {
+            // Issue #98: static methods lower to receiver-free associated
+            // functions (`Class::method(..)`) and static class constants lower
+            // to materialized static fields resolvable via `Class.CONST`. Both
+            // must round-trip through the pipeline and compile as Rust. The
+            // static method is called qualified, and the static constants are
+            // read qualified in a free function, exercising both the emitted
+            // associated function and the concrete literal read paths.
+            name: "class_static_members",
+            area: "classes",
+            source: r#"
+class MathUtils {
+  static readonly PI: number = 3.14;
+  static readonly NAME: string = "math";
+
+  static square(value: number): number {
+    return value * value;
+  }
+
+  static clamp(value: number, low: number, high: number): number {
+    if (value < low) return low;
+    if (value > high) return high;
+    return value;
+  }
+}
+
+export function circleArea(radius: number): number {
+  return MathUtils.square(radius) * MathUtils.PI;
+}
+
+export function boundedSquare(value: number): number {
+  return MathUtils.clamp(MathUtils.square(value), 0, 100);
+}
+
+export function utilName(): string {
+  return MathUtils.NAME;
+}
+"#,
+        },
+        Case {
             name: "interface_method_call",
             area: "interfaces",
             source: r"

--- a/crates/smelt-frontend-py/src/lowering.rs
+++ b/crates/smelt-frontend-py/src/lowering.rs
@@ -13,8 +13,8 @@ use std::path::Path;
 
 use ruff_python_ast::{
     BoolOp, CmpOp, ElifElseClause, Expr, ModModule, Number, Operator, Pattern as RuffPattern,
-    PatternMatchAs, Singleton, Stmt, StmtAnnAssign, StmtAssert, StmtAugAssign, StmtClassDef,
-    StmtFor, StmtFunctionDef, StmtIf, StmtImport, StmtImportFrom, StmtMatch, StmtWith,
+    PatternMatchAs, Singleton, Stmt, StmtAnnAssign, StmtAssert, StmtAssign, StmtAugAssign,
+    StmtClassDef, StmtFor, StmtFunctionDef, StmtIf, StmtImport, StmtImportFrom, StmtMatch, StmtWith,
     UnaryOp as RuffUnaryOp,
 };
 use ruff_text_size::{Ranged, TextRange};

--- a/crates/smelt-frontend-py/src/lowering/call.rs
+++ b/crates/smelt-frontend-py/src/lowering/call.rs
@@ -61,6 +61,9 @@ impl ModuleBuilder<'_> {
         if let Some(expr) = self.int_new_call_expression(call, body)? {
             return Ok(Some(expr));
         }
+        if let Some(expr) = self.class_static_method_call_expression(call, body)? {
+            return Ok(Some(expr));
+        }
         if let Some(expr) = self.class_method_call_expression(call, body)? {
             return Ok(Some(expr));
         }

--- a/crates/smelt-frontend-py/src/lowering/class.rs
+++ b/crates/smelt-frontend-py/src/lowering/class.rs
@@ -7,6 +7,11 @@ struct ClassBodyLowering {
     constructor_id: Option<ItemId>,
     /// Item ids of non-constructor methods in declaration order.
     method_ids: Vec<ItemId>,
+    /// Item ids of `@staticmethod` methods in declaration order.
+    static_methods: Vec<ItemId>,
+    /// Static (class-level) fields declared by bare/annotated class-body
+    /// assignments with a concrete literal initializer.
+    static_fields_out: Vec<smelt_hir::StaticField>,
     /// Whether the class derives from `IntEnum`.
     is_int_enum: bool,
     /// Collected `IntEnum` member name → integer value pairs.
@@ -237,6 +242,8 @@ impl ModuleBuilder<'_> {
         let mut fields: Vec<Field> = Vec::new();
         let mut constructor_id: Option<ItemId> = None;
         let mut method_ids: Vec<ItemId> = Vec::new();
+        let mut static_methods: Vec<ItemId> = Vec::new();
+        let mut static_fields_out: Vec<smelt_hir::StaticField> = Vec::new();
         let is_int_enum = base
             .and_then(|base_sym| self.ctx.krate.symbols.get(base_sym))
             .is_some_and(|base_name| base_name == "IntEnum");
@@ -252,6 +259,7 @@ impl ModuleBuilder<'_> {
             descriptors: Vec::new(),
             constructor: None,
             methods: Vec::new(),
+            static_methods: Vec::new(),
             abstract_methods: Vec::new(),
             implements: vec![],
         }));
@@ -287,6 +295,21 @@ impl ModuleBuilder<'_> {
                 Stmt::Assign(assign) if is_int_enum => {
                     self.int_enum_member_assign(class_name_str, assign, &mut enum_members)?;
                 }
+                // A bare `NAME = <literal>` in a non-enum class body declares a
+                // class variable (a static member shared by the class). Lower it
+                // to a materialized static field resolvable via `Class.NAME`.
+                Stmt::Assign(assign) if !is_int_enum => {
+                    if let Some(static_field) = self.class_var_static_field(assign)? {
+                        static_fields_out.push(static_field);
+                    } else {
+                        return Err(SmeltError::unsupported(
+                            self.span(assign.range),
+                            format!(
+                                "class '{class_name_str}': class-level assignment must be a single name bound to a literal"
+                            ),
+                        ));
+                    }
+                }
                 Stmt::FunctionDef(func) => {
                     let method_name = func.name.as_str();
                     if materialized.is_some()
@@ -297,6 +320,18 @@ impl ModuleBuilder<'_> {
                     if Self::is_abstractmethod(func) {
                         *kind = ClassKind::Abstract;
                         abstract_methods.push(self.abstract_method_sig(func)?);
+                        continue;
+                    }
+                    if Self::is_staticmethod(func) {
+                        let mid = self.class_method_with_receiver(
+                            class_name_str,
+                            class_sym,
+                            class_ty,
+                            func,
+                            true,
+                        )?;
+                        static_methods.push(mid);
+                        hir_module.items.push(mid);
                         continue;
                     }
                     if method_name == "__init__" {
@@ -369,6 +404,8 @@ impl ModuleBuilder<'_> {
                 fields,
                 constructor_id,
                 method_ids,
+                static_methods,
+                static_fields_out,
                 is_int_enum,
                 enum_members,
                 abstract_methods,
@@ -475,10 +512,11 @@ impl ModuleBuilder<'_> {
             base,
             base_args: Vec::new(),
             fields: std::mem::take(fields),
-            static_fields: Vec::new(),
+            static_fields: std::mem::take(&mut lowered.static_fields_out),
             descriptors,
             constructor: constructor_id,
             methods: std::mem::take(method_ids),
+            static_methods: std::mem::take(&mut lowered.static_methods),
             abstract_methods: std::mem::take(&mut lowered.abstract_methods),
             implements: vec![],
         });
@@ -547,7 +585,7 @@ impl ModuleBuilder<'_> {
     fn int_enum_member_assign(
         &mut self,
         class_name: &str,
-        assign: &ruff_python_ast::StmtAssign,
+        assign: &StmtAssign,
         enum_members: &mut HashMap<String, i64>,
     ) -> Result<(), SmeltError> {
         if assign.targets.len() != 1 {
@@ -676,6 +714,76 @@ impl ModuleBuilder<'_> {
         })
     }
 
+    /// Return whether a method is decorated with `@staticmethod`.
+    fn is_staticmethod(func: &StmtFunctionDef) -> bool {
+        func.decorator_list
+            .iter()
+            .any(|decorator| decorator_simple_name(decorator) == Some("staticmethod"))
+    }
+
+    /// Lower a class-level `NAME = <literal>` assignment to a static field.
+    ///
+    /// Returns `None` when the assignment is not a single `Name` target bound to
+    /// a concrete literal, so the caller can reject unsupported class-variable
+    /// forms. The static field is resolvable as `Class.NAME` and lowers to a
+    /// receiver-free associated accessor in Rust codegen.
+    fn class_var_static_field(
+        &mut self,
+        assign: &StmtAssign,
+    ) -> Result<Option<smelt_hir::StaticField>, SmeltError> {
+        let [target] = assign.targets.as_slice() else {
+            return Ok(None);
+        };
+        let Expr::Name(target_name) = target else {
+            return Ok(None);
+        };
+        let Some((value, ty)) = self.class_var_literal(assign.value.as_ref())? else {
+            return Ok(None);
+        };
+        let name = self.intern_name(target_name.id.as_str());
+        Ok(Some(smelt_hir::StaticField {
+            name,
+            ty,
+            visibility: Visibility::Public,
+            value: Some(value),
+            span: self.span(assign.range),
+        }))
+    }
+
+    /// Convert a class-variable initializer expression to a concrete literal and
+    /// its Smelt type, or `None` when it is not a supported literal form.
+    fn class_var_literal(
+        &mut self,
+        expr: &Expr,
+    ) -> Result<Option<(Literal, TypeId)>, SmeltError> {
+        let pair = match expr {
+            Expr::NumberLiteral(number) => match &number.value {
+                Number::Int(int_value) => {
+                    let value = int_value.as_i64().ok_or_else(|| {
+                        SmeltError::unsupported(
+                            self.span(number.range),
+                            "class-variable integer literal is out of i64 range",
+                        )
+                    })?;
+                    (Literal::Int(value), self.intern_type(Type::Int))
+                }
+                Number::Float(value) => {
+                    (Literal::Float(*value), self.intern_type(Type::Float))
+                }
+                Number::Complex { .. } => return Ok(None),
+            },
+            Expr::StringLiteral(value) => (
+                Literal::String(value.value.to_str().to_owned()),
+                self.intern_type(Type::String),
+            ),
+            Expr::BooleanLiteral(value) => {
+                (Literal::Bool(value.value), self.intern_type(Type::Bool))
+            }
+            _ => return Ok(None),
+        };
+        Ok(Some(pair))
+    }
+
     /// Lower an abstract Python method declaration to a HIR method signature.
     fn abstract_method_sig(&mut self, func: &StmtFunctionDef) -> Result<MethodSig, SmeltError> {
         let span = self.span(func.range);
@@ -757,12 +865,33 @@ impl ModuleBuilder<'_> {
         class_ty: TypeId,
         func: &StmtFunctionDef,
     ) -> Result<ItemId, SmeltError> {
+        self.class_method_with_receiver(class_name_str, class_sym, class_ty, func, false)
+    }
+
+    /// Lower a Python class method to a HIR function item.
+    ///
+    /// When `is_static` is set the method is a `@staticmethod`: it takes no
+    /// implicit `self`/`cls` receiver and is owned by
+    /// [`FunctionOwner::ClassStaticMethod`] so codegen emits a receiver-free
+    /// associated function resolvable via `Class.method(..)`.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "class method lowering threads class identity and the static-receiver flag through one shared body"
+    )]
+    fn class_method_with_receiver(
+        &mut self,
+        class_name_str: &str,
+        class_sym: Symbol,
+        class_ty: TypeId,
+        func: &StmtFunctionDef,
+        is_static: bool,
+    ) -> Result<ItemId, SmeltError> {
         let span = self.span(func.range);
         let method_name_str = func.name.as_str();
         let method_sym = self.intern_name(method_name_str);
-        let is_init = method_name_str == "__init__";
-        let is_new = method_name_str == "__new__";
-        let is_classmethod = self.is_classmethod(func)?;
+        let is_init = !is_static && method_name_str == "__init__";
+        let is_new = !is_static && method_name_str == "__new__";
+        let is_classmethod = !is_static && self.is_classmethod(func)?;
 
         let return_ty = if is_init {
             self.intern_type(Type::None)
@@ -787,36 +916,42 @@ impl ModuleBuilder<'_> {
         let mut params: Vec<Param> = Vec::new();
 
         // Add the implicit receiver local for use inside the method body.
+        // A `@staticmethod` has no implicit receiver, so this is skipped and all
+        // declared parameters are lowered as ordinary function parameters.
         let implicit_receiver_name = if is_classmethod || is_new {
             "cls"
         } else {
             "self"
         };
-        let self_sym = self.intern_name(implicit_receiver_name);
-        let self_local = fn_body.push_local(LocalDecl {
-            name: Some(self_sym),
-            ty: class_ty,
-            mutable: false,
-            span,
-        });
-        self.locals
-            .insert(implicit_receiver_name.to_owned(), self_local);
-        if !is_init && !is_classmethod && !is_new {
-            fn_body.params.push(self_local);
-            params.push(Param {
-                name: self_sym,
-                local: self_local,
+        if !is_static {
+            let self_sym = self.intern_name(implicit_receiver_name);
+            let self_local = fn_body.push_local(LocalDecl {
+                name: Some(self_sym),
                 ty: class_ty,
+                mutable: false,
                 span,
             });
+            self.locals
+                .insert(implicit_receiver_name.to_owned(), self_local);
+            if !is_init && !is_classmethod && !is_new {
+                fn_body.params.push(self_local);
+                params.push(Param {
+                    name: self_sym,
+                    local: self_local,
+                    ty: class_ty,
+                    span,
+                });
+            }
         }
 
         let mut first = true;
         for param_with_default in func.parameters.iter_non_variadic_params() {
             let p = &param_with_default.parameter;
             let param_name_str = p.name.as_str();
-            // Skip the implicit receiver; it was added above.
-            if first
+            // Skip the implicit receiver; it was added above. Static methods
+            // have no implicit receiver, so every parameter is a real argument.
+            if !is_static
+                && first
                 && (param_name_str == implicit_receiver_name
                     || ((is_classmethod || is_new) && param_name_str == "self"))
             {
@@ -868,6 +1003,11 @@ impl ModuleBuilder<'_> {
 
         let owner = if is_init {
             FunctionOwner::Constructor { class: class_sym }
+        } else if is_static {
+            FunctionOwner::ClassStaticMethod {
+                class: class_sym,
+                method: method_sym,
+            }
         } else {
             FunctionOwner::ClassMethod {
                 class: class_sym,

--- a/crates/smelt-frontend-py/src/lowering/literals.rs
+++ b/crates/smelt-frontend-py/src/lowering/literals.rs
@@ -128,6 +128,9 @@ impl ModuleBuilder<'_> {
                 if let Some(member_expr) = self.enum_member_expression(attr, body)? {
                     return Ok(member_expr);
                 }
+                if let Some(member_expr) = self.class_static_member_expression(attr, body)? {
+                    return Ok(member_expr);
+                }
                 if let Some(member_expr) = self.module_member_expression(attr, body)? {
                     return Ok(member_expr);
                 }

--- a/crates/smelt-frontend-py/src/lowering/member.rs
+++ b/crates/smelt-frontend-py/src/lowering/member.rs
@@ -1,4 +1,104 @@
 impl ModuleBuilder<'_> {
+    /// Lower a qualified static method call `Class.staticMethod(args)`.
+    ///
+    /// Resolves the class name to its declared `@staticmethod` items and, when a
+    /// match is found, lowers the call as a direct call to the receiver-free
+    /// associated function so codegen emits `Class::staticMethod(args)`. Returns
+    /// `None` when the callee is not a static-method call.
+    fn class_static_method_call_expression(
+        &mut self,
+        call: &ruff_python_ast::ExprCall,
+        body: &mut Body,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        let Expr::Attribute(attr) = call.func.as_ref() else {
+            return Ok(None);
+        };
+        let Some((class_name, method_name)) = self.class_member_path(attr) else {
+            return Ok(None);
+        };
+        let Some(item_id) = self.class_static_method_item(class_name, method_name) else {
+            return Ok(None);
+        };
+        let span = self.span(call.range);
+        let return_ty = match self.item_ref(item_id) {
+            Item::Function(function) => function.return_ty,
+            Item::Class(_) | Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) => {
+                return Ok(None);
+            }
+        };
+        let callee = body.push_expr(HirExpr {
+            kind: ExprKind::Item(item_id),
+            ty: self.item_expr_type(item_id),
+            span: self.span(attr.range),
+        });
+        let args = call
+            .arguments
+            .args
+            .iter()
+            .map(|arg| self.expression(arg, body))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Some(body.push_expr(HirExpr {
+            kind: ExprKind::Call { callee, args },
+            ty: return_ty,
+            span,
+        })))
+    }
+
+    /// Lower a qualified static-field read `Class.NAME` to its literal value.
+    ///
+    /// Returns `None` when the attribute does not name a class-level static
+    /// field, so the caller can fall through to the ordinary attribute path.
+    fn class_static_member_expression(
+        &self,
+        attr: &ruff_python_ast::ExprAttribute,
+        body: &mut Body,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        let Some((class_name, member)) = self.class_member_path(attr) else {
+            return Ok(None);
+        };
+        let Some(class_item) = self.items.get(class_name).copied() else {
+            return Ok(None);
+        };
+        let Item::Class(class) = self.item_ref(class_item) else {
+            return Ok(None);
+        };
+        let Some(field) = class
+            .static_fields
+            .iter()
+            .find(|field| self.ctx.krate.symbols.get(field.name) == Some(member))
+        else {
+            return Ok(None);
+        };
+        let Some(value) = field.value.clone() else {
+            return Ok(None);
+        };
+        let ty = field.ty;
+        Ok(Some(body.push_expr(HirExpr {
+            kind: ExprKind::Literal(value),
+            ty,
+            span: self.span(attr.range),
+        })))
+    }
+
+    /// Resolve a class's `@staticmethod` item by name from its class item.
+    fn class_static_method_item(
+        &self,
+        class_name: &str,
+        method_name: &str,
+    ) -> Option<ItemId> {
+        let class_item = self.items.get(class_name).copied()?;
+        let Item::Class(class) = self.item_ref(class_item) else {
+            return None;
+        };
+        class.static_methods.iter().copied().find(|item| {
+            matches!(
+                self.item_ref(*item),
+                Item::Function(function)
+                    if self.ctx.krate.symbols.get(function.name) == Some(method_name)
+            )
+        })
+    }
+
     /// Lower supported class method calls into their HIR runtime operations.
     fn class_method_call_expression(
         &mut self,

--- a/crates/smelt-frontend-py/src/lowering/module_imports.rs
+++ b/crates/smelt-frontend-py/src/lowering/module_imports.rs
@@ -140,7 +140,7 @@ impl ModuleBuilder<'_> {
     /// initialization order.
     fn constructed_constant_assign(
         &mut self,
-        assign: &ruff_python_ast::StmtAssign,
+        assign: &StmtAssign,
         hir_module: &mut Module,
     ) -> Result<(), SmeltError> {
         let Some((name, call)) = Self::constructed_constant_shape(assign) else {
@@ -205,7 +205,7 @@ impl ModuleBuilder<'_> {
 
     /// Extract the direct `NAME = ClassName(...)` constructed-constant shape.
     fn constructed_constant_shape(
-        assign: &ruff_python_ast::StmtAssign,
+        assign: &StmtAssign,
     ) -> Option<(&str, &ruff_python_ast::ExprCall)> {
         let [target] = assign.targets.as_slice() else {
             return None;

--- a/crates/smelt-frontend-py/src/lowering/specialization.rs
+++ b/crates/smelt-frontend-py/src/lowering/specialization.rs
@@ -389,7 +389,10 @@ impl ModuleBuilder<'_> {
                 };
                 let name = self.ctx.krate.symbols.get(function.name)?;
                 let owner_name = match function.owner {
-                    FunctionOwner::ClassMethod { method, .. } => self.ctx.krate.symbols.get(method),
+                    FunctionOwner::ClassMethod { method, .. }
+                    | FunctionOwner::ClassStaticMethod { method, .. } => {
+                        self.ctx.krate.symbols.get(method)
+                    }
                     FunctionOwner::Module | FunctionOwner::Constructor { .. } => None,
                 };
                 (descriptor_callable_name_matches(name, expected_name)
@@ -1124,7 +1127,8 @@ impl ModuleBuilder<'_> {
                     FunctionOwner::Module => {
                         self.ctx.krate.symbols.get(function.name) == Some(source_name)
                     }
-                    FunctionOwner::ClassMethod { class, method } => {
+                    FunctionOwner::ClassMethod { class, method }
+                    | FunctionOwner::ClassStaticMethod { class, method } => {
                         self.ctx.krate.symbols.get(method) == Some(source_name)
                             && owner_name.is_some_and(|owner| {
                                 self.ctx.krate.symbols.get(class) == Some(owner)

--- a/crates/smelt-frontend-py/src/tests/class_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/class_tests.rs
@@ -541,3 +541,70 @@ class codes(IntEnum):
     lower_module(source, &mut ctx)?;
     Ok(())
 }
+
+/// Issue #98: a `@staticmethod` lowers to a `ClassStaticMethod`-owned function
+/// with no `self` binding, and a class-level variable lowers to a static field.
+#[test]
+fn staticmethod_and_class_var_lower_to_static_members() -> TestResult {
+    let source = py!(r#"
+class MathUtils:
+    LIMIT = 7
+
+    @staticmethod
+    def square(value: float) -> float:
+        return value * value
+
+def area(radius: float) -> float:
+    return MathUtils.square(radius) * MathUtils.LIMIT
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let class = module
+        .items
+        .iter()
+        .find_map(|item_id| match item(&ctx, *item_id).ok()? {
+            Item::Class(class) if symbol(&ctx, class.name).ok()? == "MathUtils" => Some(class),
+            _ => None,
+        })
+        .ok_or("expected MathUtils class")?;
+
+    // The static method is kept in `static_methods` and owns no `self` binding.
+    ensure_eq(&class.static_methods.len(), &1, "static method count")?;
+    let static_item = class
+        .static_methods
+        .first()
+        .copied()
+        .ok_or("missing static method item")?;
+    let static_method = item(&ctx, static_item)?;
+    let Item::Function(function) = static_method else {
+        return Err("static method item is not a function".to_owned());
+    };
+    ensure(
+        matches!(
+            function.owner,
+            smelt_hir::FunctionOwner::ClassStaticMethod { .. }
+        ),
+        "expected ClassStaticMethod owner",
+    )?;
+    let method_body = body(&ctx, function.body.ok_or("expected static method body")?)?;
+    ensure(
+        !method_body
+            .locals
+            .iter()
+            .any(|local| local.name.and_then(|name| symbol(&ctx, name).ok()) == Some("self")),
+        "static method must not bind self",
+    )?;
+
+    // The class variable becomes a materialized static field.
+    ensure_eq(&class.static_fields.len(), &1, "static field count")?;
+    let static_field = class
+        .static_fields
+        .first()
+        .ok_or("missing static field")?;
+    ensure(
+        matches!(static_field.value, Some(Literal::Int(7))),
+        "expected concrete static field value",
+    )?;
+    Ok(())
+}

--- a/crates/smelt-frontend-ts/src/lowering/decls/constructor.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/constructor.rs
@@ -508,6 +508,7 @@ impl ModuleBuilder<'_> {
             fields,
             constructor: Some(constructor),
             methods,
+            static_methods: Vec::new(),
             abstract_methods: Vec::new(),
             implements: Vec::new(),
             static_fields: Vec::new(),

--- a/crates/smelt-frontend-ts/src/lowering/decls/functions.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/functions.rs
@@ -19,7 +19,7 @@ use oxc::ast::ast::{
 use oxc::span::GetSpan;
 use smelt_hir::{
     Body, CLASS_INDEX_STORE_FIELD, Class, Expr, ExprKind,
-    Field, Function, FunctionOwner, FunctionType, Item, LocalDecl, MethodSig, Param,
+    Field, Function, FunctionOwner, FunctionType, Item, Literal, LocalDecl, MethodSig, Param,
     ParamSig, Pattern, Span, Stmt, Type, Visibility,
 };
 
@@ -853,6 +853,10 @@ impl ModuleBuilder<'_> {
         let mut field_initializers = Vec::new();
         let mut constructor = None;
         let mut methods = Vec::new();
+        let mut static_methods = Vec::new();
+        // Static class constants declared directly in source (`static NAME =
+        // <literal>`), as opposed to `static_fields` merged from specialization.
+        let mut source_static_fields: Vec<smelt_hir::StaticField> = Vec::new();
         let mut abstract_methods = Vec::new();
         let mut descriptor_accessors = Vec::new();
         // Value type declared by a class string/number index signature, if any.
@@ -879,9 +883,17 @@ impl ModuleBuilder<'_> {
                         if materialized.is_some() {
                             continue;
                         }
+                        // A `static NAME: T = <literal>` declares a class-level
+                        // constant resolvable via `Class.NAME`. Lower it to a
+                        // materialized static field (issue #98). Non-literal or
+                        // untyped static initializers are not yet lowered.
+                        if let Some(static_field) = self.class_static_field(property)? {
+                            source_static_fields.push(static_field);
+                            continue;
+                        }
                         return Err(SmeltError::unsupported(
                             self.span(property.span.start, property.span.end),
-                            "static fields are not lowered yet",
+                            "static fields require a concrete literal initializer",
                         ));
                     }
                     let name = self.property_key_symbol(&property.key)?;
@@ -945,9 +957,12 @@ impl ModuleBuilder<'_> {
                         if materialized.is_some() {
                             continue;
                         }
+                        // Static getters need associated-accessor lowering that
+                        // is not implemented yet; static *methods* are handled in
+                        // the method-lowering pass below.
                         return Err(SmeltError::unsupported(
                             self.span(method.span.start, method.span.end),
-                            "static methods are not lowered yet",
+                            "static accessors are not lowered yet",
                         ));
                     }
                     let name = self.property_key_symbol(&method.key)?;
@@ -1021,11 +1036,22 @@ impl ModuleBuilder<'_> {
                 });
             }
         }
-        let static_fields = materialized
+        let mut static_fields = materialized
             .as_ref()
             .map_or_else(Vec::new, |materialized_class| {
                 self.merge_materialized_class_members(materialized_class, &mut fields, class_span)
             });
+        // Source-declared `static NAME = <literal>` constants extend the
+        // materialized set; a materialized value takes precedence when a member
+        // is named by both, so only append source statics not already present.
+        for static_field in source_static_fields {
+            if !static_fields
+                .iter()
+                .any(|existing| existing.name == static_field.name)
+            {
+                static_fields.push(static_field);
+            }
+        }
         let method_sigs = self.class_method_signatures(&class.body.body)?;
         let virtual_method_fields =
             self.virtual_method_field_names(&class.body.body, class.r#abstract);
@@ -1115,10 +1141,22 @@ impl ModuleBuilder<'_> {
                         if materialized.is_some() {
                             continue;
                         }
-                        return Err(SmeltError::unsupported(
-                            self.span(method.span.start, method.span.end),
-                            "static methods are not lowered yet",
-                        ));
+                        // Only plain `static foo(..)` methods are lowered as
+                        // receiver-free associated functions (issue #98). Static
+                        // getters/setters and computed static keys are deferred.
+                        if method.kind != MethodDefinitionKind::Method {
+                            return Err(SmeltError::unsupported(
+                                self.span(method.span.start, method.span.end),
+                                "static accessors are not lowered yet",
+                            ));
+                        }
+                        let item = self.class_static_function(
+                            class_text,
+                            class_name,
+                            method,
+                        )?;
+                        static_methods.push(item);
+                        continue;
                     }
                     if method.r#type == MethodDefinitionType::TSAbstractMethodDefinition {
                         if !matches!(method.kind, MethodDefinitionKind::Method) {
@@ -1340,6 +1378,7 @@ impl ModuleBuilder<'_> {
             descriptors,
             constructor,
             methods,
+            static_methods,
             abstract_methods,
             implements,
         }));
@@ -1377,7 +1416,7 @@ impl ModuleBuilder<'_> {
             args: Vec::new(),
         });
         Ok(body.push_expr(Expr {
-            kind: ExprKind::Literal(smelt_hir::Literal::None),
+            kind: ExprKind::Literal(Literal::None),
             ty,
             span: self.span(class.span.start, class.span.end),
         }))
@@ -1974,6 +2013,93 @@ impl ModuleBuilder<'_> {
     }
 
     /// Lower a class method or constructor to HIR.
+    /// Lower a `static NAME: T = <literal>` class field to a static field.
+    ///
+    /// Returns `None` when the initializer is missing or is not a concrete
+    /// literal, so the caller can reject unsupported static-field forms. The
+    /// field's type comes from the annotation when present, otherwise it is
+    /// inferred from the literal. It is resolvable via `Class.NAME` and lowers to
+    /// a receiver-free associated accessor in Rust codegen.
+    pub(in crate::lowering) fn class_static_field(
+        &mut self,
+        property: &oxc::ast::ast::PropertyDefinition<'_>,
+    ) -> Result<Option<smelt_hir::StaticField>, SmeltError> {
+        let name = self.property_key_symbol(&property.key)?;
+        let Some(value_expr) = &property.value else {
+            return Ok(None);
+        };
+        // The field type is taken from the materialized literal so the emitted
+        // accessor return type always matches the concrete value's Rust type.
+        let Some((literal, ty)) = self.static_field_literal(value_expr)? else {
+            return Ok(None);
+        };
+        let visibility = if matches!(&property.key, PropertyKey::PrivateIdentifier(_)) {
+            Visibility::Private
+        } else {
+            visibility(property.accessibility)
+        };
+        Ok(Some(smelt_hir::StaticField {
+            name,
+            ty,
+            visibility,
+            value: Some(literal),
+            span: self.span(property.span.start, property.span.end),
+        }))
+    }
+
+    /// Convert a static-field initializer expression to a concrete literal and
+    /// its inferred type.
+    ///
+    /// Numeric literals lower to `Float`, mirroring JavaScript's single `number`
+    /// type (TypeScript has no `int` spelling), so an annotated `number` static
+    /// and its value agree. Returns `None` when the expression is not a
+    /// supported literal form.
+    fn static_field_literal(
+        &mut self,
+        expr: &Expression<'_>,
+    ) -> Result<Option<(Literal, smelt_hir::TypeId)>, SmeltError> {
+        let pair = match expr {
+            Expression::StringLiteral(literal) => (
+                Literal::String(literal.value.to_string()),
+                self.ctx.krate.types.intern(Type::String),
+            ),
+            Expression::BooleanLiteral(literal) => (
+                Literal::Bool(literal.value),
+                self.ctx.krate.types.intern(Type::Bool),
+            ),
+            Expression::NumericLiteral(literal) => (
+                Literal::Float(literal.value),
+                self.ctx.krate.types.intern(Type::Float),
+            ),
+            _ => return Ok(None),
+        };
+        Ok(Some(pair))
+    }
+
+    /// Lower a `static foo(..)` class method to a receiver-free HIR function.
+    ///
+    /// This is the static counterpart to [`Self::class_function`]: the resulting
+    /// function has no `this` parameter and is owned by
+    /// [`FunctionOwner::ClassStaticMethod`], so codegen emits an associated
+    /// function `Class::foo(..)` resolvable via qualified access `Class.foo(..)`.
+    pub(in crate::lowering) fn class_static_function(
+        &mut self,
+        class_text: &str,
+        class_name: smelt_hir::Symbol,
+        method: &oxc::ast::ast::MethodDefinition<'_>,
+    ) -> Result<smelt_hir::ItemId, SmeltError> {
+        let class_ty = self.ctx.krate.types.intern(Type::Class {
+            name: class_name,
+            args: Vec::new(),
+        });
+        self.class_function_impl(class_text, class_name, class_ty, method, false, true, &[])
+    }
+
+    /// Lower an instance method or constructor of a class to a HIR function.
+    ///
+    /// Non-constructor methods take an implicit leading `this` receiver;
+    /// constructors run field and parameter-property initializers. Static
+    /// methods use [`Self::class_static_function`] instead.
     pub(in crate::lowering) fn class_function(
         &mut self,
         class_text: &str,
@@ -1981,6 +2107,34 @@ impl ModuleBuilder<'_> {
         class_ty: smelt_hir::TypeId,
         method: &oxc::ast::ast::MethodDefinition<'_>,
         is_constructor: bool,
+        field_initializers: &[(smelt_hir::Symbol, &Expression<'_>, smelt_hir::TypeId, Span)],
+    ) -> Result<smelt_hir::ItemId, SmeltError> {
+        self.class_function_impl(
+            class_text,
+            class_name,
+            class_ty,
+            method,
+            is_constructor,
+            false,
+            field_initializers,
+        )
+    }
+
+    /// Shared implementation for instance, constructor, and static class
+    /// functions. `is_static` suppresses the implicit `this` receiver and routes
+    /// ownership to [`FunctionOwner::ClassStaticMethod`].
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "class function lowering threads the receiver/constructor flags through one shared body"
+    )]
+    fn class_function_impl(
+        &mut self,
+        class_text: &str,
+        class_name: smelt_hir::Symbol,
+        class_ty: smelt_hir::TypeId,
+        method: &oxc::ast::ast::MethodDefinition<'_>,
+        is_constructor: bool,
+        is_static: bool,
         field_initializers: &[(smelt_hir::Symbol, &Expression<'_>, smelt_hir::TypeId, Span)],
     ) -> Result<smelt_hir::ItemId, SmeltError> {
         let Some(function_body) = &method.value.body else {
@@ -2066,15 +2220,20 @@ impl ModuleBuilder<'_> {
             mutable: true,
             span: self.span(method.span.start, method.span.start),
         });
-        self.locals.insert("this".to_owned(), this_local);
-        if !is_constructor {
-            body.params.push(this_local);
-            params.push(Param {
-                name: this_symbol,
-                local: this_local,
-                ty: class_ty,
-                span: self.span(method.span.start, method.span.start),
-            });
+        // A static method has no `this` receiver: it must not bind `this` and
+        // must not carry a receiver parameter, so it lowers to a receiver-free
+        // associated function.
+        if !is_static {
+            self.locals.insert("this".to_owned(), this_local);
+            if !is_constructor {
+                body.params.push(this_local);
+                params.push(Param {
+                    name: this_symbol,
+                    local: this_local,
+                    ty: class_ty,
+                    span: self.span(method.span.start, method.span.start),
+                });
+            }
         }
 
         let mut destructured_params = Vec::new();
@@ -2200,6 +2359,11 @@ impl ModuleBuilder<'_> {
             body: Some(body_id),
             owner: if is_constructor {
                 FunctionOwner::Constructor { class: class_name }
+            } else if is_static {
+                FunctionOwner::ClassStaticMethod {
+                    class: class_name,
+                    method: method_name,
+                }
             } else {
                 FunctionOwner::ClassMethod {
                     class: class_name,

--- a/crates/smelt-frontend-ts/src/lowering/specialization.rs
+++ b/crates/smelt-frontend-ts/src/lowering/specialization.rs
@@ -374,12 +374,14 @@ impl ModuleBuilder<'_> {
         let Item::Class(class) = self.item_ref(class_item) else {
             return Ok(None);
         };
+        // Static field names are interned through the source-name path, which
+        // case-folds camelCase to snake_case (`PI` -> `pi`). Compare against the
+        // same folded spelling so qualified reads like `Class.PI` resolve.
+        let member_symbol = crate::camel_to_snake(member.property.name.as_str());
         let Some(field) = class
             .static_fields
             .iter()
-            .find(|field| {
-                self.ctx.krate.symbols.get(field.name) == Some(member.property.name.as_str())
-            })
+            .find(|field| self.ctx.krate.symbols.get(field.name) == Some(member_symbol.as_str()))
             .cloned()
         else {
             return Ok(None);

--- a/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
@@ -123,6 +123,9 @@ impl<'builder> ModuleBuilder<'builder> {
         if let Some(expr) = self.callable_static_member_call(call, body)? {
             return Ok(expr);
         }
+        if let Some(expr) = self.class_static_method_call(call, body)? {
+            return Ok(expr);
+        }
         if let Expression::StaticMemberExpression(member) = &call.callee {
             if member.property.name == "next" && call.arguments.is_empty() {
                 let receiver = self.expression(&member.object, body)?;
@@ -1228,6 +1231,79 @@ impl<'builder> ModuleBuilder<'builder> {
             ));
         };
         self.argument(value, body).map(Some)
+    }
+
+    /// Lower a qualified static method call `Class.staticMethod(args)`.
+    ///
+    /// Resolves the receiver identifier to a user class and, when it declares a
+    /// `staticMethod`, lowers the call as a direct call to the receiver-free
+    /// associated function item so codegen emits `Class::staticMethod(args)`.
+    /// Returns `None` when the callee is not a `Class.method(..)` static call so
+    /// the caller can fall through to the ordinary member-call path.
+    pub(in crate::lowering) fn class_static_method_call(
+        &mut self,
+        call: &oxc::ast::ast::CallExpression<'_>,
+        body: &mut Body,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return Ok(None);
+        };
+        let Expression::Identifier(object) = &member.object else {
+            return Ok(None);
+        };
+        // The receiver must be a bare class name and not shadowed by a local.
+        if self.locals.contains_key(object.name.as_str()) {
+            return Ok(None);
+        }
+        let Some(class_item) = self.classes.get(object.name.as_str()).copied() else {
+            return Ok(None);
+        };
+        let Item::Class(class) = self.item_ref(class_item) else {
+            return Ok(None);
+        };
+        let Some(static_item) = self.resolve_class_static_method(
+            &class.static_methods.clone(),
+            member.property.name.as_str(),
+        ) else {
+            return Ok(None);
+        };
+        let Item::Function(function) = self.item_ref(static_item) else {
+            return Ok(None);
+        };
+        let return_ty = function.return_ty;
+        let span = self.span(call.span.start, call.span.end);
+        // Arguments are lowered as-is; the Rust emitter coerces each to the
+        // associated function's declared parameter type at the call site, the
+        // same way a direct free-function call is adapted.
+        let mut args = Vec::new();
+        for argument in &call.arguments {
+            args.push(self.argument(argument, body)?);
+        }
+        let callee = body.push_expr(Expr {
+            kind: ExprKind::Item(static_item),
+            ty: self.item_expr_type(static_item, span)?,
+            span,
+        });
+        Ok(Some(body.push_expr(Expr {
+            kind: ExprKind::Call { callee, args },
+            ty: return_ty,
+            span,
+        })))
+    }
+
+    /// Return the static method item on a class matching `method_name`, if any.
+    fn resolve_class_static_method(
+        &self,
+        static_methods: &[smelt_hir::ItemId],
+        method_name: &str,
+    ) -> Option<smelt_hir::ItemId> {
+        static_methods.iter().copied().find(|item| {
+            matches!(
+                self.item_ref(*item),
+                Item::Function(function)
+                    if self.ctx.krate.symbols.get(function.name) == Some(method_name)
+            )
+        })
     }
 
     /// Lower calls where an object property itself is a callable value.

--- a/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
@@ -287,3 +287,76 @@ export function writeBag(bag: StringBag, key: string, value: string): void {
     ensure!(!ctx.class_index_values.is_empty());
     Ok(())
 }
+
+/// Issue #98: a `static` method lowers to a `ClassStaticMethod`-owned function
+/// (no `this` receiver) kept in the class's `static_methods`, and a `static`
+/// constant becomes a materialized static field with a concrete literal value.
+#[test]
+fn lowers_static_method_and_static_const() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r"
+class MathUtils {
+  static readonly LIMIT: number = 7;
+  static square(value: number): number {
+    return value * value;
+  }
+}
+
+export function area(radius: number): number {
+  return MathUtils.square(radius) * MathUtils.LIMIT;
+}
+"),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+
+    let class = ctx
+        .krate
+        .items
+        .iter()
+        .find_map(|item| match item {
+            Item::Class(class) if ctx.krate.symbols.get(class.name) == Some("MathUtils") => {
+                Some(class)
+            }
+            _ => None,
+        })
+        .ok_or("missing MathUtils class item")?;
+
+    // The static method lives in `static_methods`, not `methods`.
+    ensure_eq!(class.static_methods.len(), 1);
+    let static_item = class
+        .static_methods
+        .first()
+        .copied()
+        .ok_or("missing static method item")?;
+    let static_index = usize::try_from(static_item.0)
+        .map_err(|err| format!("item id does not fit usize: {err}"))?;
+    let Some(Item::Function(function)) = ctx.krate.items.get(static_index) else {
+        return Err("static method item is not a function".to_owned());
+    };
+    ensure!(matches!(
+        function.owner,
+        smelt_hir::FunctionOwner::ClassStaticMethod { .. }
+    ));
+    // A static method must not carry an implicit `this` receiver.
+    ensure!(
+        function
+            .params
+            .first()
+            .is_none_or(|param| ctx.krate.symbols.get(param.name) != Some("this"))
+    );
+
+    // The static constant is materialized with its concrete literal value.
+    ensure_eq!(class.static_fields.len(), 1);
+    let static_field = class
+        .static_fields
+        .first()
+        .ok_or("missing static field")?;
+    ensure!(matches!(
+        static_field.value,
+        Some(Literal::Float(value)) if (value - 7.0).abs() < f64::EPSILON
+    ));
+    Ok(())
+}

--- a/crates/smelt-frontend-ts/src/tests/part06_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part06_tests.rs
@@ -158,7 +158,10 @@ fn lowers_generic_classes() -> Result<(), String> {
 }
 
 #[test]
-fn rejects_static_members() -> Result<(), String> {
+fn rejects_uninitialized_static_field_but_lowers_static_members() -> Result<(), String> {
+    // A `static` field without a concrete literal initializer is still rejected:
+    // there is no materializable value to resolve `Class.role` to (issue #98
+    // lowers only literal-initialized static constants).
     let mut field_ctx = HirCtx::new();
     let field_errors = lowering_errors(
         ts!("class User {
@@ -168,17 +171,22 @@ fn rejects_static_members() -> Result<(), String> {
 "),
         &mut field_ctx,
     )?;
-    assert_unsupported_ts(&field_errors, "static fields")?;
+    assert_unsupported_ts(&field_errors, "static fields require a concrete literal initializer")?;
 
-    let mut method_ctx = HirCtx::new();
-    let method_errors = lowering_errors(
+    // A literal-initialized `static` constant and a `static` method now lower
+    // successfully (issue #98): the constant becomes a materialized static field
+    // and the method a receiver-free associated function.
+    let mut ok_ctx = HirCtx::new();
+    lower_ok(
         ts!("class User {
-  static role(): string { return \"admin\"; }
+  static readonly ROLE: string = \"admin\";
+  static greeting(): string { return \"hi\"; }
 }
 "),
-        &mut method_ctx,
+        &mut ok_ctx,
     )?;
-    assert_unsupported_ts(&method_errors, "static methods")
+    ensure!(smelt_hir::validate(&ok_ctx.krate).is_empty());
+    Ok(())
 }
 
 #[test]

--- a/crates/smelt-hir/src/item.rs
+++ b/crates/smelt-hir/src/item.rs
@@ -92,6 +92,19 @@ pub enum FunctionOwner {
         /// Method name.
         method: Symbol,
     },
+    /// Function is a `static` method of a class.
+    ///
+    /// Unlike [`FunctionOwner::ClassMethod`], a static method takes no `this`
+    /// receiver: it lowers to a Rust associated function (`Class::method(..)`)
+    /// resolvable via qualified access `Class.method(..)`, keeping its typed
+    /// signature. It shares the constructor/method namespace only through its
+    /// owning class symbol, so codegen groups it into the same inherent impl.
+    ClassStaticMethod {
+        /// Owning class.
+        class: Symbol,
+        /// Method name.
+        method: Symbol,
+    },
     /// Function is a constructor of a class.
     Constructor {
         /// Owning class.
@@ -138,6 +151,14 @@ pub struct Class {
     pub constructor: Option<ItemId>,
     /// Method IDs of the class.
     pub methods: Vec<ItemId>,
+    /// Static method IDs of the class.
+    ///
+    /// These are lowered as associated functions (no `this` receiver) and are
+    /// resolved through qualified access `Class.staticMethod(..)`. They are kept
+    /// separate from [`Class::methods`] so codegen never emits a receiver for
+    /// them and call-site resolution can distinguish qualified static calls
+    /// from instance method calls.
+    pub static_methods: Vec<ItemId>,
     /// Abstract method signatures required by this class.
     pub abstract_methods: Vec<MethodSig>,
     /// Interfaces implemented by this class.

--- a/crates/smelt-mir/src/lower/context.rs
+++ b/crates/smelt-mir/src/lower/context.rs
@@ -179,6 +179,13 @@ impl<'hir> LoweringCtx<'hir> {
                 method,
                 body: body_id,
             },
+            smelt_hir::FunctionOwner::ClassStaticMethod { class, method } => {
+                HirOrigin::ClassStaticMethod {
+                    class,
+                    method,
+                    body: body_id,
+                }
+            }
         };
         let mut function = MirFunction::new(function_id, name, origin, return_ty, span);
         function.is_async = is_async;

--- a/crates/smelt-mir/src/lower/mod.rs
+++ b/crates/smelt-mir/src/lower/mod.rs
@@ -291,6 +291,11 @@ fn lower_class_table_entry(mir: &mut Mir, class: &smelt_hir::Class, item_functio
             .iter()
             .filter_map(|method_item| item_functions.get(method_item).copied())
             .collect(),
+        static_methods: class
+            .static_methods
+            .iter()
+            .filter_map(|method_item| item_functions.get(method_item).copied())
+            .collect(),
         abstract_methods: class.abstract_methods.clone(),
         implements: class.implements.clone(),
     });

--- a/crates/smelt-mir/src/types.rs
+++ b/crates/smelt-mir/src/types.rs
@@ -190,6 +190,8 @@ pub struct MirClass {
     pub constructor: Option<FuncId>,
     /// Method function IDs.
     pub methods: Vec<FuncId>,
+    /// Static method function IDs (receiver-free associated functions).
+    pub static_methods: Vec<FuncId>,
     /// Abstract method signatures required by this class.
     pub abstract_methods: Vec<smelt_hir::MethodSig>,
     /// Interfaces this class implements.
@@ -368,6 +370,15 @@ pub enum HirOrigin {
     /// A class method.
     ClassMethod {
         /// The class containing the method.
+        class: Symbol,
+        /// The method name.
+        method: Symbol,
+        /// The method body.
+        body: BodyId,
+    },
+    /// A `static` class method (associated function, no receiver).
+    ClassStaticMethod {
+        /// The class containing the static method.
         class: Symbol,
         /// The method name.
         method: Symbol,


### PR DESCRIPTION
## Summary

Implements GitHub issue #98 (part of the #18 object-model roadmap): lowering **static methods** and **static class constants/vars** so they are resolvable via qualified access `Class.staticMethod(...)` and `Class.STATIC_CONST`, for both the TypeScript and Python frontends.

Kept fully general — no per-library special cases, typed signatures preserved.

## Lowering design

- **Static methods → Rust associated functions.** A new `FunctionOwner::ClassStaticMethod` (HIR) / `HirOrigin::ClassStaticMethod` (MIR) marks a receiver-free method. `Class.static_methods` keeps them separate from instance methods so codegen never emits a `self` receiver. `Class.staticMethod(args)` lowers to a direct `Item` call, which emits `Class::staticMethod(args)`.
- **Static constants → materialized static fields.** Source-declared `static NAME: T = <literal>` (TS) and class-level `NAME = <literal>` / `@staticmethod` (Python) now flow through the existing materialized-static-field machinery instead of being rejected. Qualified reads resolve to the concrete literal value; the class also emits a receiver-free associated accessor (`__smelt_static_<name>()`).

## Changed layers

- **HIR** (`item.rs`): `FunctionOwner::ClassStaticMethod`, `Class.static_methods`.
- **MIR** (`types.rs`, `lower/*`): `HirOrigin::ClassStaticMethod`, `MirClass.static_methods`, owner→origin mapping, id/body lowering (static methods are ordinary function items, so they get FuncIds and bodies for free).
- **Rust codegen**: `emit_method` static arm (no receiver, all params), static methods emitted into the class impl block, static call site emits `Class::method(args)`, free-function loop skips static methods, class type-param scope covers static methods.
- **TS frontend**: parse `static foo()` → `class_static_function`; parse `static NAME = <literal>` → materialized static field; route `Class.staticMethod(...)` calls and `Class.CONST` reads (fixed a camelCase→snake_case symbol-comparison bug in the existing static-member resolver).
- **Python frontend**: `@staticmethod` → receiver-free `ClassStaticMethod`; class-level `NAME = <literal>` → static field; route `Class.staticMethod(...)` calls and `Class.CONST` reads.

## Tests

- Frontend HIR lowering tests (TS `class_module_tests`, Python `class_tests`) asserting the static-method owner, absence of a `this`/`self` receiver, and the materialized static field value.
- Codegen emitted-Rust tests (TS + Python) asserting the receiver-free associated function, the qualified `Class::method(..)` call, and the static-const literal read.
- A `class_static_members` compile-corpus case whose emitted Rust passes real `cargo check`.
- Updated the pre-existing `rejects_static_members` TS test (static members are now supported; an *uninitialized* static field is still correctly rejected).

`cargo check` + `cargo clippy` clean on all touched crates.

## Deferred (documented, not blocking)

- Static **accessors** (`static get`/`set`) and `static { ... }` initializer blocks still error with a clear message.
- Static members on **generic** classes: the call site emits `Class::method(..)` without a turbofish, so a static method that references the class type parameter would need explicit type args. Non-generic static methods (the common case, covered by the corpus) work.
- Static fields require a concrete literal initializer (non-literal static initializers are not yet materialized).

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)
