### PR TITLE
feat(frontend-py): ty-backed Python return-type resolution (issue #93)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6645,6 +6645,7 @@ dependencies = [
  "ruff_text_size",
  "smelt-asyncio",
  "smelt-hir",
+ "smelt-py-types",
  "smelt-specialize",
  "smelt-stdlib",
 ]
@@ -6696,6 +6697,19 @@ dependencies = [
  "anyhow",
  "ruff_db",
  "ruff_python_ast",
+ "ty_project",
+ "ty_python_semantic",
+]
+
+[[package]]
+name = "smelt-py-types"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ruff_db",
+ "ruff_python_ast",
+ "ruff_python_parser",
+ "ruff_text_size",
  "ty_project",
  "ty_python_semantic",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/smelt-cli",
     "crates/smelt-gui",
     "crates/smelt-py-ty-spike",
+    "crates/smelt-py-types",
 ]
 default-members = [
     "crates/smelt-frontend-ts",

--- a/crates/smelt-cli/Cargo.toml
+++ b/crates/smelt-cli/Cargo.toml
@@ -6,6 +6,13 @@ edition.workspace = true
 [lints]
 workspace = true
 
+[features]
+# Resolve Python types via Astral's `ty` instead of requiring explicit
+# annotations (issue #93). OFF by default so `cargo build`/`cargo install`
+# stay lean; build the CLI with `--features ty` to enable ty-backed Python
+# type resolution end to end.
+ty = ["smelt-frontend-py/ty"]
+
 [[bin]]
 name = "smelt"
 path = "src/main.rs"

--- a/crates/smelt-codegen-rust/Cargo.toml
+++ b/crates/smelt-codegen-rust/Cargo.toml
@@ -6,6 +6,13 @@ edition.workspace = true
 [lints]
 workspace = true
 
+[features]
+# Forward the Python frontend's `ty` feature so the compile corpus can exercise
+# annotation-free Python that lowers via `ty`-resolved types (issue #93). OFF by
+# default so the default build stays lean; CI runs the corpus with `--features
+# ty` alongside `--ignored`.
+ty = ["smelt-frontend-py/ty"]
+
 [dependencies]
 smelt-mir = { path = "../smelt-mir" }
 smelt-hir = { path = "../smelt-hir" }

--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -51,6 +51,11 @@ use smelt_codegen_rust::{CrateKind, EmitOptions, emit_crate};
 use smelt_frontend_ts::{HirCtx, to_hir};
 use smelt_hir::FileId;
 
+// The Python corpus is only built with the `ty` feature, where annotation-free
+// Python resolves its types via `ty` (issue #93).
+#[cfg(feature = "ty")]
+use smelt_frontend_py::{HirCtx as PyHirCtx, to_hir_with_path as py_to_hir_with_path};
+
 /// A recorded corpus failure: `(area, case name, captured error text)`.
 type CorpusFailure = (String, String, String);
 
@@ -731,6 +736,55 @@ fn emit_case_crate(case: &Case, crate_dir: &Path) -> Result<(), String> {
     emit_crate(&mir, crate_dir, &options).map_err(|err| format!("crate emission failed: {err}"))
 }
 
+/// Python corpus: annotation-free source that only lowers because `ty`
+/// resolves the return types (issue #93).
+///
+/// Each function omits its `-> T` return annotation; without the `ty` feature
+/// the Python frontend would reject these with "must have an explicit return
+/// type annotation". With `ty`, the return type is inferred from the body and
+/// the program lowers and compiles.
+#[cfg(feature = "ty")]
+fn python_corpus() -> Vec<Case> {
+    vec![Case {
+        name: "py_inferred_returns",
+        area: "py_ty_return_inference",
+        // No function carries a `-> T`; `ty` infers int/str/bool from the
+        // bodies. Parameters keep annotations (unannotated params stay an
+        // explicit boundary — a documented deferral).
+        source: r"
+def inc(x: int):
+    return x + 1
+
+def label(name: str):
+    return 'hi ' + name
+
+def at_least_ten(n: int):
+    return n >= 10
+
+def total(values: list[int]):
+    result = 0
+    for value in values:
+        result = result + value
+    return result
+",
+    }]
+}
+
+/// Lowers a Python corpus `case` through the real Python pipeline (with `ty`
+/// type resolution) and emits a full program crate into `crate_dir`.
+#[cfg(feature = "ty")]
+fn emit_python_case_crate(case: &Case, crate_dir: &Path) -> Result<(), String> {
+    let mut ctx = PyHirCtx::new();
+    py_to_hir_with_path(case.source, FileId(0), "corpus/main.py", &mut ctx)
+        .map_err(|err| format!("Python HIR lowering failed: {err:?}"))?;
+    let mut mir =
+        smelt_mir::lower_hir(&ctx.krate).map_err(|err| format!("MIR lowering failed: {err:?}"))?;
+    smelt_mir::opt::optimize(&mut mir);
+    let options = EmitOptions::new(format!("smelt_corpus_{}", case.name))
+        .with_crate_kind(CrateKind::Program);
+    emit_crate(&mir, crate_dir, &options).map_err(|err| format!("crate emission failed: {err}"))
+}
+
 /// Runs `cargo check` on the emitted crate at `crate_dir`, sharing the given
 /// `target_dir` so corpus crates reuse compiled dependencies.
 ///
@@ -798,6 +852,25 @@ fn corpus_emitted_rust_compiles() {
         }
         let crate_dir = crates_dir.join(case.name);
         if let Err(err) = emit_case_crate(&case, &crate_dir) {
+            failures.push((case.area.to_owned(), case.name.to_owned(), err));
+            continue;
+        }
+        if let Err(err) = cargo_check(&crate_dir, &target_dir) {
+            failures.push((case.area.to_owned(), case.name.to_owned(), err));
+        }
+    }
+
+    // Python corpus (only when built with `--features ty`): annotation-free
+    // Python whose return types are resolved by `ty` (issue #93).
+    #[cfg(feature = "ty")]
+    for case in python_corpus() {
+        if let Some(only_name) = &only
+            && case.name != only_name
+        {
+            continue;
+        }
+        let crate_dir = crates_dir.join(case.name);
+        if let Err(err) = emit_python_case_crate(&case, &crate_dir) {
             failures.push((case.area.to_owned(), case.name.to_owned(), err));
             continue;
         }

--- a/crates/smelt-frontend-py/Cargo.toml
+++ b/crates/smelt-frontend-py/Cargo.toml
@@ -7,11 +7,22 @@ autoexamples = false
 [lints]
 workspace = true
 
+[features]
+# Resolve Python function/method/parameter/closure types via Astral's `ty`
+# instead of requiring explicit source annotations (issue #93). OFF by default:
+# it pulls in the heavy `ty` dependency tree (salsa + vendored typeshed) through
+# `smelt-py-types`, so a lean `cargo build` never pays for it. The central
+# pipeline and CI probes enable `--features ty`.
+ty = ["dep:smelt-py-types"]
+
 [dependencies]
 smelt-asyncio = { path = "../smelt-asyncio" }
 smelt-hir = { path = "../smelt-hir" }
 smelt-specialize = { path = "../smelt-specialize" }
 smelt-stdlib = { path = "../smelt-stdlib" }
+
+# Optional `ty`-backed Python type resolution, gated behind the `ty` feature.
+smelt-py-types = { path = "../smelt-py-types", optional = true }
 
 # Python parsing via Astral's Ruff parser. Not published to crates.io, so we
 # pull it from the upstream git repo — the same approach `ty` (Astral's type

--- a/crates/smelt-frontend-py/src/lib.rs
+++ b/crates/smelt-frontend-py/src/lib.rs
@@ -374,7 +374,15 @@ pub fn to_hir_with_options(
     }
     let module_ast = parse_module(source, file_id)?;
     let specialization = lowering::specialization_for_path(path, options.specialization);
+    // Resolve Python types via `ty` (no-op unless the `ty` feature is enabled).
+    // The stem only names `ty`'s temporary module; lookups are keyed by offset.
+    let stem = Path::new(path)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("smelt_module");
+    let resolved_types = ty_resolve::ResolvedTypes::resolve(source, stem);
     let mut builder = ModuleBuilder::new(file_id, path.to_owned(), ctx, specialization);
+    builder.set_resolved_types(resolved_types);
     builder.module(&module_ast)
 }
 
@@ -390,6 +398,7 @@ pub(crate) mod helpers;
 pub(crate) mod lowering;
 #[doc(hidden)]
 pub mod test_support;
+pub(crate) mod ty_resolve;
 
 #[cfg(test)]
 mod tests;

--- a/crates/smelt-frontend-py/src/lowering.rs
+++ b/crates/smelt-frontend-py/src/lowering.rs
@@ -84,6 +84,8 @@ pub(crate) struct ModuleBuilder<'ctx> {
     function_variadics: HashMap<String, FunctionVariadics>,
     /// Materialized final bindings for this source module.
     specialization: Option<SpecializationData>,
+    /// `ty`-resolved types for this module (empty unless the `ty` feature is on).
+    resolved_types: crate::ty_resolve::ResolvedTypes,
 }
 
 /// A local Python lambda value that can be consumed by callback APIs without escaping.
@@ -231,7 +233,14 @@ impl<'ctx> ModuleBuilder<'ctx> {
             local_callbacks: HashMap::new(),
             function_variadics: HashMap::new(),
             specialization,
+            resolved_types: crate::ty_resolve::ResolvedTypes::disabled(),
         }
+    }
+
+    /// Install the `ty`-resolved module types used to fill in missing
+    /// annotations. Called once, immediately after construction.
+    pub(crate) fn set_resolved_types(&mut self, resolved: crate::ty_resolve::ResolvedTypes) {
+        self.resolved_types = resolved;
     }
 
     // -----------------------------------------------------------------------

--- a/crates/smelt-frontend-py/src/lowering/class.rs
+++ b/crates/smelt-frontend-py/src/lowering/class.rs
@@ -769,17 +769,19 @@ impl ModuleBuilder<'_> {
         } else if is_new && func.returns.is_none() {
             class_ty
         } else {
-            func.returns
-                .as_deref()
-                .ok_or_else(|| {
-                    SmeltError::type_constraint(
+            // Reconcile any declared annotation with `ty`'s inferred actual
+            // return type (issue #93); error only when neither is available.
+            match self.resolve_return_ty(func, func.returns.as_deref()) {
+                Some(ty) => ty,
+                None => {
+                    return Err(SmeltError::type_constraint(
                         span,
                         format!(
                             "method '{class_name_str}.{method_name_str}' must have an explicit return type annotation"
                         ),
-                    )
-                })
-                .and_then(|ann| self.annotation_to_hir(ann))?
+                    ));
+                }
+            }
         };
 
         let saved_locals = std::mem::take(&mut self.locals);
@@ -825,18 +827,18 @@ impl ModuleBuilder<'_> {
             }
             first = false;
 
-            let param_ty = p
-                .annotation
-                .as_deref()
-                .ok_or_else(|| {
+            let param_ty = match p.annotation.as_deref() {
+                Some(ann) => self.annotation_to_hir(ann)?,
+                // No annotation: consult `ty` (issue #93) before erroring.
+                None => self.resolved_param_ty(p).ok_or_else(|| {
                     SmeltError::type_constraint(
                         self.span(p.range),
                         format!(
                             "parameter '{param_name_str}' in '{class_name_str}.{method_name_str}' must have a type annotation"
                         ),
                     )
-                })
-                .and_then(|ann| self.annotation_to_hir(ann))?;
+                })?,
+            };
 
             let param_sym = self.intern_name(param_name_str);
             let local = fn_body.push_local(LocalDecl {

--- a/crates/smelt-frontend-py/src/lowering/pytest.rs
+++ b/crates/smelt-frontend-py/src/lowering/pytest.rs
@@ -126,15 +126,23 @@ impl ModuleBuilder<'_> {
         let name = self.intern_name(name_str);
 
         // Return type — required except for pytest test functions, where an
-        // omitted annotation is treated as `-> None`.
-        let annotated_return_ty = match func.returns.as_deref() {
-            Some(annotation) => self.annotation_to_hir(annotation)?,
-            None if self.is_pytest_test_function(func) => self.intern_type(Type::None),
-            None => {
-                return Err(SmeltError::type_constraint(
-                    self.span(func.range),
-                    format!("function '{name_str}' must have an explicit return type annotation"),
-                ));
+        // omitted annotation is treated as `-> None`. `resolve_return_ty`
+        // reconciles any declared annotation with `ty`'s inferred *actual*
+        // returned type (issue #93), preferring the accurate type. Only a
+        // genuinely unresolved, unannotated case falls through to the error.
+        let annotated_return_ty = if self.is_pytest_test_function(func) && func.returns.is_none() {
+            self.intern_type(Type::None)
+        } else {
+            match self.resolve_return_ty(func, func.returns.as_deref()) {
+                Some(ty) => ty,
+                None => {
+                    return Err(SmeltError::type_constraint(
+                        self.span(func.range),
+                        format!(
+                            "function '{name_str}' must have an explicit return type annotation"
+                        ),
+                    ));
+                }
             }
         };
         let return_ty = if func.is_async {
@@ -210,18 +218,17 @@ impl ModuleBuilder<'_> {
                 continue;
             }
 
-            let param_ty = p
-                .annotation
-                .as_deref()
-                .ok_or_else(|| {
+            let param_ty = match p.annotation.as_deref() {
+                Some(ann) => self.annotation_to_hir(ann)?,
+                None => self.resolved_param_ty(p).ok_or_else(|| {
                     SmeltError::type_constraint(
                         self.span(p.range),
                         format!(
                             "parameter '{param_name_str}' must have an explicit type annotation"
                         ),
                     )
-                })
-                .and_then(|ann| self.annotation_to_hir(ann))?;
+                })?,
+            };
 
             let param_name = self.intern_name(param_name_str);
             let local = fn_body.push_local(LocalDecl {

--- a/crates/smelt-frontend-py/src/lowering/types.rs
+++ b/crates/smelt-frontend-py/src/lowering/types.rs
@@ -3,6 +3,70 @@ impl ModuleBuilder<'_> {
     // Type annotation lowering
     // -----------------------------------------------------------------------
 
+    /// Resolve a function/method return type, reconciling any source-declared
+    /// annotation with `ty`'s inferred *actual* returned type (issue #93).
+    ///
+    /// Behaviour, in order:
+    /// * No annotation → use `ty`'s inferred return type; `None` if `ty` could
+    ///   not resolve one (the caller then raises the explicit-annotation error).
+    /// * Annotation present → lower it. If `ty` also resolved a representable
+    ///   return type and it *differs* from the annotation, prefer `ty`'s: the
+    ///   annotation may be stale/wider/narrower than what the body actually
+    ///   returns, and lowering must follow the accurate type. If `ty` resolved
+    ///   nothing (or the same type), keep the annotation.
+    ///
+    /// The `func` node's start offset is the key `smelt-py-types` records return
+    /// types under.
+    fn resolve_return_ty(
+        &mut self,
+        func: &StmtFunctionDef,
+        annotation: Option<&Expr>,
+    ) -> Option<TypeId> {
+        let inferred = self
+            .resolved_types
+            .return_type_at(func.start())
+            .map(ToOwned::to_owned)
+            .and_then(|spelling| self.resolved_spelling_to_hir(&spelling));
+        match annotation {
+            None => inferred,
+            Some(ann) => {
+                let declared = self.annotation_to_hir(ann).ok()?;
+                // Prefer ty's inferred actual return type when it diverges.
+                Some(match inferred {
+                    Some(inferred_ty) if inferred_ty != declared => inferred_ty,
+                    _ => declared,
+                })
+            }
+        }
+    }
+
+    /// Return the `ty`-resolved HIR type for parameter `p`, if `ty` resolved a
+    /// representable type for it.
+    ///
+    /// Used when the source omits the parameter's annotation (issue #93). The
+    /// key is the parameter node's start offset, matching how `smelt-py-types`
+    /// records resolved parameter types.
+    fn resolved_param_ty(&mut self, p: &ruff_python_ast::Parameter) -> Option<TypeId> {
+        let spelling = self.resolved_types.param_type_at(p.start())?.to_owned();
+        self.resolved_spelling_to_hir(&spelling)
+    }
+
+    /// Lower a `ty`-resolved type *spelling* (a canonical Python type string
+    /// such as `"int"`, `"list[int]"`, or `"str | None"`) to a HIR [`TypeId`].
+    ///
+    /// The spelling is re-parsed as a Python annotation expression and routed
+    /// through the same [`Self::annotation_to_hir`] path source annotations use,
+    /// so unions, `list[T]`, custom classes, etc. all lower identically to hand-
+    /// written annotations. Returns `None` if the spelling does not parse or
+    /// lands on an annotation form the frontend cannot lower, letting the caller
+    /// fall back to its explicit-annotation requirement (an explicit boundary,
+    /// never a silent widening).
+    fn resolved_spelling_to_hir(&mut self, spelling: &str) -> Option<TypeId> {
+        let parsed = ruff_python_parser::parse_expression(spelling).ok()?;
+        let expr = parsed.syntax().body.as_ref();
+        self.annotation_to_hir(expr).ok()
+    }
+
     /// Lower a Python type annotation expression to a HIR [`TypeId`].
     fn annotation_to_hir(&mut self, annotation: &Expr) -> Result<TypeId, SmeltError> {
         if let Expr::Name(name) = annotation {

--- a/crates/smelt-frontend-py/src/tests/category_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/category_tests.rs
@@ -1,11 +1,23 @@
 //! Tests for the structured [`DiagnosticCategory`] assigned to Python errors.
+//!
+//! The missing-annotation cases only apply without the `ty` feature: with `ty`
+//! on, those annotations are resolved instead of erroring (see
+//! `ty_resolution_tests`). Their imports are therefore gated too.
 
+#[cfg(not(feature = "ty"))]
 use super::{first_error, lower_errors};
+#[cfg(not(feature = "ty"))]
 use crate::HirCtx;
+#[cfg(not(feature = "ty"))]
 use smelt_stdlib::DiagnosticCategory;
 
 /// A function missing its return type annotation is a typed-subset violation,
 /// not an unimplemented lowering.
+///
+/// Only meaningful without the `ty` feature: with `ty` on, the missing
+/// annotation is resolved from the body instead of erroring (see
+/// `ty_resolution_tests`).
+#[cfg(not(feature = "ty"))]
 #[test]
 fn missing_return_annotation_is_type_constraint() -> Result<(), String> {
     let mut ctx = HirCtx::new();
@@ -21,6 +33,9 @@ fn missing_return_annotation_is_type_constraint() -> Result<(), String> {
 }
 
 /// A parameter missing its type annotation is also a typed-subset violation.
+///
+/// Only meaningful without the `ty` feature (see above).
+#[cfg(not(feature = "ty"))]
 #[test]
 fn missing_param_annotation_is_type_constraint() -> Result<(), String> {
     let mut ctx = HirCtx::new();

--- a/crates/smelt-frontend-py/src/tests/mod.rs
+++ b/crates/smelt-frontend-py/src/tests/mod.rs
@@ -155,3 +155,5 @@ mod collections_reject_b_tests;
 mod packages_tests;
 mod pytest_tests;
 mod specialization_tests;
+#[cfg(feature = "ty")]
+mod ty_resolution_tests;

--- a/crates/smelt-frontend-py/src/tests/pytest_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/pytest_tests.rs
@@ -36,6 +36,10 @@ def find(x: int) -> str | None:
     Ok(())
 }
 
+/// Without the `ty` feature, an omitted return annotation is a hard error.
+/// With `ty` on, it is resolved from the body instead (see
+/// `ty_resolution_tests`).
+#[cfg(not(feature = "ty"))]
 #[test]
 fn missing_return_annotation_is_error() -> TestResult {
     let source = py!("def bad(x: int):\n    return x\n");

--- a/crates/smelt-frontend-py/src/tests/ty_resolution_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/ty_resolution_tests.rs
@@ -1,0 +1,132 @@
+//! Tests for `ty`-backed type resolution (issue #93).
+//!
+//! These are gated on the crate's `ty` feature because they depend on Astral's
+//! `ty` resolving Python types from source that omits (or mis-declares) type
+//! annotations. Without the feature the frontend still requires explicit
+//! annotations, which is covered by `category_tests`.
+//!
+//! Run with: `cargo test -p smelt-frontend-py --features ty ty_resolution`
+
+use super::{ensure, ensure_eq, item, lower_module};
+use crate::HirCtx;
+use smelt_hir::{Item, Type};
+
+/// A function with no return annotation lowers, with the return type `ty`
+/// inferred from the body (`x + 1` → `int`).
+#[test]
+fn function_without_return_annotation_lowers() -> Result<(), String> {
+    let source = "def inc(x: int):\n    return x + 1\n";
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = crate::tests::module(&ctx, module_id)?;
+    let item_id = module
+        .items
+        .first()
+        .copied()
+        .ok_or_else(|| "expected function item".to_owned())?;
+    let Item::Function(func) = item(&ctx, item_id)? else {
+        return Err("expected Function item".to_owned());
+    };
+    ensure_eq(
+        &ctx.krate.types.get(func.return_ty),
+        &Some(&Type::Int),
+        "resolved return type",
+    )?;
+    Ok(())
+}
+
+/// Several unannotated functions in one module all resolve their return types
+/// from their bodies and lower together.
+///
+/// This exercises the dominant blocker family from the library probes: plain
+/// `def`s with no `-> T`. (Unannotated *parameters* are a separate, deferred
+/// case: `ty` reports an unannotated parameter as dynamic, so those still
+/// require a source annotation — see the module-level note in
+/// `smelt-py-types`.)
+#[test]
+fn multiple_unannotated_functions_lower() -> Result<(), String> {
+    let source = concat!(
+        "def inc(x: int):\n    return x + 1\n\n",
+        "def label(name: str):\n    return \"hi \" + name\n\n",
+        "def flag(b: bool):\n    return not b\n",
+    );
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = crate::tests::module(&ctx, module_id)?;
+    ensure_eq(&module.items.len(), &3, "item count")?;
+
+    let expected = [Type::Int, Type::String, Type::Bool];
+    for (index, want) in expected.iter().enumerate() {
+        let Item::Function(func) = item(&ctx, module.items[index])? else {
+            return Err(format!("item {index} is not a function"));
+        };
+        ensure_eq(
+            &ctx.krate.types.get(func.return_ty),
+            &Some(want),
+            "resolved return type",
+        )?;
+    }
+    Ok(())
+}
+
+/// A method with no return annotation lowers, with the return type resolved by
+/// `ty` from the body.
+#[test]
+fn method_without_return_annotation_lowers() -> Result<(), String> {
+    let source = "class Counter:\n    def __init__(self, n: int):\n        self.n = n\n\n    def snapshot(self, extra: int):\n        return extra + 1\n";
+    let mut ctx = HirCtx::new();
+    // `snapshot` has no `-> T`; without the `ty` feature this raises
+    // "method '...' must have an explicit return type annotation".
+    lower_module(source, &mut ctx)?;
+    Ok(())
+}
+
+/// A valueless function (no `return <expr>`) resolves to `None`.
+#[test]
+fn function_returning_none_lowers() -> Result<(), String> {
+    let source = "def noop(x: int):\n    pass\n";
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = crate::tests::module(&ctx, module_id)?;
+    let item_id = module
+        .items
+        .first()
+        .copied()
+        .ok_or_else(|| "expected function item".to_owned())?;
+    let Item::Function(func) = item(&ctx, item_id)? else {
+        return Err("expected Function item".to_owned());
+    };
+    ensure_eq(
+        &ctx.krate.types.get(func.return_ty),
+        &Some(&Type::None),
+        "resolved None return type",
+    )?;
+    Ok(())
+}
+
+/// When a declared return annotation diverges from the actual returned type,
+/// lowering follows `ty`'s inferred type, not the stale annotation.
+///
+/// Here the body returns an `int` (`x + 1`) but the source annotates `-> float`.
+/// `ty` reports the actual `int`, and the frontend uses it.
+#[test]
+fn divergent_return_annotation_prefers_inferred() -> Result<(), String> {
+    let source = "def inc(x: int) -> float:\n    return x + 1\n";
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = crate::tests::module(&ctx, module_id)?;
+    let item_id = module
+        .items
+        .first()
+        .copied()
+        .ok_or_else(|| "expected function item".to_owned())?;
+    let Item::Function(func) = item(&ctx, item_id)? else {
+        return Err("expected Function item".to_owned());
+    };
+    // The actual returned type is `int`; the annotation said `float`.
+    ensure(
+        matches!(ctx.krate.types.get(func.return_ty), Some(Type::Int)),
+        "expected inferred int return type to override float annotation",
+    )?;
+    Ok(())
+}

--- a/crates/smelt-frontend-py/src/ty_resolve.rs
+++ b/crates/smelt-frontend-py/src/ty_resolve.rs
@@ -1,0 +1,101 @@
+//! Optional `ty`-backed type resolution seam for the Python frontend.
+//!
+//! The Python frontend historically required explicit type annotations and
+//! emitted a hard error otherwise. Issue #93 replaces those errors, for
+//! resolvable cases, with types inferred by Astral's `ty` (see
+//! `smelt-py-types`). Because the `ty` dependency tree is heavy, that
+//! resolution lives behind the crate's optional `ty` feature.
+//!
+//! This module is the single seam between the lowering walk and `ty`. It
+//! exposes one type, [`ResolvedTypes`], with the same public surface in both
+//! build configurations:
+//!
+//! * With `--features ty`, it wraps `smelt_py_types::ResolvedModuleTypes` and
+//!   answers return/parameter type queries keyed by AST byte offset.
+//! * Without the feature, it is a zero-sized stub whose queries always return
+//!   `None`, so the frontend falls back to its annotation-based lowering and
+//!   the original "must have an explicit ... annotation" errors still fire.
+//!
+//! Keeping the `#[cfg]` split here means the lowering call sites are written
+//! once, against a stable API, regardless of whether `ty` is compiled in.
+#![allow(
+    clippy::redundant_pub_crate,
+    reason = "the crate root exposes this seam to the lowering builder"
+)]
+
+use ruff_text_size::TextSize;
+
+/// Types resolved by `ty` for the module currently being lowered.
+///
+/// Lookups are keyed by the source byte offset of the AST node the frontend is
+/// visiting (a function-definition start for a return type, a parameter start
+/// for a parameter type). Both accessors return the resolved type as a
+/// canonical Python type *spelling* (e.g. `"int"`, `"list[int]"`,
+/// `"str | None"`) that the frontend re-parses through its annotation lowering.
+#[derive(Debug, Default)]
+pub(crate) struct ResolvedTypes {
+    /// `ty`'s resolved module types, or `None` if resolution was skipped/failed.
+    #[cfg(feature = "ty")]
+    inner: Option<smelt_py_types::ResolvedModuleTypes>,
+}
+
+impl ResolvedTypes {
+    /// A resolver that resolves nothing (feature off, or resolution skipped).
+    #[must_use]
+    pub(crate) fn disabled() -> Self {
+        Self::default()
+    }
+
+    /// Resolve every function/method return and parameter type in `source`
+    /// via `ty`.
+    ///
+    /// `stem` is the file stem used for `ty`'s temporary module (only affects
+    /// `ty`'s module naming, not lookup keys). If `ty` fails to run over the
+    /// source, resolution is silently skipped and every later query returns
+    /// `None`, so lowering falls back to annotations.
+    ///
+    /// Without the `ty` feature this is a no-op returning a disabled resolver.
+    #[must_use]
+    pub(crate) fn resolve(source: &str, stem: &str) -> Self {
+        #[cfg(feature = "ty")]
+        {
+            let inner = smelt_py_types::resolve_module_types(source, stem).ok();
+            Self { inner }
+        }
+        #[cfg(not(feature = "ty"))]
+        {
+            let _ = (source, stem);
+            Self::disabled()
+        }
+    }
+
+    /// Return the `ty`-resolved return-type spelling for the function whose
+    /// definition starts at `offset`, if any.
+    #[must_use]
+    pub(crate) fn return_type_at(&self, offset: TextSize) -> Option<&str> {
+        #[cfg(feature = "ty")]
+        {
+            self.inner.as_ref()?.return_type_at(offset)
+        }
+        #[cfg(not(feature = "ty"))]
+        {
+            let _ = (self, offset);
+            None
+        }
+    }
+
+    /// Return the `ty`-resolved parameter-type spelling for the parameter whose
+    /// declaration starts at `offset`, if any.
+    #[must_use]
+    pub(crate) fn param_type_at(&self, offset: TextSize) -> Option<&str> {
+        #[cfg(feature = "ty")]
+        {
+            self.inner.as_ref()?.param_type_at(offset)
+        }
+        #[cfg(not(feature = "ty"))]
+        {
+            let _ = (self, offset);
+            None
+        }
+    }
+}

--- a/crates/smelt-py-types/Cargo.toml
+++ b/crates/smelt-py-types/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "smelt-py-types"
+version.workspace = true
+edition.workspace = true
+publish = false
+autoexamples = false
+
+# Astral `ty`-backed Python type resolution for the Python frontend.
+#
+# This crate owns the HEAVY `ty` dependency tree (salsa, the ty semantic model,
+# and the vendored typeshed stubs in `ty_vendored`). It is intentionally kept
+# OUT of `default-members` so a normal `cargo build` never pays for that tree.
+# The Python frontend depends on it only behind its optional `ty` feature, so
+# resolving Python types via `ty` is opt-in and does not affect lean builds.
+#
+# See `specs/python-type-checking-with-ty.md` for the feasibility spike this
+# productionizes, and issue #93 for the motivation (replacing the hard
+# "must have an explicit ... annotation" errors with ty-resolved types).
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "1.0.103"
+
+# `ty` and the ruff parser crates are not published to crates.io, so they are
+# pulled from the upstream git repo pinned to the SAME revision already used by
+# `smelt-frontend-py` (`ruff_python_parser`/`ruff_python_ast`/`ruff_text_size`)
+# and the `smelt-py-ty-spike` crate, keeping the workspace on one ruff checkout.
+ruff_db = { git = "https://github.com/astral-sh/ruff", rev = "f82a36b6baf8c0547a17bbde6c0d927ccd45d938", features = ["os"] }
+ruff_python_ast = { git = "https://github.com/astral-sh/ruff", rev = "f82a36b6baf8c0547a17bbde6c0d927ccd45d938" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff", rev = "f82a36b6baf8c0547a17bbde6c0d927ccd45d938" }
+ty_project = { git = "https://github.com/astral-sh/ruff", rev = "f82a36b6baf8c0547a17bbde6c0d927ccd45d938" }
+ty_python_semantic = { git = "https://github.com/astral-sh/ruff", rev = "f82a36b6baf8c0547a17bbde6c0d927ccd45d938" }
+
+[dev-dependencies]
+# Only the tests parse source directly to look up node offsets; the library
+# receives its AST from `ty`'s db-tracked parse.
+ruff_python_parser = { git = "https://github.com/astral-sh/ruff", rev = "f82a36b6baf8c0547a17bbde6c0d927ccd45d938" }

--- a/crates/smelt-py-types/src/lib.rs
+++ b/crates/smelt-py-types/src/lib.rs
@@ -1,0 +1,544 @@
+//! Astral `ty`-backed Python type resolution for Smelt's Python frontend.
+//!
+//! # Why this crate exists
+//!
+//! Smelt's Python frontend (`smelt-frontend-py`) uses Ruff only as a *parser*
+//! and, historically, required every function/method/parameter to carry an
+//! explicit type annotation — otherwise it emitted a hard
+//! `must have an explicit ... annotation` error. Idiomatic Python omits most of
+//! those annotations, so that policy blocked nearly every real library before
+//! any lowering could happen (see issue #93).
+//!
+//! Rather than build a bespoke Python inference engine, this crate embeds
+//! **`ty`** (Astral's Rust type checker, formerly red-knot) as a *library* and
+//! consumes the types it resolves. `ty` already understands call-result types,
+//! unions/narrowing, generics, and — crucially — types that live in the
+//! **vendored typeshed stubs** rather than user source. The feasibility of
+//! embedding it was proven by `crates/smelt-py-ty-spike`; this crate
+//! productionizes that spike into a small, stable query surface.
+//!
+//! # The stable query surface
+//!
+//! `ty`'s internal `Type` lattice is large and almost entirely `pub(crate)` —
+//! there is no public way to walk a function's inferred signature struct. The
+//! one stable, public capability `ty` exposes is
+//! [`ty_python_semantic::HasType::inferred_type`] on AST nodes, plus
+//! `Type::display(db)`, which renders a resolved type in **canonical Python
+//! spelling** (`int`, `list[int]`, `int | float`, `str | None`, …). That
+//! spelling is exactly the grammar the frontend's existing
+//! `annotation_to_hir` already parses. So this crate's contract is
+//! deliberately narrow: it hands the frontend *type strings*, not `ty`'s
+//! internal types, insulating the frontend (and the rest of the workspace)
+//! from `ty`'s unstable internal API.
+//!
+//! # Parameter types (a note on limits)
+//!
+//! `ty` resolves a parameter's type from its *annotation* (or a resolvable
+//! binding); it reports an **unannotated** parameter as dynamic/`Unknown` — it
+//! does not infer a parameter type from a default value or from call sites.
+//! Such dynamic results are dropped by [`displayable_type`], so a genuinely
+//! unannotated parameter stays an explicit boundary and the frontend keeps
+//! requiring an annotation for it. The productive win from `ty` is therefore
+//! **return-type resolution**, which is the dominant blocker family; broader
+//! parameter inference is a deferred follow-up (see issue #93).
+//!
+//! # Return type: actual vs. declared
+//!
+//! Issue #93 stresses that a function's *actual returned* type may differ from
+//! its declared annotation, and that lowering should follow the accurate type.
+//! This crate therefore derives a function's return type from the inferred
+//! types of its `return <expr>` statements (unioned across all return sites),
+//! not from the annotation. A function with no value-returning `return` is
+//! reported as `None`.
+//!
+//! # Batch model
+//!
+//! Smelt is a batch compiler; `ty` is incremental. The simplest correct
+//! integration — and the one used here — is a fresh `ProjectDatabase` per
+//! resolved module, mirroring the spike. The source is materialized into a
+//! temporary directory and checked through an `OsSystem`, the exact path the
+//! spike proved works in this environment. Reuse/caching is a later
+//! optimization, not a correctness concern.
+
+#![expect(
+    clippy::wildcard_enum_match_arm,
+    reason = "Ruff AST statement matches group all non-block variants in one fallback arm"
+)]
+
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, anyhow};
+use ruff_db::files::system_path_to_file;
+use ruff_db::parsed::parsed_module;
+use ruff_db::system::{OsSystem, SystemPathBuf};
+use ruff_python_ast::{Stmt, StmtFunctionDef};
+use ruff_text_size::{Ranged, TextSize};
+use ty_project::{ProjectDatabase, ProjectMetadata};
+use ty_python_semantic::types::Type;
+use ty_python_semantic::{HasType, SemanticModel};
+
+/// Types resolved by `ty` for one Python module, keyed by AST byte offset.
+///
+/// Keys are the source byte offset of the *start* of the relevant AST node —
+/// a `StmtFunctionDef` for a return type, or a `Parameter` for a parameter
+/// type. Byte offsets are stable and unique within a parse, so the frontend
+/// can look up a node's resolved type using the same Ruff AST it already
+/// walks (via `ruff_text_size::Ranged::start`), without name-based matching
+/// that would break on nesting, overloads, or shadowing.
+///
+/// Every stored value is a **canonical Python type string** as produced by
+/// `ty`'s `Type::display` (e.g. `"int"`, `"list[int]"`, `"str | None"`). The
+/// frontend feeds these back through its existing annotation parser.
+#[derive(Debug, Clone, Default)]
+pub struct ResolvedModuleTypes {
+    /// Function-definition start offset → resolved return type spelling.
+    return_types: HashMap<u32, String>,
+    /// Parameter start offset → resolved parameter type spelling.
+    param_types: HashMap<u32, String>,
+}
+
+impl ResolvedModuleTypes {
+    /// Return the resolved return-type spelling for the function whose
+    /// definition starts at `offset`, if `ty` resolved one.
+    #[must_use]
+    pub fn return_type_at(&self, offset: TextSize) -> Option<&str> {
+        self.return_types.get(&offset.to_u32()).map(String::as_str)
+    }
+
+    /// Return the resolved type spelling for the parameter whose declaration
+    /// starts at `offset`, if `ty` resolved one.
+    #[must_use]
+    pub fn param_type_at(&self, offset: TextSize) -> Option<&str> {
+        self.param_types.get(&offset.to_u32()).map(String::as_str)
+    }
+
+    /// Number of resolved return types (used by tests / diagnostics).
+    #[must_use]
+    pub fn resolved_return_count(&self) -> usize {
+        self.return_types.len()
+    }
+
+    /// Number of resolved parameter types (used by tests / diagnostics).
+    #[must_use]
+    pub fn resolved_param_count(&self) -> usize {
+        self.param_types.len()
+    }
+}
+
+/// Resolve, via `ty`, the return and parameter types of every function/method
+/// in `source`.
+///
+/// `module_stem` is the file stem used for the temporary `.py` file (e.g.
+/// `"main"`); it only affects `ty`'s module naming, not the result keys.
+///
+/// The source is written into a fresh temporary directory and checked with a
+/// `ty` `ProjectDatabase` over an `OsSystem`. A resolved type is recorded only
+/// when `ty` produces a *representable, concrete* spelling — dynamic/unknown
+/// results (`Unknown`, `Any`, `Never`, unresolved imports) are intentionally
+/// dropped so the frontend keeps them as an explicit boundary rather than
+/// silently widening to a catch-all.
+///
+/// # Errors
+/// Returns an error if the temporary project cannot be created or `ty` cannot
+/// open the file. A `ty` *checker* error on the file is not fatal: it yields an
+/// empty result so the caller falls back to annotation-based lowering.
+pub fn resolve_module_types(source: &str, module_stem: &str) -> Result<ResolvedModuleTypes> {
+    let dir = unique_temp_dir();
+    std::fs::create_dir_all(&dir).context("create ty resolution project dir")?;
+    // Clean up defensively even if a later step fails; ignore removal errors.
+    // Constructed before any fallible step so the directory is always removed.
+    let guard = TempDirGuard(dir.clone());
+
+    let stem = if module_stem.is_empty() {
+        "smelt_module"
+    } else {
+        module_stem
+    };
+    let file_path = dir.join(format!("{stem}.py"));
+    std::fs::write(&file_path, source).context("write ty resolution source")?;
+
+    let root = SystemPathBuf::from_path_buf(dir)
+        .map_err(|original| anyhow!("non-UTF-8 temp dir path: {}", original.display()))?;
+    let system = OsSystem::new(&root);
+    let metadata =
+        ProjectMetadata::discover(&root, &system).context("discover ty project metadata")?;
+    let db = ProjectDatabase::use_defaults(metadata, system);
+
+    let file_system_path = SystemPathBuf::from_path_buf(file_path)
+        .map_err(|original| anyhow!("non-UTF-8 source path: {}", original.display()))?;
+    let file = system_path_to_file(&db, &file_system_path).context("resolve file in ty db")?;
+
+    let model = SemanticModel::new(&db, file);
+    let parsed = parsed_module(&db, file).load(&db);
+
+    let mut collector = TypeCollector {
+        db: &db,
+        model: &model,
+        resolved: ResolvedModuleTypes::default(),
+    };
+    collector.collect_stmts(&parsed.syntax().body);
+
+    let resolved = collector.resolved;
+    drop(guard);
+    Ok(resolved)
+}
+
+/// Best-effort temporary directory removal on drop.
+struct TempDirGuard(std::path::PathBuf);
+
+impl Drop for TempDirGuard {
+    fn drop(&mut self) {
+        // Best-effort cleanup; a leftover temp dir is harmless.
+        drop(std::fs::remove_dir_all(&self.0));
+    }
+}
+
+/// Build a unique temporary directory path for one resolution.
+///
+/// The process id plus a monotonic counter keeps concurrent resolutions (and
+/// repeated runs in the same process) from colliding.
+fn unique_temp_dir() -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("smelt-ty-resolve-{pid}-{seq}"))
+}
+
+/// Walks a module's statements, recording `ty`-resolved return/parameter types.
+///
+/// Nested functions and class methods are visited too, so closures/methods
+/// defined inside other definitions are also resolved; but a function's return
+/// type is derived only from the `return` statements in *its own* body, not
+/// those of nested functions (see [`FunctionReturnVisitor`]).
+struct TypeCollector<'a, 'db> {
+    /// `ty` project database used to display resolved types.
+    db: &'db ProjectDatabase,
+    /// `ty` semantic model used to query inferred node types.
+    model: &'a SemanticModel<'db>,
+    /// Accumulated resolved return/parameter type spellings.
+    resolved: ResolvedModuleTypes,
+}
+
+impl TypeCollector<'_, '_> {
+    /// Record every function/method reachable from `stmts`, descending into
+    /// nested function, class, and control-flow blocks.
+    fn collect_stmts(&mut self, stmts: &[Stmt]) {
+        for stmt in stmts {
+            if let Stmt::FunctionDef(func) = stmt {
+                self.record_function(func);
+            }
+            // Recurse into every block child so nested defs/methods are found.
+            self.collect_stmts_of(stmt);
+        }
+    }
+
+    /// Recurse into the block children of one statement, including the bodies
+    /// of nested function/class definitions (unlike [`child_stmts`], which is
+    /// used for a single function's own-return search).
+    fn collect_stmts_of(&mut self, stmt: &Stmt) {
+        match stmt {
+            Stmt::FunctionDef(func) => self.collect_stmts(&func.body),
+            Stmt::ClassDef(class) => self.collect_stmts(&class.body),
+            other => {
+                for child in child_stmts(other) {
+                    if let Stmt::FunctionDef(func) = child {
+                        self.record_function(func);
+                    }
+                    self.collect_stmts_of(child);
+                }
+            }
+        }
+    }
+
+    /// Record `ty`'s resolved parameter and return types for one function.
+    fn record_function(&mut self, func: &StmtFunctionDef) {
+        // Parameters (including `*args` / `**kwargs`): use ty's binding type.
+        // `AnyParameterRef::as_parameter` yields the underlying `Parameter` node
+        // for both variadic and non-variadic parameters, and that node's start
+        // offset is the key the frontend uses to look the type back up.
+        for param in &func.parameters {
+            let parameter = param.as_parameter();
+            if let Some(ty) = parameter.inferred_type(self.model)
+                && let Some(spelling) = displayable_type(self.db, ty)
+            {
+                self.resolved
+                    .param_types
+                    .insert(parameter.start().to_u32(), spelling);
+            }
+        }
+
+        // Return type: union of the inferred types of this body's own
+        // value-returning `return` statements. No such statement => `None`.
+        let mut returns = FunctionReturnVisitor {
+            db: self.db,
+            model: self.model,
+            spellings: Vec::new(),
+        };
+        for statement in &func.body {
+            returns.visit_body_stmt(statement);
+        }
+        if let Some(spelling) = returns.into_return_spelling() {
+            self.resolved
+                .return_types
+                .insert(func.start().to_u32(), spelling);
+        }
+    }
+}
+
+/// Collects the inferred spellings of the value-returning `return` statements
+/// belonging to a single function body.
+///
+/// It deliberately does **not** descend into nested function or lambda bodies:
+/// those returns belong to the inner callable, which is recorded separately by
+/// the enclosing [`TypeCollector`].
+struct FunctionReturnVisitor<'a, 'db> {
+    /// `ty` project database used to display resolved types.
+    db: &'db ProjectDatabase,
+    /// `ty` semantic model used to query inferred expression types.
+    model: &'a SemanticModel<'db>,
+    /// Canonical spellings gathered from each `return <expr>` site, in order.
+    spellings: Vec<String>,
+}
+
+impl<'db> FunctionReturnVisitor<'_, 'db> {
+    /// Visit one statement of the owning function body without crossing into a
+    /// nested function/class scope.
+    fn visit_body_stmt(&mut self, stmt: &'db Stmt) {
+        match stmt {
+            // Do not descend into nested callables: their `return`s are not ours.
+            Stmt::FunctionDef(_) | Stmt::ClassDef(_) => {}
+            Stmt::Return(ret) => {
+                if let Some(value) = ret.value.as_deref() {
+                    if let Some(ty) = value.inferred_type(self.model)
+                        && let Some(spelling) = displayable_type(self.db, ty)
+                    {
+                        self.spellings.push(spelling);
+                    } else {
+                        // A return whose value type we cannot represent makes the
+                        // whole return type unresolved; mark it and stop trusting
+                        // a partial union.
+                        self.spellings.push(UNRESOLVED_MARKER.to_owned());
+                    }
+                } else {
+                    self.spellings.push("None".to_owned());
+                }
+            }
+            other => self.walk_children(other),
+        }
+    }
+
+    /// Recurse into the control-flow children of `stmt` (if/for/while/with/try/
+    /// match blocks) so nested `return`s are found, still without entering a
+    /// nested function scope.
+    fn walk_children(&mut self, stmt: &'db Stmt) {
+        for child in child_stmts(stmt) {
+            self.visit_body_stmt(child);
+        }
+    }
+
+    /// Fold the collected return spellings into one canonical return type, or
+    /// `None` when the function has no value-returning `return` (a bare `pass`
+    /// / fall-through function), or when any return was unrepresentable.
+    fn into_return_spelling(self) -> Option<String> {
+        if self.spellings.is_empty() {
+            // No `return <expr>` at all — the function returns `None`.
+            return Some("None".to_owned());
+        }
+        if self.spellings.iter().any(|s| s == UNRESOLVED_MARKER) {
+            return None;
+        }
+        let mut unique: Vec<String> = Vec::new();
+        for spelling in self.spellings {
+            if !unique.contains(&spelling) {
+                unique.push(spelling);
+            }
+        }
+        if unique.len() == 1 {
+            return unique.into_iter().next();
+        }
+        // Multiple distinct return types → a PEP 604 union spelling, which the
+        // frontend's `annotation_to_hir` already understands.
+        Some(unique.join(" | "))
+    }
+}
+
+/// Sentinel pushed for a `return` whose value type could not be represented.
+const UNRESOLVED_MARKER: &str = "\u{0}unresolved";
+
+/// Return the direct control-flow child statements of `stmt`, excluding the
+/// bodies of nested function/class definitions.
+///
+/// This is a small, explicit traversal (rather than the generic AST visitor)
+/// so it is obvious that lambda/def scopes are never crossed while searching
+/// for a function's own `return` statements.
+fn child_stmts(stmt: &Stmt) -> Vec<&Stmt> {
+    let mut out: Vec<&Stmt> = Vec::new();
+    match stmt {
+        Stmt::If(node) => {
+            out.extend(&node.body);
+            for clause in &node.elif_else_clauses {
+                out.extend(&clause.body);
+            }
+        }
+        Stmt::For(node) => {
+            out.extend(&node.body);
+            out.extend(&node.orelse);
+        }
+        Stmt::While(node) => {
+            out.extend(&node.body);
+            out.extend(&node.orelse);
+        }
+        Stmt::With(node) => out.extend(&node.body),
+        Stmt::Try(node) => {
+            out.extend(&node.body);
+            for handler in &node.handlers {
+                let ruff_python_ast::ExceptHandler::ExceptHandler(except) = handler;
+                out.extend(&except.body);
+            }
+            out.extend(&node.orelse);
+            out.extend(&node.finalbody);
+        }
+        Stmt::Match(node) => {
+            for case in &node.cases {
+                out.extend(&case.body);
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Render `ty`'s resolved `Type` to a canonical Python type spelling, or
+/// `None` if the type is dynamic/unrepresentable and should be left as an
+/// explicit frontend boundary.
+///
+/// Dynamic (`Unknown`/`Any`), `Never`, and other non-value forms are dropped
+/// on purpose: per Smelt's `SmeltUnknown` philosophy, unresolved cases must stay
+/// an explicit boundary rather than be routed through a catch-all. Everything
+/// else is displayed and lightly normalized into the annotation subset the
+/// frontend understands.
+fn displayable_type(db: &ProjectDatabase, ty: Type<'_>) -> Option<String> {
+    // Drop dynamic / bottom types outright: these are genuine boundaries.
+    if matches!(ty, Type::Dynamic(_) | Type::Never | Type::Divergent(_)) {
+        return None;
+    }
+    let spelling = ty.display(db).to_string();
+    normalize_spelling(&spelling)
+}
+
+/// Normalize a `ty` display string into the type-annotation subset the Python
+/// frontend can lower, or reject it (returning `None`) when it clearly falls
+/// outside that subset.
+///
+/// `ty` displays a *value's* narrow type using literal spellings such as
+/// `Literal[3]`, `Literal["hi"]`, or `bool`-narrowed `Literal[True]`. Smelt's
+/// frontend widens those to the underlying primitive, so we do too. Anything
+/// containing `ty`-internal markers (`Unknown`, `@Todo`, `<...>` special
+/// forms) is treated as unresolved.
+fn normalize_spelling(spelling: &str) -> Option<String> {
+    let trimmed = spelling.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Reject clearly-dynamic or ty-internal renderings.
+    if trimmed.contains("Unknown")
+        || trimmed.contains("@Todo")
+        || trimmed.contains('<')
+        || trimmed.contains("Any")
+    {
+        return None;
+    }
+    // Widen literal spellings to their underlying primitive.
+    if let Some(widened) = widen_literal(trimmed) {
+        return Some(widened);
+    }
+    Some(trimmed.to_owned())
+}
+
+/// Widen a `Literal[...]` (or `bool` literal) spelling to its primitive type.
+///
+/// `ty` reports the narrowest type it can prove (`Literal[3]` for the constant
+/// `3`); the frontend's HIR carries primitive types (`int`), so a literal
+/// spelling is widened to the matching primitive. Returns `None` when the
+/// spelling is not a recognized literal form, so the caller keeps it as-is.
+fn widen_literal(spelling: &str) -> Option<String> {
+    let inner = spelling.strip_prefix("Literal[")?.strip_suffix(']')?;
+    // A `Literal[...]` may pack several members (`Literal[1, 2]`); every member
+    // of one literal set shares a base type in practice for our inputs, so key
+    // off the first member's shape.
+    let first = inner.split(',').next()?.trim();
+    let base = if first == "True" || first == "False" {
+        "bool"
+    } else if first.starts_with("b\"") || first.starts_with("b'") {
+        // bytes literal — outside the lowering subset.
+        return None;
+    } else if first.starts_with('"') || first.starts_with('\'') {
+        "str"
+    } else if first.parse::<i128>().is_ok() {
+        "int"
+    } else if first.parse::<f64>().is_ok() {
+        "float"
+    } else {
+        // Enum members and other exotic literals: leave unresolved.
+        return None;
+    };
+    Some(base.to_owned())
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::panic_in_result_fn,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    reason = "tests assert against fixed source and index known-good parse results"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_return_from_body_not_annotation() -> Result<()> {
+        // No return annotation: ty infers `int` from `x + 1`.
+        let resolved = resolve_module_types("def inc(x: int):\n    return x + 1\n", "m")?;
+        let parsed = ruff_python_parser::parse_module("def inc(x: int):\n    return x + 1\n")?;
+        let func = parsed.syntax().body[0].as_function_def_stmt().unwrap();
+        assert_eq!(resolved.return_type_at(func.start()), Some("int"));
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_none_for_valueless_function() -> Result<()> {
+        let resolved = resolve_module_types("def noop():\n    pass\n", "m")?;
+        let parsed = ruff_python_parser::parse_module("def noop():\n    pass\n")?;
+        let func = parsed.syntax().body[0].as_function_def_stmt().unwrap();
+        assert_eq!(resolved.return_type_at(func.start()), Some("None"));
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_parameter_type() -> Result<()> {
+        let src = "def f(x: int, y: str):\n    return x\n";
+        let resolved = resolve_module_types(src, "m")?;
+        let parsed = ruff_python_parser::parse_module(src)?;
+        let func = parsed.syntax().body[0].as_function_def_stmt().unwrap();
+        let x = func.parameters.iter().next().unwrap().as_parameter();
+        assert_eq!(resolved.param_type_at(x.start()), Some("int"));
+        Ok(())
+    }
+
+    #[test]
+    fn widens_literals() {
+        assert_eq!(widen_literal("Literal[3]").as_deref(), Some("int"));
+        assert_eq!(widen_literal("Literal[\"hi\"]").as_deref(), Some("str"));
+        assert_eq!(widen_literal("Literal[True]").as_deref(), Some("bool"));
+        assert_eq!(widen_literal("int"), None);
+    }
+
+    #[test]
+    fn rejects_dynamic_spellings() {
+        assert_eq!(normalize_spelling("Unknown"), None);
+        assert_eq!(normalize_spelling("int | Unknown"), None);
+        assert_eq!(normalize_spelling("int"), Some("int".to_owned()));
+        assert_eq!(normalize_spelling("str | None"), Some("str | None".to_owned()));
+    }
+}

--- a/specs/python-type-checking-with-ty.md
+++ b/specs/python-type-checking-with-ty.md
@@ -1,7 +1,12 @@
 # Spike: using Astral's `ty` as Smelt's Python type source
 
-**Status:** feasibility spike (branch `claude/python-ty-spike`, crate
-`crates/smelt-py-ty-spike`). Not wired into the real frontend yet.
+**Status:** productionized for **function/method return-type resolution**
+(issue #93). The spike below proved feasibility; the working integration now
+lives in `crates/smelt-py-types` and is consumed by `smelt-frontend-py` behind
+its optional `ty` feature. See "Productionization (issue #93)" at the end.
+
+The original spike crate `crates/smelt-py-ty-spike` is retained as the minimal
+feasibility harness.
 
 ## Motivation
 
@@ -216,3 +221,62 @@ Two things jump out:
 - The earlier "only return-type mismatches, promising!" was an artifact of
   testing one tiny dependency-free library; full apps need deps resolved before
   any conclusion about ty's accuracy holds.
+
+## Productionization (issue #93)
+
+The spike is now productionized as a focused, opt-in increment: **`ty`-backed
+return-type resolution** for functions and methods.
+
+### Crates & wiring
+
+- **`crates/smelt-py-types`** — owns the heavy `ty` dependency tree (salsa +
+  vendored typeshed) and exposes one small, stable API:
+  `resolve_module_types(source, stem) -> ResolvedModuleTypes`. It runs `ty` over
+  the source (materialized into a temp dir + `OsSystem`, exactly as the spike
+  proved works) and returns, keyed by **AST byte offset**, canonical Python
+  type *spellings* (`"int"`, `"list[int]"`, `"str | None"`). It deliberately
+  does **not** leak `ty`'s internal `Type` lattice (almost all `pub(crate)` and
+  unstable) — it hands the frontend strings, which the frontend's existing
+  `annotation_to_hir` already parses. Kept **out of `default-members`** so lean
+  builds never pay for `ty`.
+- **`smelt-frontend-py`** — new optional `ty` feature (`dep:smelt-py-types`).
+  The `ty_resolve` module is a `#[cfg]` seam presenting the same API with or
+  without the feature (a zero-cost stub when off). At each former
+  "must have an explicit ... annotation" site, lowering now consults the
+  resolver; only genuinely unresolved cases fall through to the (unchanged)
+  error. `smelt-codegen-rust` and `smelt-cli` forward the feature.
+
+### What it resolves — and the actual-vs-declared rule
+
+- **Return types** (the dominant blocker: ~389 function + ~162 method
+  annotations): derived from `ty`'s inferred types of the body's own
+  `return <expr>` statements (unioned; `None` for a valueless function). This is
+  the *actual returned* type. When a declared `-> T` annotation is present but
+  diverges from `ty`'s inferred return, lowering **prefers `ty`'s inferred
+  type**, per issue #93 (the annotation may be stale/wider/narrower).
+- Literal narrowings are widened to primitives (`Literal[3]` → `int`), matching
+  the frontend's HIR. Dynamic/`Unknown`/`Never`/`@Todo`/special-form spellings
+  are dropped so the case stays an **explicit boundary** — never a blanket
+  `SmeltUnknown`.
+
+### Deferred (documented follow-ups)
+
+- **Parameter inference.** `ty` reports an *unannotated* parameter as
+  dynamic/`Unknown` (it does not infer a param's type from a default value or
+  from call sites), so an unannotated parameter still requires a source
+  annotation. The plumbing to consume a resolved param type exists
+  (`resolved_param_ty`), so annotated/derivable params benefit, but the raw
+  "parameter must have an explicit type annotation" blocker (~8-15 occ) is not
+  removed by inference here.
+- **Nested closure** return/param resolution (`statement.rs`) is unchanged.
+- **Cross-module / third-party dep resolution.** As the spike notes, `ty` needs
+  the project's own modules + installed deps to resolve non-stdlib types;
+  isolated single-file resolution (what the frontend does today) leaves those as
+  boundaries. This mirrors the existing "probe lowers files in isolation"
+  caveat.
+
+### Build note
+
+The `ty` tree is large (first build ~3 min in this environment; cached
+afterwards). It is only compiled when a crate is built with `--features ty`
+(CI probes, the compile corpus's Python case, and an explicitly ty-built CLI).


### PR DESCRIPTION
Part of #93.

Replaces the hard **"function/method must have an explicit return type annotation"** errors, for `ty`-resolvable cases, with types inferred by Astral's **`ty`** — using `ty`, not a custom inference engine.

## What landed

- **New crate `smelt-py-types`** embeds `ty` as a library (owning the heavy salsa + vendored-typeshed tree) and exposes one small, stable API: `resolve_module_types(source, stem) -> ResolvedModuleTypes`, returning canonical Python type *spellings* (`int`, `list[int]`, `str | None`) keyed by AST byte offset. It does **not** leak `ty`'s internal (mostly `pub(crate)`, unstable) `Type` lattice — the frontend re-parses the spellings through its existing `annotation_to_hir`, insulating the workspace from `ty`'s API churn. Kept **out of `default-members`** (like the existing spike) so lean builds never pull the `ty` tree.
- **`smelt-frontend-py`** gains an optional **`ty` feature** (default OFF). A `ty_resolve` `#[cfg]` seam presents the same API with or without the feature (zero-cost stub when off). Each former annotation-error site now consults the resolver first and only errors when `ty` resolves nothing.
- **Actual-vs-declared rule (issue #93):** return types follow the *actual returned* type — the union of the body's own `return <expr>` inferred types (`None` for a valueless function). When a declared `-> T` diverges from `ty`'s inferred return, `ty`'s is preferred. Literals widen to primitives (`Literal[3]` → `int`); dynamic/`Unknown`/`Never` stays an **explicit boundary**, never a blanket `SmeltUnknown`.
- `smelt-codegen-rust` and `smelt-cli` forward the `ty` feature.

## Did ty integration work in this environment?

**Yes.** The `ty` crates build here (~3 min cold, cached after) and resolve types at runtime. Verified end to end: an annotation-free Python program lowers via `ty` and its emitted Rust `cargo check`s.

## Scope covered vs deferred

**Covered:** function + method **return-type** resolution — the dominant blocker family (~389 function + ~162 method annotations in the probes).

**Deferred (documented in `specs/python-type-checking-with-ty.md`):**
- **Unannotated-parameter inference** — `ty` reports an unannotated parameter as dynamic/`Unknown` (it does not infer from defaults or call sites), so those still require a source annotation. The consume-a-resolved-param-type plumbing exists (`resolved_param_ty`) for annotated/derivable params.
- Nested-closure resolution (`statement.rs`) and cross-module/third-party dep resolution (isolated single-file resolution mirrors the existing "probe lowers files in isolation" caveat).

## Tests

- `smelt-py-types`: unit tests for `ty` resolution + spelling normalization/widening.
- `smelt-frontend-py`: new feature-gated `ty_resolution_tests` (return inference, `None`, method, annotation-divergence). Missing-annotation tests gated to non-`ty` builds; both configs green (163 default / 165 with `ty`).
- **Compile-corpus case** `py_inferred_returns`: annotation-free Python that lowers via `ty` and whose emitted Rust `cargo check`s (`--features ty -- --ignored`).

## Verification (touched crates only, per instructions)

- `cargo check` + `cargo clippy` clean on `smelt-py-types`, `smelt-frontend-py` (both configs), `smelt-codegen-rust`.
- My own tests + the single Python compile-corpus case pass. Full `cargo test`, the remeda gate, and the library probes are left to central integration (the probe delta should be reported there, since probe lowers files in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)