### PR TITLE
python-frontend: try/except, lambda expressions, and class-body placeholders

### DIFF
--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -912,13 +912,14 @@ fn emit_case_crate(case: &Case, crate_dir: &Path) -> Result<(), String> {
 /// the program lowers and compiles.
 #[cfg(feature = "ty")]
 fn python_corpus() -> Vec<Case> {
-    vec![Case {
-        name: "py_inferred_returns",
-        area: "py_ty_return_inference",
-        // No function carries a `-> T`; `ty` infers int/str/bool from the
-        // bodies. Parameters keep annotations (unannotated params stay an
-        // explicit boundary — a documented deferral).
-        source: r"
+    vec![
+        Case {
+            name: "py_inferred_returns",
+            area: "py_ty_return_inference",
+            // No function carries a `-> T`; `ty` infers int/str/bool from the
+            // bodies. Parameters keep annotations (unannotated params stay an
+            // explicit boundary — a documented deferral).
+            source: r"
 def inc(x: int):
     return x + 1
 
@@ -934,7 +935,34 @@ def total(values: list[int]):
         result = result + value
     return result
 ",
-    }]
+        },
+        Case {
+            name: "py_lang_features",
+            area: "py_try_lambda_classbody",
+            // Issue #95: try/except/finally lowers to TryCatch, a lambda call
+            // argument recovers its `Callable[...]` type and lowers to a
+            // closure, and a class-body `...` placeholder is a no-op.
+            source: r#"
+from typing import Callable
+
+class Marker:
+    """A placeholder class."""
+    ...
+
+def apply(f: Callable[[int], int], value: int) -> int:
+    return f(value)
+
+def guarded(value: int) -> int:
+    try:
+        return apply(lambda x: x + 1, value)
+    except ValueError as error:
+        print(error)
+        return 0
+    finally:
+        print("done")
+"#,
+        },
+    ]
 }
 
 /// Lowers a Python corpus `case` through the real Python pipeline (with `ty`

--- a/crates/smelt-frontend-py/src/lowering.rs
+++ b/crates/smelt-frontend-py/src/lowering.rs
@@ -12,10 +12,10 @@ use std::convert::TryFrom;
 use std::path::Path;
 
 use ruff_python_ast::{
-    BoolOp, CmpOp, ElifElseClause, Expr, ModModule, Number, Operator, Pattern as RuffPattern,
-    PatternMatchAs, Singleton, Stmt, StmtAnnAssign, StmtAssert, StmtAssign, StmtAugAssign,
-    StmtClassDef, StmtFor, StmtFunctionDef, StmtIf, StmtImport, StmtImportFrom, StmtMatch, StmtWith,
-    UnaryOp as RuffUnaryOp,
+    BoolOp, CmpOp, ElifElseClause, ExceptHandler, Expr, ModModule, Number, Operator,
+    Pattern as RuffPattern, PatternMatchAs, Singleton, Stmt, StmtAnnAssign, StmtAssert, StmtAssign,
+    StmtAugAssign, StmtClassDef, StmtFor, StmtFunctionDef, StmtIf, StmtImport, StmtImportFrom,
+    StmtMatch, StmtTry, StmtWith, UnaryOp as RuffUnaryOp,
 };
 use ruff_text_size::{Ranged, TextRange};
 use smelt_hir::{

--- a/crates/smelt-frontend-py/src/lowering/call.rs
+++ b/crates/smelt-frontend-py/src/lowering/call.rs
@@ -519,12 +519,20 @@ impl ModuleBuilder<'_> {
                 ),
             ));
         }
+        // Positional arguments are lowered with the corresponding parameter
+        // type as an expected-type hint. This is what lets a `lambda` argument
+        // recover its parameter/return types from a `Callable[...]` parameter
+        // (a bare lambda has no annotations of its own); it is otherwise inert
+        // because the argument type is re-checked against the parameter below.
         let mut args = call
             .arguments
             .args
             .iter()
             .take(packed_param_start)
-            .map(|arg| self.expression(arg, body))
+            .enumerate()
+            .map(|(index, arg)| {
+                self.expression_with_hint(arg, body, signature.params.get(index).copied())
+            })
             .collect::<Result<Vec<_>, _>>()?;
         for index in supplied_arg_count..packed_param_start {
             let Some(default) = signature.defaults.get(index).and_then(|default| *default) else {

--- a/crates/smelt-frontend-py/src/lowering/class.rs
+++ b/crates/smelt-frontend-py/src/lowering/class.rs
@@ -369,9 +369,17 @@ impl ModuleBuilder<'_> {
                     }
                 }
                 Stmt::Pass(_) => {}
-                // Docstring (bare string literal as Expr statement)
+                // A bare expression statement in a class body carries no runtime
+                // member. Two shapes are accepted as no-ops (matching how `pass`
+                // is skipped): a docstring (`"""..."""`) and an ellipsis body
+                // (`...`), the latter being the common Protocol/stub placeholder.
+                // Any other bare expression would have an observable effect that
+                // the class model cannot represent, so it stays rejected.
                 Stmt::Expr(e) => {
-                    if !matches!(e.value.as_ref(), Expr::StringLiteral(_)) {
+                    if !matches!(
+                        e.value.as_ref(),
+                        Expr::StringLiteral(_) | Expr::EllipsisLiteral(_)
+                    ) {
                         return Err(SmeltError::unsupported(
                             self.span(e.range),
                             format!("class '{class_name_str}': unsupported class body statement"),

--- a/crates/smelt-frontend-py/src/lowering/literals.rs
+++ b/crates/smelt-frontend-py/src/lowering/literals.rs
@@ -275,8 +275,12 @@ impl ModuleBuilder<'_> {
             Expr::DictComp(c) => self.dict_comprehension(c, body),
             Expr::Generator(c) => self.generator_expression(c, body),
 
+            // `lambda a, b: expr` — a first-class closure value. Parameter types
+            // come from an expected `Callable`/function `type_hint`; without one
+            // the parameters must be individually annotated.
+            Expr::Lambda(lambda) => self.lambda_expression(lambda, body, type_hint),
+
             Expr::Named(_)
-            | Expr::Lambda(_)
             | Expr::Yield(_)
             | Expr::YieldFrom(_)
             | Expr::TString(_)
@@ -289,6 +293,53 @@ impl ModuleBuilder<'_> {
                 format!("unsupported expression: {}", expr_kind_name(expr)),
             )),
         }
+    }
+
+    /// Lower a Python `lambda` expression as a first-class closure value.
+    ///
+    /// A lambda is lowered through the same compact callback IR the frontend
+    /// already uses for `map`/`filter`/`sorted(key=...)` lambdas: the body is
+    /// classified into a [`CallbackExpr`] tree by [`Self::lambda_callback`], then
+    /// materialized into a real [`ExprKind::Closure`] CFG body by
+    /// [`Self::callback_expr_to_closure`]. The resulting closure value can be
+    /// stored in a local, passed to a call argument, or returned.
+    ///
+    /// Python lambda parameters never carry type annotations, so their types can
+    /// only come from an expected `Callable[...]`/function `type_hint` supplied
+    /// by the surrounding context (an annotated assignment, an annotated call
+    /// parameter, a typed return). When no function-typed hint is available the
+    /// lambda's parameter types are unknowable and the construct is rejected with
+    /// a specific message rather than routed through an erased ABI — keeping the
+    /// static-shape-first policy. (Bare `x = lambda ...` without an annotation is
+    /// the documented deferral; annotate the target with `Callable[...]`.)
+    fn lambda_expression(
+        &mut self,
+        lambda: &ruff_python_ast::ExprLambda,
+        body: &mut Body,
+        type_hint: Option<TypeId>,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let Some(hint) = type_hint else {
+            return Err(SmeltError::unsupported(
+                self.span(lambda.range),
+                "lambda expressions need an expected `Callable[...]` type from their context \
+                 (annotate the assignment target or call parameter)",
+            ));
+        };
+        let Some(Type::Function(function)) = self.ctx.krate.types.get(hint).cloned() else {
+            return Err(SmeltError::unsupported(
+                self.span(lambda.range),
+                "lambda expressions require a `Callable[...]`/function-typed context",
+            ));
+        };
+
+        let callback = self.lambda_callback(lambda, &function.params, body)?;
+        if callback.ty != function.return_ty {
+            return Err(SmeltError::unsupported(
+                self.span(lambda.range),
+                "lambda return type does not match its expected callable annotation",
+            ));
+        }
+        self.callback_expr_to_closure(&callback, &function.params, self.span(lambda.range), body)
     }
 
     /// Lower a Python f-string (`f"a{expr}b"`) as runtime string concatenation.

--- a/crates/smelt-frontend-py/src/lowering/statement.rs
+++ b/crates/smelt-frontend-py/src/lowering/statement.rs
@@ -185,8 +185,10 @@ impl ModuleBuilder<'_> {
             // `del target[, target]...` — currently only `del dict[key]` is lowered.
             Stmt::Delete(delete_stmt) => self.delete_statement(delete_stmt, body, block),
 
+            // `try: … except …: … else: … finally: …`
+            Stmt::Try(try_stmt) => self.try_statement(try_stmt, body, block),
+
             Stmt::TypeAlias(_)
-            | Stmt::Try(_)
             | Stmt::Global(_)
             | Stmt::Nonlocal(_)
             | Stmt::IpyEscapeCommand(_) => Err(SmeltError::unsupported(
@@ -194,6 +196,112 @@ impl ModuleBuilder<'_> {
                 format!("unsupported statement: {}", stmt_kind_name(stmt)),
             )),
         }
+    }
+
+    /// Lower a Python `try/except/finally` statement to [`HirStmt::TryCatch`].
+    ///
+    /// The mapping onto Smelt's error model (a thrown value is a string message,
+    /// mirroring the pytest.raises lowering and the TypeScript `try`/`catch`
+    /// lowering) is:
+    ///
+    /// * The `try:` suite becomes the protected `body` block. A trailing
+    ///   `else:` suite (which Python runs only when the `try` body did not
+    ///   raise) is appended to the end of that same block — semantically the
+    ///   no-exception continuation.
+    /// * A single `except [E [as name]]:` handler becomes the `catch_body`
+    ///   block. When the handler binds `as name`, a fresh string local named
+    ///   `name` is introduced as the `catch_binding` so the handler body can
+    ///   reference the caught message.
+    /// * A `finally:` suite becomes the `finally_body` block.
+    ///
+    /// Smelt's HIR models a single catch handler, so shapes that need
+    /// per-exception-type dispatch are rejected with a specific message rather
+    /// than silently collapsing distinct handlers: multiple `except` clauses and
+    /// `except*` (exception groups) remain explicit deferrals. Filtering on the
+    /// caught exception *type* is likewise not modelled — every handler catches
+    /// all thrown values — so the exception type expression is accepted but does
+    /// not narrow the catch, matching how the rest of the error model treats
+    /// thrown values as opaque strings.
+    fn try_statement(
+        &mut self,
+        try_stmt: &StmtTry,
+        body: &mut Body,
+        block: smelt_hir::BlockId,
+    ) -> Result<(), SmeltError> {
+        if try_stmt.is_star {
+            return Err(SmeltError::unsupported(
+                self.span(try_stmt.range),
+                "`except*` exception groups are not supported",
+            ));
+        }
+        if try_stmt.handlers.len() > 1 {
+            return Err(SmeltError::unsupported(
+                self.span(try_stmt.range),
+                "multiple `except` clauses are not supported; Smelt models a single catch handler",
+            ));
+        }
+
+        // The protected block holds the `try:` suite followed by any `else:`
+        // suite (the else suite only runs when the try suite did not raise, so
+        // appending it to the same block keeps that ordering).
+        let try_block = self.block_from_stmts(&try_stmt.body, body)?;
+        for stmt in &try_stmt.orelse {
+            self.statement_in_block(stmt, body, try_block)?;
+        }
+
+        // At most one handler reaches here (the multi-handler case is rejected
+        // above), so lowering the first handler covers every accepted shape.
+        let (catch_binding, catch_body) = match try_stmt.handlers.first() {
+            None => (None, None),
+            Some(ExceptHandler::ExceptHandler(handler)) => {
+                // Bindings and body locals introduced by the handler must not
+                // leak into the surrounding scope, matching the TypeScript
+                // `catch` lowering.
+                let previous_locals = self.locals.clone();
+                let catch_binding = handler
+                    .name
+                    .as_ref()
+                    .map(|name| self.except_binding(name.as_str(), name.range, body));
+                let catch_block = self.block_from_stmts(&handler.body, body)?;
+                self.locals = previous_locals;
+                (catch_binding, Some(catch_block))
+            }
+        };
+
+        let finally_body = if try_stmt.finalbody.is_empty() {
+            None
+        } else {
+            Some(self.block_from_stmts(&try_stmt.finalbody, body)?)
+        };
+
+        body.push_stmt_to_block(
+            block,
+            HirStmt::TryCatch {
+                body: try_block,
+                catch_binding,
+                catch_body,
+                finally_body,
+            },
+        );
+        Ok(())
+    }
+
+    /// Introduce the `except … as name` binding as a fresh string local.
+    ///
+    /// Smelt's error model represents a thrown value as a string message (see
+    /// the pytest.raises lowering), so the caught exception name is bound to a
+    /// `String` local and registered in the local scope for the handler body.
+    fn except_binding(&mut self, name: &str, range: TextRange, body: &mut Body) -> smelt_hir::LocalId {
+        let ty = self.intern_type(Type::String);
+        let symbol = self.intern_name(name);
+        let local = body.push_local(LocalDecl {
+            name: Some(symbol),
+            ty,
+            mutable: false,
+            span: self.span(range),
+        });
+        self.locals.insert(name.to_owned(), local);
+        local
     }
 
     /// Lower a Python `del target[, target]...` statement.

--- a/crates/smelt-frontend-py/src/tests/lang_features_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/lang_features_tests.rs
@@ -1,0 +1,269 @@
+//! Regression tests for issue #95 Python language-feature lowering:
+//! `try`/`except`/`finally`, `lambda` expressions, and additional class-body
+//! statements.
+
+use super::*;
+
+/// Return the lowered body of the named top-level function in `module`.
+fn named_function_body<'a>(
+    ctx: &'a HirCtx,
+    module: &Module,
+    name: &str,
+) -> Result<&'a Body, String> {
+    for &item_id in &module.items {
+        if let Item::Function(function) = item(ctx, item_id)?
+            && symbol(ctx, function.name)? == name
+        {
+            return body(ctx, function.body.ok_or("expected a function body")?);
+        }
+    }
+    Err(format!("no top-level function named `{name}`"))
+}
+
+#[test]
+fn try_except_lowers_to_try_catch() -> TestResult {
+    let source = py!(r#"
+def risky() -> int:
+    return 1
+
+def run() -> int:
+    try:
+        return risky()
+    except ValueError:
+        return 0
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let function_body = named_function_body(&ctx, module, "run")?;
+    ensure(
+        function_body
+            .stmts
+            .iter()
+            .any(|stmt| matches!(stmt, Stmt::TryCatch { catch_body: Some(_), .. })),
+        "expected try/except to lower to a TryCatch with a catch body",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn try_except_binding_is_visible_in_handler() -> TestResult {
+    let source = py!(r#"
+def risky() -> str:
+    return "ok"
+
+def describe() -> str:
+    try:
+        return risky()
+    except ValueError as error:
+        return error
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let function_body = named_function_body(&ctx, module, "describe")?;
+    let has_binding = function_body.stmts.iter().any(|stmt| {
+        matches!(
+            stmt,
+            Stmt::TryCatch {
+                catch_binding: Some(_),
+                catch_body: Some(_),
+                ..
+            }
+        )
+    });
+    ensure(has_binding, "expected `except ... as error` to bind a catch local")?;
+    Ok(())
+}
+
+#[test]
+fn try_finally_lowers_finally_block() -> TestResult {
+    let source = py!(r#"
+def risky() -> int:
+    return 1
+
+def note() -> None:
+    print("done")
+
+def cleanup() -> int:
+    try:
+        return risky()
+    finally:
+        note()
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let function_body = named_function_body(&ctx, module, "cleanup")?;
+    ensure(
+        function_body.stmts.iter().any(|stmt| {
+            matches!(
+                stmt,
+                Stmt::TryCatch {
+                    catch_body: None,
+                    finally_body: Some(_),
+                    ..
+                }
+            )
+        }),
+        "expected try/finally to lower to a TryCatch with a finally body and no catch",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn try_except_else_appends_else_to_try_body() -> TestResult {
+    let source = py!(r#"
+def risky() -> int:
+    return 1
+
+def choose() -> int:
+    value: int = 0
+    try:
+        value = risky()
+    except ValueError:
+        return 0
+    else:
+        return value
+    return -1
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let function_body = named_function_body(&ctx, module, "choose")?;
+    ensure(
+        function_body
+            .stmts
+            .iter()
+            .any(|stmt| matches!(stmt, Stmt::TryCatch { .. })),
+        "expected try/except/else to lower to a TryCatch",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn multiple_except_clauses_are_rejected() -> TestResult {
+    let source = py!(r#"
+def run() -> int:
+    try:
+        return risky()
+    except ValueError:
+        return 0
+    except KeyError:
+        return 1
+
+def risky() -> int:
+    return 1
+"#);
+    let mut ctx = HirCtx::new();
+    let errors = lower_errors(source, &mut ctx)?;
+    ensure(
+        first_error(&errors)?.message.contains("multiple `except`"),
+        "expected multiple except clauses to be rejected with a specific message",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn except_star_is_rejected() -> TestResult {
+    let source = py!(r#"
+def run() -> int:
+    try:
+        return risky()
+    except* ValueError:
+        return 0
+
+def risky() -> int:
+    return 1
+"#);
+    let mut ctx = HirCtx::new();
+    let errors = lower_errors(source, &mut ctx)?;
+    ensure(
+        first_error(&errors)?.message.contains("except*"),
+        "expected `except*` to be rejected with a specific message",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn lambda_call_argument_lowers_to_closure() -> TestResult {
+    let source = py!(r#"
+from typing import Callable
+
+def apply(f: Callable[[int], int], value: int) -> int:
+    return f(value)
+
+def run() -> int:
+    return apply(lambda x: x + 1, 10)
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    // The lambda argument to `apply` recovers its `Callable[[int], int]` type
+    // from the parameter hint and materializes a first-class closure value.
+    let has_closure = ctx
+        .krate
+        .bodies
+        .iter()
+        .any(|b| b.exprs.iter().any(|expr| matches!(expr.kind, ExprKind::Closure(_))));
+    ensure(has_closure, "expected the lambda argument to lower to a closure")?;
+    let _ = module;
+    Ok(())
+}
+
+#[test]
+fn bare_lambda_without_hint_is_rejected_with_actionable_message() -> TestResult {
+    // Without a `Callable[...]` context the parameter types are unknowable.
+    // The lambda must be rejected with a specific, actionable message rather
+    // than the generic "unsupported expression: lambda".
+    let source = py!(r#"
+def run() -> int:
+    handlers = [lambda x: x]
+    return 0
+"#);
+    let mut ctx = HirCtx::new();
+    let errors = lower_errors(source, &mut ctx)?;
+    let message = &first_error(&errors)?.message;
+    ensure(
+        message.contains("lambda") && message.contains("Callable"),
+        "expected a hint-less lambda to be rejected with a Callable-oriented message",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn class_body_ellipsis_is_a_no_op() -> TestResult {
+    let source = py!(r#"
+class Marker:
+    ...
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    ensure(
+        module.items.iter().any(|&item_id| {
+            matches!(item(&ctx, item_id), Ok(Item::Class(_)))
+        }),
+        "expected a class-body `...` placeholder to lower to a class",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn class_body_docstring_and_ellipsis_together_lower() -> TestResult {
+    let source = py!(r#"
+class Doc:
+    """A documented placeholder."""
+    ...
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    ensure(
+        module.items.iter().any(|&item_id| {
+            matches!(item(&ctx, item_id), Ok(Item::Class(_)))
+        }),
+        "expected a docstring + `...` class body to lower to a class",
+    )?;
+    Ok(())
+}

--- a/crates/smelt-frontend-py/src/tests/mod.rs
+++ b/crates/smelt-frontend-py/src/tests/mod.rs
@@ -152,6 +152,7 @@ mod collections_a_tests;
 mod collections_b_tests;
 mod collections_reject_a_tests;
 mod collections_reject_b_tests;
+mod lang_features_tests;
 mod packages_tests;
 mod pytest_tests;
 mod specialization_tests;


### PR DESCRIPTION
## Summary

Part of #95. Lands the general Python language-feature gaps that were the highest-frequency probe blockers, keeping the rest as documented follow-ups.

### try / except / finally
Lowers to the existing `HirStmt::TryCatch` node (already used by the `pytest.raises` and TypeScript `try`/`catch` lowerings, and wired through MIR and the Rust emitter):
- `try:` suite becomes the protected block; a trailing `else:` suite is appended to it (its no-exception continuation).
- `except [E [as name]]:` becomes the catch block; `as name` binds a string catch local (matching the error model where a thrown value is a string message).
- `finally:` becomes the finally block.
- Multiple `except` clauses and `except*` groups stay explicit deferrals (HIR models a single catch handler), rejected with specific messages rather than silently collapsing distinct handlers or narrowing on exception type.

### lambda expressions
Lower to first-class closures through the existing compact callback IR (`lambda_callback` → `callback_expr_to_closure`). Python lambda params carry no annotations, so parameter types come from an expected `Callable[...]` context. Call arguments now thread the parameter type as an expected-type hint, so `f(lambda x: ...)` recovers its signature from `f`'s `Callable[...]` parameter. A hint-less lambda is rejected with an actionable `Callable`-oriented message instead of the generic "unsupported expression: lambda".

### class-body statements
Class bodies now accept an ellipsis (`...`) placeholder as a no-op alongside the existing docstring case — the common Protocol/stub shape.

## Tests
- New `tests/lang_features_tests.rs`: try/except → TryCatch, `except … as` binding, try/finally, try/except/else, multi-`except` rejection, `except*` rejection, lambda-as-argument → closure, hint-less-lambda rejection, class-body `...` no-op. All 176 frontend-py lib tests pass.
- New Python compile-corpus case `py_lang_features` exercising all three features; its emitted Rust type-checks (`cargo test -p smelt-codegen-rust --test compile_corpus --features ty -- --ignored`, verified via `SMELT_CORPUS_ONLY`).
- `cargo check` + `cargo clippy` clean on `smelt-frontend-py` (lib). Pre-existing clippy findings in untouched test files (`basic_tests.rs`, `builtins_sets_tests.rs`) are unrelated to this change.

## Deferred (per issue)
Nested classes, multiple inheritance, and unsupported decorators remain separable follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)