### PR TITLE
python-frontend: lower method and non-top-level calls (issue #94)

### DIFF
--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -912,13 +912,14 @@ fn emit_case_crate(case: &Case, crate_dir: &Path) -> Result<(), String> {
 /// the program lowers and compiles.
 #[cfg(feature = "ty")]
 fn python_corpus() -> Vec<Case> {
-    vec![Case {
-        name: "py_inferred_returns",
-        area: "py_ty_return_inference",
-        // No function carries a `-> T`; `ty` infers int/str/bool from the
-        // bodies. Parameters keep annotations (unannotated params stay an
-        // explicit boundary — a documented deferral).
-        source: r"
+    vec![
+        Case {
+            name: "py_inferred_returns",
+            area: "py_ty_return_inference",
+            // No function carries a `-> T`; `ty` infers int/str/bool from the
+            // bodies. Parameters keep annotations (unannotated params stay an
+            // explicit boundary — a documented deferral).
+            source: r"
 def inc(x: int):
     return x + 1
 
@@ -934,7 +935,52 @@ def total(values: list[int]):
         result = result + value
     return result
 ",
-    }]
+        },
+        Case {
+            // Issue #94: method and non-top-level calls. `Counter.total`
+            // (instance method) calls `self.doubled()`, a sibling declared
+            // *later* in the class body — resolvable only because method items
+            // are pre-registered before any body is lowered. `Counter.make` is a
+            // `@classmethod` that constructs the class through the implicit `cls`
+            // receiver (`cls(start)`) and calls the sibling `@staticmethod`
+            // `origin()` via `cls.origin()`. `use_counter` drives an instance
+            // method on a local, and `via_factory` calls the classmethod
+            // qualified (`Counter.make(..)`). Every dispatch must lower to the
+            // right shape (receiver method vs receiver-free associated call) and
+            // the emitted Rust must compile.
+            name: "py_method_calls",
+            area: "py_method_dispatch",
+            source: r#"
+class Counter:
+    value: int
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def total(self) -> int:
+        return self.doubled() + Counter.origin()
+
+    def doubled(self) -> int:
+        return self.value * 2
+
+    @classmethod
+    def make(cls, start: int) -> "Counter":
+        base = cls(start)
+        return cls(base.value + cls.origin())
+
+    @staticmethod
+    def origin() -> int:
+        return 0
+
+def use_counter(start: int) -> int:
+    counter = Counter(start)
+    return counter.total()
+
+def via_factory(start: int) -> int:
+    return Counter.make(start).total()
+"#,
+        },
+    ]
 }
 
 /// Lowers a Python corpus `case` through the real Python pipeline (with `ty`

--- a/crates/smelt-frontend-py/src/lowering.rs
+++ b/crates/smelt-frontend-py/src/lowering.rs
@@ -66,8 +66,20 @@ pub(crate) struct ModuleBuilder<'ctx> {
     exports: HashMap<String, ItemId>,
     /// Integer enum members keyed by class name, then member name.
     enum_members: HashMap<String, HashMap<String, i64>>,
-    /// Class method items keyed by class name, then method name.
+    /// Instance-method items keyed by class name, then method name.
+    ///
+    /// Populated by a per-class pre-pass ([`Self::reserve_class_method_slots`])
+    /// *before* any method body is lowered, so a method that calls an instance
+    /// sibling declared later (`self.helper()`) can still resolve it.
     class_methods: HashMap<String, HashMap<String, ItemId>>,
+    /// Class `@staticmethod` and `@classmethod` items keyed by class name, then
+    /// method name.
+    ///
+    /// Both dispatch receiver-free (`Class::method(args)`), so they are kept
+    /// separate from the instance-method [`Self::class_methods`] registry. This
+    /// also lets a forward `cls.helper()` / `Class.helper()` call resolve the
+    /// method before the class item's `static_methods` field is finalized.
+    class_static_methods: HashMap<String, HashMap<String, ItemId>>,
     /// Class fields keyed by class name while a class body is being lowered.
     class_fields: HashMap<String, Vec<Field>>,
     /// Imported module/package namespaces available by local module name.
@@ -215,6 +227,7 @@ impl<'ctx> ModuleBuilder<'ctx> {
         let items = visible_items(ctx);
         let enum_members = ctx.enum_members.clone();
         let class_methods = visible_class_methods(ctx);
+        let class_static_methods = visible_class_static_methods(ctx);
         let module_namespaces = ctx.module_namespaces.clone();
         Self {
             file_id,
@@ -226,6 +239,7 @@ impl<'ctx> ModuleBuilder<'ctx> {
             exports: HashMap::new(),
             enum_members,
             class_methods,
+            class_static_methods,
             class_fields: HashMap::new(),
             module_namespaces,
             pytest_fixtures: HashMap::new(),

--- a/crates/smelt-frontend-py/src/lowering/call.rs
+++ b/crates/smelt-frontend-py/src/lowering/call.rs
@@ -23,6 +23,9 @@ impl ModuleBuilder<'_> {
         if let Some(error) = self.unsupported_deferred_stdlib_call(call) {
             return Err(error);
         }
+        if let Some(expr) = self.cls_receiver_call_expression(call, body)? {
+            return Ok(expr);
+        }
         if let Some(expr) = self.protocol_call_expression(call, body)? {
             return Ok(expr);
         }
@@ -640,9 +643,20 @@ impl ModuleBuilder<'_> {
 
     /// Lower calls to statically-known Python protocol/class methods.
     ///
-    /// The dispatch remains intentionally static: the receiver's HIR type must
-    /// be a known class and the method must be declared on that class.  `str(x)`
-    /// is mapped to `x.__str__()` for class values that provide `__str__`.
+    /// The receiver's HIR type must be a known class and the method must be
+    /// declared on that class. Dispatch stays static and mirrors Python method
+    /// binding:
+    ///
+    /// * instance methods lower to [`ExprKind::Method`] (`receiver.method(..)`);
+    /// * `@classmethod` / `@staticmethod` members lower to a receiver-free
+    ///   associated call [`ExprKind::Call`] (`Class::method(..)`), because the
+    ///   implicit `cls` (or no receiver) is erased in the lowered signature.
+    ///
+    /// Because Python's `cls`/`self`/instance bindings all carry the same
+    /// `Type::Class` HIR type, whether the method dispatches receiver-free is
+    /// decided by the *method kind* (looked up in the classmethod/staticmethod
+    /// registries), not by the receiver expression. `str(x)` is mapped to
+    /// `x.__str__()` for class values that provide `__str__`.
     fn protocol_call_expression(
         &mut self,
         call: &ruff_python_ast::ExprCall,
@@ -654,7 +668,10 @@ impl ModuleBuilder<'_> {
             && call.arguments.keywords.is_empty()
         {
             let receiver = self.expression(&call.arguments.args[0], body)?;
-            if self.class_has_method(Self::expr_ty(body, receiver), "__str__") {
+            if self
+                .class_method_dispatch(Self::expr_ty(body, receiver), "__str__")
+                .is_some()
+            {
                 return self
                     .protocol_method_expr(
                         ProtocolMethodCall {
@@ -681,7 +698,7 @@ impl ModuleBuilder<'_> {
         let receiver = self.expression(&attr.value, body)?;
         let receiver_ty = Self::expr_ty(body, receiver);
         let method = attr.attr.as_str();
-        if !self.class_has_method(receiver_ty, method) {
+        if self.class_method_dispatch(receiver_ty, method).is_none() {
             return Ok(None);
         }
         let args = call
@@ -701,7 +718,60 @@ impl ModuleBuilder<'_> {
         .map(Some)
     }
 
-    /// Create a HIR method call for a statically-known class method.
+    /// Lower a `cls(...)` construction inside a `@classmethod` body.
+    ///
+    /// Inside a `@classmethod` the implicit `cls` receiver is a local bound to
+    /// the owning class's `Type::Class`, so `cls(args)` constructs that class
+    /// ([`ExprKind::New`]) — the alternate-constructor idiom common in
+    /// `result`/`returns`. `cls.helper(args)` is handled by the general method
+    /// dispatch in [`Self::protocol_call_expression`] (the `cls` local is a class
+    /// value with the method resolved via [`Self::class_method_dispatch`]).
+    ///
+    /// Returns `None` when the callee is not a `cls` name, so the ordinary call
+    /// handlers still run.
+    fn cls_receiver_call_expression(
+        &mut self,
+        call: &ruff_python_ast::ExprCall,
+        body: &mut Body,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        let span = self.span(call.range);
+        // `cls(args)` — construct the owning class. `cls` is the class-method
+        // receiver local bound to `Type::Class`; keying on the `cls` binding
+        // name distinguishes the class object from an instance value (both carry
+        // the same `Type::Class` and only the classmethod receiver is callable).
+        if let Expr::Name(name) = call.func.as_ref()
+            && name.id.as_str() == "cls"
+            && let Some(&local) = self.locals.get("cls")
+            && let Some(Type::Class { name: class_sym, .. }) =
+                self.ctx.krate.types.get(Self::local_ty(body, local)).cloned()
+        {
+            let class_ty = self.intern_type(Type::Class {
+                name: class_sym,
+                args: vec![],
+            });
+            let args = call
+                .arguments
+                .args
+                .iter()
+                .map(|arg| self.expression(arg, body))
+                .collect::<Result<Vec<_>, _>>()?;
+            return Ok(Some(body.push_expr(HirExpr {
+                kind: ExprKind::New {
+                    class: class_sym,
+                    args,
+                },
+                ty: class_ty,
+                span,
+            })));
+        }
+        Ok(None)
+    }
+
+    /// Create a HIR call/method expression for a statically-known class method.
+    ///
+    /// The [`ClassMethodDispatch`] resolved from the receiver type and method
+    /// name decides the shape: an associated call for classmethods/staticmethods
+    /// (the receiver is dropped) or a receiver method call for instance methods.
     fn protocol_method_expr(
         &mut self,
         call: ProtocolMethodCall,
@@ -711,14 +781,36 @@ impl ModuleBuilder<'_> {
         let method = call.method;
         let receiver_ty = Self::expr_ty(body, receiver);
         let span = Self::expr_span(body, receiver);
-        let return_ty = self
-            .class_method_return_ty(receiver_ty, &method)
-            .ok_or_else(|| {
-                SmeltError::unsupported(
-                    span,
-                    format!("class method '{method}' is not statically known"),
-                )
-            })?;
+        let dispatch = self.class_method_dispatch(receiver_ty, &method).ok_or_else(|| {
+            SmeltError::unsupported(
+                span,
+                format!("class method '{method}' is not statically known"),
+            )
+        })?;
+        let Item::Function(function) = self.item_ref(dispatch.item) else {
+            return Err(SmeltError::unsupported(
+                span,
+                format!("class method '{method}' is not a function item"),
+            ));
+        };
+        let return_ty = function.return_ty;
+        if dispatch.receiver_free {
+            // Classmethod/staticmethod: drop the receiver and call the
+            // associated function directly (`Class::method(args)`).
+            let callee = body.push_expr(HirExpr {
+                kind: ExprKind::Item(dispatch.item),
+                ty: self.item_expr_type(dispatch.item),
+                span,
+            });
+            return Ok(body.push_expr(HirExpr {
+                kind: ExprKind::Call {
+                    callee,
+                    args: call.args,
+                },
+                ty: return_ty,
+                span,
+            }));
+        }
         let method_sym = self.intern_name(&method);
         Ok(body.push_expr(HirExpr {
             kind: ExprKind::Method {
@@ -731,30 +823,50 @@ impl ModuleBuilder<'_> {
         }))
     }
 
-    /// Return whether a type is a class that declares `method`.
-    fn class_has_method(&self, receiver_ty: TypeId, method: &str) -> bool {
-        self.class_method_item(receiver_ty, method).is_some()
-    }
-
-    /// Return a statically-known class method's return type.
-    fn class_method_return_ty(&self, receiver_ty: TypeId, method: &str) -> Option<TypeId> {
-        let item = self.class_method_item(receiver_ty, method)?;
-        let Item::Function(function) = self.item_ref(item) else {
-            return None;
-        };
-        Some(function.return_ty)
-    }
-
-    /// Resolve a method item by receiver class type and source method name.
-    fn class_method_item(&self, receiver_ty: TypeId, method: &str) -> Option<ItemId> {
+    /// Resolve a class method by receiver type and name, classifying its
+    /// dispatch shape (instance vs receiver-free associated call).
+    ///
+    /// `@staticmethod` and `@classmethod` members live in
+    /// [`Self::class_static_methods`] and dispatch receiver-free; instance
+    /// methods live in [`Self::class_methods`] and dispatch through the receiver.
+    /// Returns `None` when the receiver type is not a known class or the class
+    /// declares no such method.
+    fn class_method_dispatch(&self, receiver_ty: TypeId, method: &str) -> Option<ClassMethodDispatch> {
         let Some(Type::Class { name, .. }) = self.ctx.krate.types.get(receiver_ty) else {
             return None;
         };
         let class_name = self.ctx.krate.symbols.get(*name)?;
-        self.class_methods
+        // Static methods and classmethods dispatch receiver-free.
+        if let Some(item) = self
+            .class_static_methods
             .get(class_name)
             .and_then(|methods| methods.get(method))
             .copied()
-            .or_else(|| self.class_method_item_by_name(class_name, method))
+        {
+            return Some(ClassMethodDispatch {
+                item,
+                receiver_free: true,
+            });
+        }
+        // Instance methods dispatch through the receiver.
+        let item = self
+            .class_methods
+            .get(class_name)
+            .and_then(|methods| methods.get(method))
+            .copied()
+            .or_else(|| self.class_method_item_by_name(class_name, method))?;
+        Some(ClassMethodDispatch {
+            item,
+            receiver_free: false,
+        })
     }
+}
+
+/// A resolved class-method call target plus its dispatch shape.
+struct ClassMethodDispatch {
+    /// The resolved method function item.
+    item: ItemId,
+    /// Whether the method dispatches receiver-free (`@classmethod`/`@staticmethod`),
+    /// i.e. lowers to `Class::method(args)` rather than `receiver.method(args)`.
+    receiver_free: bool,
 }

--- a/crates/smelt-frontend-py/src/lowering/class.rs
+++ b/crates/smelt-frontend-py/src/lowering/class.rs
@@ -264,6 +264,10 @@ impl ModuleBuilder<'_> {
             implements: vec![],
         }));
         self.items.insert(class_name_str.to_owned(), class_item_id);
+        // Pre-register every method's `ItemId` so a body can call siblings
+        // declared later in the class (`self.helper()`, `cls.helper()`).
+        let method_slots =
+            self.reserve_class_method_slots(class, class_name_str, class_sym, materialized.is_some())?;
         let mut enum_members = HashMap::new();
         let mut abstract_methods = Vec::new();
 
@@ -333,6 +337,10 @@ impl ModuleBuilder<'_> {
                         abstract_methods.push(self.abstract_method_sig(func)?);
                         continue;
                     }
+                    // A slot pre-reserved by `reserve_class_method_slots` is
+                    // overwritten in place so forward references resolved during
+                    // an earlier sibling body keep a valid `ItemId`.
+                    let reserved_slot = method_slots.get(&func.range.start().to_u32()).copied();
                     if Self::is_staticmethod(func) {
                         let mid = self.class_method_with_receiver(
                             class_name_str,
@@ -340,6 +348,7 @@ impl ModuleBuilder<'_> {
                             class_ty,
                             func,
                             true,
+                            reserved_slot,
                         )?;
                         static_methods.push(mid);
                         hir_module.items.push(mid);
@@ -358,13 +367,35 @@ impl ModuleBuilder<'_> {
                         constructor_id = Some(mid);
                         hir_module.items.push(mid);
                     } else {
-                        let mid = self.class_method(class_name_str, class_sym, class_ty, func)?;
+                        // Both instance methods and `@classmethod`s take the
+                        // body-lowering path with `is_static = false` so the
+                        // implicit `self`/`cls` local is created. A classmethod
+                        // then dispatches receiver-free (its `owner` becomes
+                        // `ClassStaticMethod`), so it is bookkept as a static
+                        // method and registered in `class_static_methods`.
+                        let is_classmethod = self.is_classmethod(func)?;
+                        let mid = self.class_method_with_receiver(
+                            class_name_str,
+                            class_sym,
+                            class_ty,
+                            func,
+                            false,
+                            reserved_slot,
+                        )?;
                         self.rename_materialized_descriptor_callable(class_name_str, func, mid)?;
-                        method_ids.push(mid);
-                        self.class_methods
-                            .entry(class_name_str.to_owned())
-                            .or_default()
-                            .insert(method_name.to_owned(), mid);
+                        if is_classmethod {
+                            static_methods.push(mid);
+                            self.class_static_methods
+                                .entry(class_name_str.to_owned())
+                                .or_default()
+                                .insert(method_name.to_owned(), mid);
+                        } else {
+                            method_ids.push(mid);
+                            self.class_methods
+                                .entry(class_name_str.to_owned())
+                                .or_default()
+                                .insert(method_name.to_owned(), mid);
+                        }
                         hir_module.items.push(mid);
                     }
                 }
@@ -865,6 +896,105 @@ impl ModuleBuilder<'_> {
         params
     }
 
+    /// Reserve an [`ItemId`] for every ordinary/class/static method in `class`
+    /// *before* any method body is lowered.
+    ///
+    /// Method resolution at call sites (`self.helper()`, `cls.helper()`,
+    /// `Class.helper()`) looks methods up by name in [`Self::class_methods`] /
+    /// [`Self::class_static_methods`]. Those registries were previously filled
+    /// incrementally as each body was lowered, so a call to a sibling declared
+    /// *later* in the class body could not be resolved (issue #94's dominant
+    /// blocker). Reserving placeholder items up front — keyed by each method's
+    /// source-range start so the main pass can overwrite the exact slot — makes
+    /// intra-class forward references resolvable regardless of declaration order.
+    ///
+    /// The reservation set mirrors the main class-body loop exactly: it skips
+    /// `@abstractmethod`, `__init__`/`__new__` (constructor-shaped), materialized
+    /// descriptor callables (property getters/setters), and — under a
+    /// materialized class — the `__init_subclass__`/`__set_name__` hooks. Each
+    /// remaining instance method is registered in [`Self::class_methods`]; each
+    /// `@staticmethod` / `@classmethod` is registered in
+    /// [`Self::class_static_methods`] (both dispatch receiver-free).
+    fn reserve_class_method_slots(
+        &mut self,
+        class: &StmtClassDef,
+        class_name_str: &str,
+        class_sym: Symbol,
+        materialized_hooks_skipped: bool,
+    ) -> Result<HashMap<u32, ItemId>, SmeltError> {
+        let mut slots: HashMap<u32, ItemId> = HashMap::new();
+        for body_stmt in &class.body {
+            let Stmt::FunctionDef(func) = body_stmt else {
+                continue;
+            };
+            let method_name = func.name.as_str();
+            if materialized_hooks_skipped
+                && matches!(method_name, "__init_subclass__" | "__set_name__")
+            {
+                continue;
+            }
+            if Self::is_abstractmethod(func) || self.is_materialized_descriptor_callable(func) {
+                continue;
+            }
+            let is_static = Self::is_staticmethod(func);
+            // `__init__`/`__new__` are constructor-shaped and are not exposed
+            // through the method registries; leave them to the main pass.
+            if !is_static && matches!(method_name, "__init__" | "__new__") {
+                continue;
+            }
+            // A `@classmethod` dispatches receiver-free like a `@staticmethod`
+            // (its implicit `cls` is erased to the concrete class), so it is
+            // reserved as a static method and registered in `class_static_methods`.
+            let is_classmethod = !is_static && self.is_classmethod(func)?;
+            let receiver_free = is_static || is_classmethod;
+            let method_sym = self.intern_name(method_name);
+            let owner = if receiver_free {
+                FunctionOwner::ClassStaticMethod {
+                    class: class_sym,
+                    method: method_sym,
+                }
+            } else {
+                FunctionOwner::ClassMethod {
+                    class: class_sym,
+                    method: method_sym,
+                }
+            };
+            // Record the real return type now: a sibling body lowered *before*
+            // this method resolves the call through this placeholder, so its
+            // return type must already be accurate. This mirrors the return-type
+            // reconciliation the main pass performs. When it cannot be resolved
+            // the main pass reports the missing-annotation error; a `None`
+            // placeholder here is only a stand-in until then.
+            let return_ty = self
+                .resolve_return_ty(func, func.returns.as_deref())
+                .unwrap_or_else(|| self.intern_type(Type::None));
+            let placeholder = Item::Function(Function {
+                name: method_sym,
+                span: self.span(func.range),
+                params: Vec::new(),
+                rest: None,
+                required_params: None,
+                return_ty,
+                is_async: false,
+                is_test: false,
+                body: None,
+                owner,
+            });
+            let item_id = self.ctx.krate.push_item(placeholder);
+            let registry = if receiver_free {
+                &mut self.class_static_methods
+            } else {
+                &mut self.class_methods
+            };
+            registry
+                .entry(class_name_str.to_owned())
+                .or_default()
+                .insert(method_name.to_owned(), item_id);
+            slots.insert(func.range.start().to_u32(), item_id);
+        }
+        Ok(slots)
+    }
+
     /// Lower a method or constructor inside a class body.
     ///
     /// Handles `self` parameter injection, param annotation enforcement, and
@@ -876,7 +1006,7 @@ impl ModuleBuilder<'_> {
         class_ty: TypeId,
         func: &StmtFunctionDef,
     ) -> Result<ItemId, SmeltError> {
-        self.class_method_with_receiver(class_name_str, class_sym, class_ty, func, false)
+        self.class_method_with_receiver(class_name_str, class_sym, class_ty, func, false, None)
     }
 
     /// Lower a Python class method to a HIR function item.
@@ -896,6 +1026,7 @@ impl ModuleBuilder<'_> {
         class_ty: TypeId,
         func: &StmtFunctionDef,
         is_static: bool,
+        slot: Option<ItemId>,
     ) -> Result<ItemId, SmeltError> {
         let span = self.span(func.range);
         let method_name_str = func.name.as_str();
@@ -1014,9 +1145,16 @@ impl ModuleBuilder<'_> {
 
         let body_id = self.ctx.krate.push_body(fn_body);
 
+        // A `@classmethod` lowers to a receiver-free associated function, the
+        // same owner a `@staticmethod` uses. Python binds its implicit `cls` to
+        // the class object, not an instance, so codegen must emit
+        // `Class::method(args)` (no `&self`). `cls(..)`/`cls.helper(..)` inside
+        // the body are lowered to concrete class construction / associated calls
+        // (see `cls_receiver_call_expression` and `class_method_dispatch`), so
+        // the `cls` local is never dereferenced as a receiver.
         let owner = if is_init {
             FunctionOwner::Constructor { class: class_sym }
-        } else if is_static {
+        } else if is_static || is_classmethod {
             FunctionOwner::ClassStaticMethod {
                 class: class_sym,
                 method: method_sym,
@@ -1040,7 +1178,17 @@ impl ModuleBuilder<'_> {
             body: Some(body_id),
             owner,
         });
-        Ok(self.ctx.krate.push_item(item))
+        // Reuse the slot reserved by the pre-pass when present so any earlier
+        // sibling body that resolved a forward reference to this method keeps a
+        // valid `ItemId`; otherwise append a fresh item.
+        match slot {
+            Some(item_id) => {
+                let index = usize::try_from(item_id.0).unwrap_or(usize::MAX);
+                self.ctx.krate.items[index] = item;
+                Ok(item_id)
+            }
+            None => Ok(self.ctx.krate.push_item(item)),
+        }
     }
 
     // Class helper lowering continues in `class_init.rs`.

--- a/crates/smelt-frontend-py/src/lowering/validate.rs
+++ b/crates/smelt-frontend-py/src/lowering/validate.rs
@@ -41,6 +41,33 @@ fn visible_class_methods(ctx: &HirCtx) -> HashMap<String, HashMap<String, ItemId
     class_methods
 }
 
+/// Collect class `@staticmethod` items already present in the shared crate.
+fn visible_class_static_methods(ctx: &HirCtx) -> HashMap<String, HashMap<String, ItemId>> {
+    let mut class_static_methods: HashMap<String, HashMap<String, ItemId>> = HashMap::new();
+    for (idx, item) in ctx.krate.items.iter().enumerate() {
+        let Item::Function(function) = item else {
+            continue;
+        };
+        let FunctionOwner::ClassStaticMethod { class, method } = function.owner else {
+            continue;
+        };
+        let Ok(item_idx) = u32::try_from(idx) else {
+            continue;
+        };
+        let Some(class_name) = ctx.krate.symbols.get(class) else {
+            continue;
+        };
+        let Some(method_name) = ctx.krate.symbols.get(method) else {
+            continue;
+        };
+        class_static_methods
+            .entry(class_name.to_owned())
+            .or_default()
+            .insert(method_name.to_owned(), ItemId(item_idx));
+    }
+    class_static_methods
+}
+
 /// Return true for module-level `__all__` metadata assignments.
 fn is_module_all_assignment(stmt: &Stmt) -> bool {
     match stmt {

--- a/crates/smelt-frontend-py/src/tests/class_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/class_tests.rs
@@ -697,3 +697,200 @@ def area(radius: float) -> float:
     )?;
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Issue #94: method and non-top-level calls.
+// ---------------------------------------------------------------------------
+
+/// Return the body of the named function/method item in `module`.
+fn method_body_named<'a>(
+    ctx: &'a HirCtx,
+    module: &Module,
+    name: &str,
+) -> Result<&'a Body, String> {
+    let item_id = module
+        .items
+        .iter()
+        .copied()
+        .find(|item_id| match item(ctx, *item_id) {
+            Ok(Item::Function(function)) => symbol(ctx, function.name).ok() == Some(name),
+            _ => false,
+        })
+        .ok_or_else(|| format!("missing method '{name}'"))?;
+    let Item::Function(function) = item(ctx, item_id)? else {
+        return Err(format!("item '{name}' is not a function"));
+    };
+    body(ctx, function.body.ok_or("expected method body")?)
+}
+
+/// An instance method may call a sibling method declared *later* in the class
+/// body: method items are pre-registered before any body is lowered, so the
+/// forward reference resolves and lowers to a receiver method call.
+#[test]
+fn instance_method_forward_reference_lowers() -> TestResult {
+    let source = py!(r#"
+class Counter:
+    value: int
+    def __init__(self, value: int) -> None:
+        self.value = value
+    def total(self) -> int:
+        return self.doubled()
+    def doubled(self) -> int:
+        return self.value * 2
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let total = method_body_named(&ctx, module, "total")?;
+    ensure(
+        total
+            .exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Method { .. })),
+        "expected self.doubled() to lower as a receiver method call",
+    )?;
+    Ok(())
+}
+
+/// Inside a `@classmethod`, `cls(args)` constructs the owning class and
+/// `cls.helper()` dispatches to a sibling classmethod/staticmethod as a
+/// receiver-free associated call.
+#[test]
+fn classmethod_cls_construction_and_dispatch_lower() -> TestResult {
+    let source = py!(r#"
+class Counter:
+    value: int
+    def __init__(self, value: int) -> None:
+        self.value = value
+    @classmethod
+    def make(cls, start: int) -> "Counter":
+        base = cls(start)
+        return cls(base.value + cls.origin())
+    @staticmethod
+    def origin() -> int:
+        return 0
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let make = method_body_named(&ctx, module, "make")?;
+    // `cls(...)` lowers to class construction, not a receiver method call.
+    ensure(
+        make.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::New { .. })),
+        "expected cls(args) to lower as class construction",
+    )?;
+    // `cls.origin()` (staticmethod) lowers to a receiver-free associated call.
+    ensure(
+        make.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Call { .. })),
+        "expected cls.origin() to lower as an associated call",
+    )?;
+    // No `cls.origin()` receiver method call was emitted for the associated call.
+    // The classmethod itself dispatches receiver-free, so its owner is static.
+    let Item::Function(make_fn) = item(
+        &ctx,
+        module
+            .items
+            .iter()
+            .copied()
+            .find(|item_id| matches!(
+                item(&ctx, *item_id),
+                Ok(Item::Function(function)) if symbol(&ctx, function.name).ok() == Some("make")
+            ))
+            .ok_or("missing make item")?,
+    )?
+    else {
+        return Err("make is not a function".to_owned());
+    };
+    ensure(
+        matches!(
+            make_fn.owner,
+            smelt_hir::FunctionOwner::ClassStaticMethod { .. }
+        ),
+        "expected @classmethod to lower with a receiver-free (static) owner",
+    )?;
+    Ok(())
+}
+
+/// A `@classmethod` called qualified (`Class.make(..)`) lowers to a
+/// receiver-free associated call, and a subsequent instance method on its
+/// result chains correctly.
+#[test]
+fn classmethod_qualified_call_and_chain_lower() -> TestResult {
+    let source = py!(r#"
+class Counter:
+    value: int
+    def __init__(self, value: int) -> None:
+        self.value = value
+    def total(self) -> int:
+        return self.value
+    @classmethod
+    def make(cls, start: int) -> "Counter":
+        return cls(start)
+
+def via_factory(start: int) -> int:
+    return Counter.make(start).total()
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let factory = method_body_named(&ctx, module, "via_factory")?;
+    // `Counter.make(start)` is an associated call; `.total()` is a method call.
+    ensure(
+        factory
+            .exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Call { .. })),
+        "expected Counter.make(..) associated call",
+    )?;
+    ensure(
+        factory
+            .exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Method { .. })),
+        "expected chained .total() receiver method call",
+    )?;
+    Ok(())
+}
+
+/// A `@staticmethod` may call a sibling declared later via `Class.helper()`.
+#[test]
+fn staticmethod_forward_reference_lowers() -> TestResult {
+    let source = py!(r#"
+class Ops:
+    @staticmethod
+    def start() -> int:
+        return Ops.base() + 1
+    @staticmethod
+    def base() -> int:
+        return 10
+"#);
+    let mut ctx = HirCtx::new();
+    lower_module(source, &mut ctx)?;
+    Ok(())
+}
+
+/// A method call to a name the receiver class does not declare is still
+/// rejected with the unsupported-call diagnostic.
+#[test]
+fn unknown_instance_method_rejects() -> TestResult {
+    let source = py!(r#"
+class C:
+    def m(self) -> int:
+        return 1
+
+def f(c: C) -> int:
+    return c.nope()
+"#);
+    let mut ctx = HirCtx::new();
+    let errors = lower_errors(source, &mut ctx)?;
+    let error = first_error(&errors)?;
+    ensure(
+        error.message.contains("only calls to top-level functions"),
+        "expected the unsupported-call diagnostic for an unknown method",
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Lowers the biggest single blocker class in the Python corpus — `only calls to top-level functions, class constructors, and print() are supported` (~599 occurrences across funcy, more-itertools, result, returns, toolz).

The frontend already handled instance-method calls on statically-known receivers (`c.m()`, `self.m()` for a method defined *earlier*). This PR fixes the remaining concrete gaps found by probing real shapes:

1. **Forward-referenced methods** — `self.helper()` where `helper` is declared *later* in the class body (the dominant real-world case: `__init__`/`total` at the top calling helpers below). Method items are now pre-registered before any body is lowered.
2. **`@classmethod` dispatch** — `cls(...)` alternate-constructor construction, `cls.helper()` calls, and qualified `Class.make(...)` all lower. Classmethods now lower to receiver-free associated functions (`Class::method(args)`), matching Python's `cls` = class-object (not instance) binding — the previous shared instance-method codegen emitted a wrong `&self` receiver.
3. **`@staticmethod` forward references** — `Class.helper()` where `helper` is declared later.

Instance methods lower to `ExprKind::Method`; classmethods/staticmethods lower to a receiver-free `ExprKind::Call`. Unknown methods still reject with the same diagnostic.

## How

- New per-class pre-pass `reserve_class_method_slots` reserves each method's `ItemId` and resolved return type before bodies are lowered, then the main pass overwrites each slot in place (forward references resolve regardless of declaration order).
- `@classmethod` → `FunctionOwner::ClassStaticMethod`; `cls(...)` → `ExprKind::New`; central `class_method_dispatch` picks the receiver / receiver-free shape.
- `class_static_methods` registry (+ cross-module `visible_class_static_methods` collector) holds classmethods and staticmethods.

## Verification

- `cargo check` + `cargo clippy` clean on `smelt-frontend-py`.
- `cargo test -p smelt-frontend-py` (171) and `--features ty` (173) green.
- New regression tests in `class_tests.rs`: instance/classmethod/staticmethod forward references, `cls(...)` construction, `cls.helper()` and `Class.make().total()` dispatch, and the rejection path.
- New Python compile-corpus case `py_method_calls` — the emitted Rust compiles (`cargo test -p smelt-codegen-rust --features ty --test compile_corpus -- --ignored`), producing idiomatic `self.doubled()`, `Counter::make(start)`, `Counter::origin()`.

## Scope covered vs deferred

Covered: instance methods (any declaration order), classmethods (`cls(...)`, `cls.method()`, `Class.method()`), staticmethods, chained calls on class-typed results.

Deferred (documented in code): passing a bare `cls`/class-object value where the class object escapes as a value, and class-object locals not named `cls`.

Part of #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)