### PR TITLE
fix(codegen-rust): make concrete union enums Debug + Default

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/union.rs
+++ b/crates/smelt-codegen-rust/src/emitter/union.rs
@@ -377,6 +377,30 @@ pub(crate) fn emit_union_definitions(
         output.push_str(
             "        self.clone().into_smelt_unknown() == other.clone().into_smelt_unknown()\n",
         );
+        output.push_str("    }\n}\n");
+        // Concrete unions surface as fields of generated classes, which derive
+        // `Debug` and `Default`. A data-carrying enum can derive neither, and a
+        // `#[derive(Debug)]` would additionally demand that every member type be
+        // `Debug` (excluding `SmeltJsMap`, function members, and other runtime
+        // carriers). Emit both by hand: `Debug` reuses the erased `SmeltUnknown`
+        // view (always present, since the union already emits `IntoSmeltUnknown`)
+        // exactly like the `PartialEq` impl above, and `Default` selects the
+        // first arm, matching how `default_value` builds a concrete-union default.
+        output.push_str(&format!("impl ::std::fmt::Debug for {name} {{\n"));
+        output.push_str(
+            "    fn fmt(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {\n",
+        );
+        output.push_str(
+            "        ::std::fmt::Debug::fmt(&self.clone().into_smelt_unknown(), formatter)\n",
+        );
+        output.push_str("    }\n}\n");
+        let first_member = *members
+            .first()
+            .ok_or_else(|| EmitError::new("concrete union has no members"))?;
+        let first_default = emitter.default_value(first_member)?;
+        output.push_str(&format!("impl Default for {name} {{\n"));
+        output.push_str("    fn default() -> Self {\n");
+        output.push_str(&format!("        Self::M0({first_default})\n"));
         output.push_str("    }\n}\n\n");
     }
     Ok(output)

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -62,6 +62,45 @@ function read(value: Left | Right): string {
     assert!(source.contains("matches!(value.clone(), SmeltUnion"), "{source}");
 }
 
+/// A class field typed as a concrete union (`string | number`) lowers the field
+/// to a tagged `SmeltUnion*` enum. The class struct derives `Clone, Debug,
+/// Default`, so the union enum must supply `Debug` and `Default` as well — a
+/// data-carrying enum can derive neither. The enum keeps `#[derive(Clone)]` and
+/// gains a hand-written `Debug` (reusing the erased `SmeltUnknown` view, exactly
+/// like its `PartialEq`) and a hand-written `Default` selecting the first arm.
+/// Without these impls the struct's `Debug`/`Default` derives fail to compile.
+#[test]
+fn emits_debug_and_default_for_union_typed_class_field() {
+    let source = source_for(
+        r"
+class Holder {
+  value: string | number = 0;
+}
+export function getVal(h: Holder): string | number {
+  return h.value;
+}
+",
+    );
+
+    // The class struct keeps deriving the standard traits.
+    assert!(
+        source.contains("#[derive(Clone, Debug, Default)]"),
+        "{source}"
+    );
+    // The union enum carries hand-written Debug and Default impls.
+    assert!(source.contains("pub enum SmeltUnion"), "{source}");
+    assert!(
+        source.contains("impl ::std::fmt::Debug for SmeltUnion"),
+        "{source}"
+    );
+    assert!(
+        source.contains("impl Default for SmeltUnion"),
+        "{source}"
+    );
+    // Default selects the first union arm.
+    assert!(source.contains("Self::M0("), "{source}");
+}
+
 /// Issue #84: a class string index signature `[key: string]: T` emits Rust that
 /// compiles and carries a real runtime keyed store. A pure-index class
 /// (`StringBag`) exposes keyed access whose value type drives an honest

--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -379,6 +379,30 @@ function resolvePath(path: string | (() => string)): string {
 "#,
         },
         Case {
+            // A class field whose declared type is a concrete union
+            // (`string | number`) lowers the field to a tagged `SmeltUnion*`
+            // enum. The struct derives `Clone, Debug, Default`, so the union
+            // enum must provide `Debug` and `Default` too (an enum with
+            // data-carrying variants can derive neither). Regression for the
+            // union-field derive gap: the emitted crate must compile. The same
+            // gap blocks union-valued class index signatures (issue #84).
+            name: "class_union_field",
+            area: "concrete_unions",
+            source: r"
+class Holder {
+  value: string | number = 0;
+}
+
+export function getVal(h: Holder): string | number {
+  return h.value;
+}
+
+export function makeHolder(): Holder {
+  return new Holder();
+}
+",
+        },
+        Case {
             name: "set_collection",
             area: "collections",
             source: r"


### PR DESCRIPTION
## What

A class field typed as a concrete union (e.g. `value: string | number`) lowers the field to a tagged `SmeltUnion*` enum. The class struct derives `#[derive(Clone, Debug, Default)]`, but the union enum only derived `Clone`, so the emitted Rust did **not** compile:

```
error[E0277]: `SmeltUnion3` doesn't implement `Debug`
error[E0277]: the trait bound `SmeltUnion3: Default` is not satisfied
```

Repro:
```ts
class Holder {
  value: string | number = 0;
}
export function getVal(h: Holder): string | number { return h.value; }
```

## Fix

`emit_union_definitions` ([union.rs](../blob/claude/hopeful-blackwell-007a0b/crates/smelt-codegen-rust/src/emitter/union.rs)) now emits **manual `Debug` and `Default` impls for every concrete union enum**, unconditionally:

- **`Debug`** delegates through `into_smelt_unknown()` — the exact pattern the union's existing `PartialEq` already uses, and `SmeltUnknown` is guaranteed present (the union already emits `IntoSmeltUnknown`). This avoids the two traps of a `#[derive(Debug)]`: enums with data-carrying variants can't derive it, and it would require *every* member type to be `Debug` (which `SmeltJsMap`, function members, etc. are not).
- **`Default`** returns `Self::M0(<first-member default>)`, reusing `default_value` — matching the convention the codebase already uses for concrete-union defaults.

### Why this approach

Chosen over gating the struct's derives because it keeps the class-struct derive logic untouched, needs no fragile per-member Debug/Default predicate, and works for **all** member kinds — including function members (`Rc<dyn Fn>`, which are `Clone`). The only member that can't work is a `Future` (`Pin<Box<dyn Future>>`), but that already breaks the enum's `Clone` derive upstream, so no new breakage is introduced.

This was discovered while implementing issue #84 (class index signatures); union-valued index signatures (`[key: string]: string | number`) hit the same gap, so this also unblocks their runtime store. (Actually wiring the store for a union value type remains issue #84 frontend work.)

## Tests

- **Compile-corpus case** `class_union_field` ([compile_corpus.rs](../blob/claude/hopeful-blackwell-007a0b/crates/smelt-codegen-rust/tests/compile_corpus.rs)) — lowers the repro and `cargo check`s the emitted crate.
- **Fast codegen test** `emits_debug_and_default_for_union_typed_class_field` ([part_7_tests.rs](../blob/claude/hopeful-blackwell-007a0b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs)) — asserts the struct keeps `#[derive(Clone, Debug, Default)]` and the union gains hand-written `Debug`/`Default` with `Self::M0(`.

## Verification

- `cargo check -p smelt-codegen-rust` ✅ · `cargo clippy -p smelt-codegen-rust` ✅ (clean)
- `cargo test -p smelt-codegen-rust --lib` — 484 pass, no snapshot regressions
- compile-corpus `class_union_field` — emitted crate compiles ✅
- full `cargo test` — no failures; bare `cargo check` ✅
- Confirmed no golden `expected.rs` contains a concrete union enum, so no goldens needed regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)