### PR TITLE
Make `ty` a default feature and prefer explicit annotations over ty's wider inference (#93)

### DIFF
--- a/crates/smelt-cli/Cargo.toml
+++ b/crates/smelt-cli/Cargo.toml
@@ -7,10 +7,11 @@ edition.workspace = true
 workspace = true
 
 [features]
+default = ["ty"]
 # Resolve Python types via Astral's `ty` instead of requiring explicit
-# annotations (issue #93). OFF by default so `cargo build`/`cargo install`
-# stay lean; build the CLI with `--features ty` to enable ty-backed Python
-# type resolution end to end.
+# annotations (issue #93). ON by default so the CLI resolves Python types via
+# ty end to end out of the box. Build with `--no-default-features` for a lean
+# CLI that requires explicit annotations instead.
 ty = ["smelt-frontend-py/ty"]
 
 [[bin]]

--- a/crates/smelt-codegen-rust/Cargo.toml
+++ b/crates/smelt-codegen-rust/Cargo.toml
@@ -7,10 +7,11 @@ edition.workspace = true
 workspace = true
 
 [features]
-# Forward the Python frontend's `ty` feature so the compile corpus can exercise
-# annotation-free Python that lowers via `ty`-resolved types (issue #93). OFF by
-# default so the default build stays lean; CI runs the corpus with `--features
-# ty` alongside `--ignored`.
+default = ["ty"]
+# Forward the Python frontend's `ty` feature so the compile corpus exercises
+# annotation-free Python that lowers via `ty`-resolved types (issue #93). ON by
+# default; the corpus's Python cases now run under a plain `--ignored` run.
+# Build with `--no-default-features` to drop the ty dependency tree.
 ty = ["smelt-frontend-py/ty"]
 
 [dependencies]

--- a/crates/smelt-frontend-py/Cargo.toml
+++ b/crates/smelt-frontend-py/Cargo.toml
@@ -8,11 +8,13 @@ autoexamples = false
 workspace = true
 
 [features]
+default = ["ty"]
 # Resolve Python function/method/parameter/closure types via Astral's `ty`
-# instead of requiring explicit source annotations (issue #93). OFF by default:
-# it pulls in the heavy `ty` dependency tree (salsa + vendored typeshed) through
-# `smelt-py-types`, so a lean `cargo build` never pays for it. The central
-# pipeline and CI probes enable `--features ty`.
+# instead of requiring explicit source annotations (issue #93). ON by default:
+# ty-backed resolution is now the standard Python type source, so it is enabled
+# out of the box (this pulls in the `ty` dependency tree — salsa + vendored
+# typeshed — through `smelt-py-types`). Disable with `--no-default-features` for
+# a lean build that requires explicit annotations instead.
 ty = ["dep:smelt-py-types"]
 
 [dependencies]

--- a/crates/smelt-frontend-py/src/lowering/types.rs
+++ b/crates/smelt-frontend-py/src/lowering/types.rs
@@ -6,14 +6,24 @@ impl ModuleBuilder<'_> {
     /// Resolve a function/method return type, reconciling any source-declared
     /// annotation with `ty`'s inferred *actual* returned type (issue #93).
     ///
-    /// Behaviour, in order:
+    /// The reconciliation is **annotation-respecting**: an explicit source
+    /// contract is honoured and is never widened just because `ty` infers a
+    /// broader type for the body. Behaviour, in order:
+    ///
     /// * No annotation → use `ty`'s inferred return type; `None` if `ty` could
     ///   not resolve one (the caller then raises the explicit-annotation error).
-    /// * Annotation present → lower it. If `ty` also resolved a representable
-    ///   return type and it *differs* from the annotation, prefer `ty`'s: the
-    ///   annotation may be stale/wider/narrower than what the body actually
-    ///   returns, and lowering must follow the accurate type. If `ty` resolved
-    ///   nothing (or the same type), keep the annotation.
+    /// * Annotation present → lower it to `declared`, then:
+    ///   * `ty` resolved nothing, or resolved the same type → keep `declared`.
+    ///   * `declared` is assignable to `ty`'s inferred type — i.e. the
+    ///     annotation is an equal-or-narrower, still-valid description of what
+    ///     the body returns (e.g. `-> float` while `ty` infers `int | float`)
+    ///     → keep `declared`. This is the fix for the #93 regression: an
+    ///     annotated `-> float` must stay `f64`, not degrade into an erased
+    ///     union.
+    ///   * Otherwise `ty` inferred a strictly narrower / genuinely more precise
+    ///     type than the annotation (`declared` is *not* assignable to it, e.g.
+    ///     an annotation of `object`/`float` while the body only ever returns
+    ///     `int`) → prefer `ty`'s refinement.
     ///
     /// The `func` node's start offset is the key `smelt-py-types` records return
     /// types under.
@@ -31,13 +41,112 @@ impl ModuleBuilder<'_> {
             None => inferred,
             Some(ann) => {
                 let declared = self.annotation_to_hir(ann).ok()?;
-                // Prefer ty's inferred actual return type when it diverges.
                 Some(match inferred {
-                    Some(inferred_ty) if inferred_ty != declared => inferred_ty,
+                    // A genuine refinement: `ty` inferred a strictly narrower
+                    // type than the annotation, so the annotation is not a valid
+                    // (equal-or-narrower) description of it. Follow `ty`.
+                    Some(inferred_ty)
+                        if inferred_ty != declared
+                            && !self.type_assignable_to(declared, inferred_ty) =>
+                    {
+                        inferred_ty
+                    }
+                    // No inference, an identical type, or the annotation is a
+                    // still-valid equal-or-narrower contract: respect the
+                    // explicit annotation and never widen it.
                     _ => declared,
                 })
             }
         }
+    }
+
+    /// Whether the `value` HIR type is assignable to (a subtype of, or equal to)
+    /// the `target` HIR type under the subset of Python typing rules the frontend
+    /// needs to reconcile annotations with `ty`'s inference (issue #93).
+    ///
+    /// This is intentionally narrow and conservative — it exists only to decide
+    /// whether an explicit annotation remains a valid description of `ty`'s
+    /// inferred type, so it errs toward `false` for shapes it does not model:
+    ///
+    /// * Equal types are assignable.
+    /// * `int` is assignable to `float` (Python's numeric tower).
+    /// * `value` is assignable to a `Union`/`Optional` `target` when it is
+    ///   assignable to at least one member (Optional is treated as `T | None`).
+    /// * A `Union`/`Optional` `value` is assignable to `target` when *every*
+    ///   member is assignable to `target`.
+    ///
+    /// Anything else (containers, functions, unrelated classes) is only
+    /// assignable when structurally equal. Returning `false` on the unmodelled
+    /// cases is safe: the caller then keeps the explicit annotation rather than
+    /// widening, which is the conservative choice for a source contract.
+    fn type_assignable_to(&self, value: TypeId, target: TypeId) -> bool {
+        if value == target {
+            return true;
+        }
+        let types = &self.ctx.krate.types;
+        let (Some(value_kind), Some(target_kind)) = (types.get(value), types.get(target)) else {
+            return false;
+        };
+
+        // Python numeric widening: an `int` value satisfies a `float` contract.
+        if is_int_like(value_kind) && is_float_like(target_kind) {
+            return true;
+        }
+
+        // A union/optional on the value side is assignable only when every member
+        // is; an `Optional(T)` (`T | None`) member must include `None` so it is
+        // not silently narrowed to `T`.
+        if let Some(members) = self.union_like_members(value_kind) {
+            return members
+                .into_iter()
+                .all(|member| self.type_assignable_to(member, target));
+        }
+
+        // A union/optional on the target side accepts the value when any member
+        // does.
+        if let Some(members) = self.union_like_members(target_kind) {
+            return members
+                .into_iter()
+                .any(|member| self.type_assignable_to(value, member));
+        }
+
+        false
+    }
+
+    /// Flatten a `Union`/`Optional` type into its member [`TypeId`]s, or `None`
+    /// when `ty` is not a union-like type.
+    ///
+    /// `Optional(T)` expands to `[T, None]` so an optional on the assignable-to
+    /// *source* side is not silently narrowed by dropping its `None` arm. The
+    /// `None` member is looked up read-only from the interner; if no `Type::None`
+    /// has been interned (it always has in practice, being pervasive) the inner
+    /// type is returned alone.
+    fn union_like_members(&self, ty: &Type) -> Option<Vec<TypeId>> {
+        match ty {
+            Type::Union(members) => Some(members.clone()),
+            Type::Optional(inner) => {
+                let mut members = vec![*inner];
+                if let Some(none_id) = self.find_interned_type(&Type::None) {
+                    members.push(none_id);
+                }
+                Some(members)
+            }
+            _ => None,
+        }
+    }
+
+    /// Find the [`TypeId`] of an already-interned type without mutating the
+    /// interner. Read-only counterpart to [`Self::intern_type`] used by the
+    /// annotation/inference reconciliation, which must stay `&self`.
+    fn find_interned_type(&self, needle: &Type) -> Option<TypeId> {
+        let idx = self
+            .ctx
+            .krate
+            .types
+            .all()
+            .iter()
+            .position(|existing| existing == needle)?;
+        u32::try_from(idx).ok().map(TypeId)
     }
 
     /// Return the `ty`-resolved HIR type for parameter `p`, if `ty` resolved a
@@ -304,4 +413,17 @@ impl ModuleBuilder<'_> {
         }
     }
 
+}
+
+/// Whether `ty` is the `int` primitive, for the numeric-tower widening rule in
+/// [`ModuleBuilder::type_assignable_to`].
+fn is_int_like(ty: &Type) -> bool {
+    matches!(ty, Type::Int)
+}
+
+/// Whether `ty` is the `float` primitive, for the numeric-tower widening rule in
+/// [`ModuleBuilder::type_assignable_to`] (an `int` value satisfies a `float`
+/// contract in Python).
+fn is_float_like(ty: &Type) -> bool {
+    matches!(ty, Type::Float)
 }

--- a/crates/smelt-frontend-py/src/tests/ty_resolution_tests.rs
+++ b/crates/smelt-frontend-py/src/tests/ty_resolution_tests.rs
@@ -130,3 +130,76 @@ fn divergent_return_annotation_prefers_inferred() -> Result<(), String> {
     )?;
     Ok(())
 }
+
+/// An explicit `-> float` annotation is preserved even when `ty` infers a wider
+/// type for the body (issue #93 regression).
+///
+/// `value * value` for `value: float` is inferred by `ty` as a broader numeric
+/// type (`int | float`) than the declared `float`. The declared `float` is a
+/// valid, equal-or-narrower description of that inference, so lowering must keep
+/// the annotation and emit `f64` rather than degrading into an erased union.
+#[test]
+fn annotated_return_kept_when_ty_infers_wider() -> Result<(), String> {
+    let source = "def square(value: float) -> float:\n    return value * value\n";
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = crate::tests::module(&ctx, module_id)?;
+    let item_id = module
+        .items
+        .first()
+        .copied()
+        .ok_or_else(|| "expected function item".to_owned())?;
+    let Item::Function(func) = item(&ctx, item_id)? else {
+        return Err("expected Function item".to_owned());
+    };
+    // The explicit `-> float` contract must survive `ty`'s wider inference.
+    ensure_eq(
+        &ctx.krate.types.get(func.return_ty),
+        &Some(&Type::Float),
+        "annotated float return type must be preserved",
+    )?;
+    Ok(())
+}
+
+/// A `@staticmethod` annotated `-> float` keeps `float`, mirroring the codegen
+/// regression where `square` degraded into an erased union under ty-default.
+#[test]
+fn annotated_staticmethod_return_kept_when_ty_infers_wider() -> Result<(), String> {
+    let source = concat!(
+        "class MathUtils:\n",
+        "    @staticmethod\n",
+        "    def square(value: float) -> float:\n",
+        "        return value * value\n",
+    );
+    let mut ctx = HirCtx::new();
+    // Lowering succeeds and does not panic; the static method's `-> float`
+    // contract is honoured (verified end to end by the codegen `f64` test).
+    lower_module(source, &mut ctx)?;
+    Ok(())
+}
+
+/// An UNANNOTATED function still resolves its return type via `ty` after the
+/// annotation-respecting reconciliation change: the fix must only affect the
+/// annotated path, leaving the #93 inference-for-unannotated behaviour intact.
+#[test]
+fn unannotated_return_still_resolves_via_ty() -> Result<(), String> {
+    let source = "def to_text(x: int):\n    return str(x)\n";
+    let mut ctx = HirCtx::new();
+    let module_id = lower_module(source, &mut ctx)?;
+    let module = crate::tests::module(&ctx, module_id)?;
+    let item_id = module
+        .items
+        .first()
+        .copied()
+        .ok_or_else(|| "expected function item".to_owned())?;
+    let Item::Function(func) = item(&ctx, item_id)? else {
+        return Err("expected Function item".to_owned());
+    };
+    // No annotation was present; `ty` resolved the body's `str(x)` to `str`.
+    ensure_eq(
+        &ctx.krate.types.get(func.return_ty),
+        &Some(&Type::String),
+        "ty-inferred return type for unannotated function",
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Two changes shipped together:

1. **`ty` is now a default feature** in `smelt-frontend-py`, `smelt-cli`, and `smelt-codegen-rust` (each `default = ["ty"]`). ty-backed Python type resolution is the standard type source; plain `cargo build`/`test` now exercises it. A lean build is still available via `--no-default-features`.

2. **Fix for the #93 reconciliation regression.** #93 wired Python types via Astral's `ty` and its reconciliation preferred ty's inferred return type whenever it differed from the source annotation. That over-prefers ty: for an *annotated* function ty can infer a *wider* type than the annotation, degrading clean code. With ty now on by default, `def square(value: float) -> float: return value * value` emitted `fn square(value: f64) -> SmeltUnion5` (an erased union) because ty infers `int | float` for `value * value`, overriding the explicit `-> float` contract.

## The reconciliation rule implemented

Return-type resolution is now **annotation-respecting**:

- **No annotation** → use ty's inferred type (unchanged #93 behaviour; unannotated functions still resolve via ty).
- **Annotation present**, ty inferred nothing or the same type → keep the annotation.
- **Annotation present** and the annotation is *assignable to* ty's inferred type — i.e. the annotation is an equal-or-narrower, still-valid description of what the body returns (e.g. `float` vs `int | float`) → **keep the annotation**, never widen.
- **Only** when ty inferred a strictly narrower / genuinely more precise type (the annotation is *not* assignable to it, e.g. an `object`/`float` annotation on a body that only returns `int`) → prefer ty's refinement.

The check is a focused, documented `type_assignable_to` helper: equality, the Python `int → float` numeric tower, and union/optional membership (value-side requires *all* members assignable; target-side requires *any*). Unmodelled shapes return `false`, which conservatively keeps the explicit annotation. General — no per-library or per-function special cases.

## Verification

- `cargo clippy` clean on all three touched crates.
- `smelt-codegen-rust::emits_python_static_method_and_class_var` — passes; `square` is back to `fn square(value: f64) -> f64` (assertions unchanged).
- `smelt-cli::build_runs_typescript_entry_importing_python_function` — passes (`add(9, 4)` → `13`).
- `cargo test -p smelt-frontend-py` — 186 passed; adds regression tests: annotated `-> float` where ty infers wider stays `f64` (free fn and `@staticmethod`), and an unannotated function still resolves via ty.
- `cargo test -p smelt-codegen-rust --lib` — 483 passed; `--test compile_corpus -- --ignored` (Python cases, now default) — passes.
- Full `smelt-cli` suite — all binaries pass.

## Note

Building with ty default compiles the `ty`/salsa/vendored-typeshed tree (~3 min cold, cached after). Expected, and the reason `--no-default-features` remains for lean builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)