### PR TITLE
feat(generics): lower generic free functions to typed Rust (part of #99)

### DIFF
--- a/crates/smelt-codegen-rust/src/classes.rs
+++ b/crates/smelt-codegen-rust/src/classes.rs
@@ -4,9 +4,10 @@
     reason = "class helpers are shared across sibling emitter modules"
 )]
 
-use smelt_mir::{Mir, MirClass, MirField, MirInterface};
+use smelt_hir::{Symbol, Type, TypeId};
+use smelt_mir::{Mir, MirClass, MirField, MirFunction, MirInterface};
 
-use crate::{EmitError, emitter::FunctionEmitter, rust::RustIdent};
+use crate::{EmitError, emitter::FunctionEmitter, id_index, rust::RustIdent};
 
 /// Return the sanitized Rust storage type name for a MIR class.
 ///
@@ -126,6 +127,333 @@ pub(crate) fn class_impl_generics_text(mir: &Mir, class: &MirClass) -> Result<St
                     )
                 })
                 .ok_or_else(|| EmitError::new("class type parameter has unknown symbol"))
+        })
+        .collect::<Result<Vec<_>, _>>()?
+        .join(", ");
+    Ok(format!("<{params}>"))
+}
+
+/// Return whether a free function's signature should emit real Rust generics.
+///
+/// This increment lowers a free function to real Rust generics
+/// (`fn identity<T>(x: T) -> T`) only when doing so is provably sound for Rust's
+/// type inference at every call site. It is an all-or-nothing decision per
+/// function: if any type parameter fails a safety check, the whole function
+/// falls back to full erasure (all its type parameters render as
+/// `SmeltUnknown`), matching pre-#99 behavior.
+///
+/// A function emits real generics only when EVERY declared type parameter is:
+/// - **unconstrained** — a bounded parameter (`<D extends Date>`, `<O extends {
+///   ... }>`) still needs method/property dispatch through the erased boundary
+///   that this increment does not model;
+/// - **inferable from a plain value parameter** — the parameter must appear in a
+///   *direct* (non-callback) parameter position such as `T`, `T[]`, or
+///   `Option<T>`, so Rust can infer it from the argument. A type parameter used
+///   only in the return type (e.g. a type predicate `data is T`) or only inside
+///   a callback parameter cannot be inferred and would produce `E0283`;
+/// - **absent from every callback (function-typed) parameter** — codegen
+///   synthesizes default callbacks as `move |arg: SmeltUnknown| ...`, which
+///   cannot unify with a generic callback signature `Fn(T) -> _` (`E0631`), so a
+///   type parameter appearing inside a function-typed parameter is unsafe.
+///
+/// These are the deferred "bounded / higher-order / return-only" slices of #99.
+pub(crate) fn function_emits_rust_generics(mir: &Mir, function: &MirFunction) -> bool {
+    if function.type_params.is_empty()
+        || function
+            .type_params
+            .iter()
+            .any(|param| param.constraint.is_some())
+    {
+        return false;
+    }
+
+    let param_types: Vec<TypeId> = function
+        .params
+        .iter()
+        .filter_map(|param| {
+            function
+                .locals
+                .get(id_index(param.0, "local index does not fit usize").ok()?)
+                .map(|local| local.ty)
+        })
+        .collect();
+
+    let signature_safe = function.type_params.iter().all(|type_param| {
+        let name = type_param.name;
+        // The parameter must be inferable from at least one direct value
+        // parameter position and must never appear inside a callback parameter.
+        let mut inferable = false;
+        for &param_ty in &param_types {
+            if type_param_in_callback(mir, param_ty, name) {
+                return false;
+            }
+            if type_param_directly_inferable(mir, param_ty, name) {
+                inferable = true;
+            }
+        }
+        inferable
+    });
+
+    signature_safe && !called_with_erased_type_param_argument(mir, function)
+}
+
+/// Return whether any call site in the crate passes an *erased* argument into a
+/// position typed as one of `function`'s own type parameters.
+///
+/// Rust must be able to infer a unique concrete type argument at every call
+/// site. When a generic free function is invoked with an argument whose static
+/// type is already erased — `SmeltUnknown`, a union (also emitted as
+/// `SmeltUnknown`), or a type parameter from a *different* scope — the emitted
+/// argument does not pin the callee's type parameter, so monomorphization fails
+/// with `E0283` ("type annotations needed"). Such a function cannot safely emit
+/// real generics; it must fall back to the fully erased signature so its
+/// parameter accepts the erased value directly.
+///
+/// This scans every function's `Call` terminators for calls that resolve to
+/// `function` and checks the argument at each of its type-parameter positions.
+fn called_with_erased_type_param_argument(mir: &Mir, function: &MirFunction) -> bool {
+    // Parameter positions whose declared type is exactly one of the function's
+    // own type parameters (`x: T`). Nested shapes (`T[]`) still bind `T` from
+    // the argument's element type, so only bare-parameter positions are checked.
+    let own_params: std::collections::HashSet<Symbol> =
+        function.type_params.iter().map(|param| param.name).collect();
+    let bare_type_param_positions: Vec<usize> = function
+        .params
+        .iter()
+        .enumerate()
+        .filter_map(|(index, param)| {
+            let ty = function
+                .locals
+                .get(id_index(param.0, "local index does not fit usize").ok()?)?
+                .ty;
+            matches!(mir.types.get(ty), Some(Type::TypeParam { name }) if own_params.contains(name))
+                .then_some(index)
+        })
+        .collect();
+    if bare_type_param_positions.is_empty() {
+        return false;
+    }
+
+    for caller in &mir.functions {
+        for block in &caller.blocks {
+            let Some(smelt_mir::Terminator::Call {
+                callee: smelt_mir::Callee::Static(target),
+                args,
+                ..
+            }) = &block.terminator
+            else {
+                continue;
+            };
+            if *target != function.id {
+                continue;
+            }
+            for &position in &bare_type_param_positions {
+                let Some(arg) = args.get(position) else {
+                    continue;
+                };
+                if operand_type_is_erased(mir, caller, arg) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Return whether an operand's static type is erased for codegen purposes
+/// (`SmeltUnknown`, `Never`, a union — all emitted as `SmeltUnknown` — or a type
+/// parameter that is not resolvable to a concrete type at the call site).
+fn operand_type_is_erased(mir: &Mir, caller: &MirFunction, operand: &smelt_mir::Operand) -> bool {
+    let ty = match operand {
+        smelt_mir::Operand::Copy(place) | smelt_mir::Operand::Move(place) => {
+            match place_local(place) {
+                Some(local) => match caller
+                    .locals
+                    .get(usize::try_from(local.0).unwrap_or(usize::MAX))
+                {
+                    Some(decl) => decl.ty,
+                    None => return true,
+                },
+                // A field/index projection is conservatively treated as erased.
+                None => return true,
+            }
+        }
+        // Literal constants (numbers, strings, booleans) are concrete and pin
+        // the type parameter, so they never force erasure.
+        smelt_mir::Operand::Const(_) => return false,
+    };
+    matches!(
+        mir.types.get(ty),
+        Some(Type::Unknown | Type::Never | Type::Union(_) | Type::TypeParam { .. })
+    )
+}
+
+/// Return the base local of a simple `Place::Local`, or `None` for projections.
+fn place_local(place: &smelt_mir::Place) -> Option<smelt_mir::LocalId> {
+    match place {
+        smelt_mir::Place::Local(local) => Some(*local),
+        _ => None,
+    }
+}
+
+/// Return whether `name` appears in a *direct* (non-callback) position of `ty`.
+///
+/// Direct positions are the value shapes Rust can infer a type argument from:
+/// the bare parameter (`T`), collections and wrappers over it (`T[]`,
+/// `Set<T>`, `Option<T>`, `T[]` inside a tuple, a union member, dict key/value).
+/// This walk must mirror what codegen actually EMITS for a parameter type
+/// (see `type_text_with_scoped_type_params`): it only descends through shapes
+/// that preserve the type parameter in the emitted Rust. It intentionally does
+/// NOT descend into:
+/// - **`Union`** — a union parameter erases to `SmeltUnknown` in emission, so a
+///   `T` inside `T | string` disappears from the emitted signature and cannot be
+///   inferred (`E0283`);
+/// - **`Function`** — a callback boundary, handled by [`type_param_in_callback`].
+fn type_param_directly_inferable(mir: &Mir, ty: TypeId, name: Symbol) -> bool {
+    match mir.types.get(ty) {
+        Some(Type::TypeParam { name: param_name }) => *param_name == name,
+        Some(Type::List(item) | Type::Set(item) | Type::Optional(item) | Type::Future(item)) => {
+            type_param_directly_inferable(mir, *item, name)
+        }
+        Some(Type::Dict(key, value)) => {
+            type_param_directly_inferable(mir, *key, name)
+                || type_param_directly_inferable(mir, *value, name)
+        }
+        Some(Type::Tuple(items)) => items
+            .iter()
+            .any(|item| type_param_directly_inferable(mir, *item, name)),
+        Some(Type::Class { args, .. }) => args
+            .iter()
+            .any(|arg| type_param_directly_inferable(mir, *arg, name)),
+        // Unions erase to `SmeltUnknown` and functions are a callback boundary,
+        // so neither preserves the type parameter in a directly-inferable value
+        // position.
+        Some(
+            Type::Union(_)
+            | Type::Function(_)
+            | Type::Bool
+            | Type::Int
+            | Type::Float
+            | Type::String
+            | Type::Unknown
+            | Type::Never
+            | Type::None,
+        )
+        | None => false,
+    }
+}
+
+/// Return whether `name` appears anywhere inside a function-typed sub-shape of
+/// `ty` (a callback parameter or return).
+///
+/// Such positions are unsafe for real generics because codegen synthesizes a
+/// default callback as `move |arg: SmeltUnknown| ...`, which cannot unify with a
+/// generic `Fn(T) -> _` signature. The walk descends through value wrappers to
+/// find a nested `Type::Function`, then checks whether `name` occurs anywhere
+/// within that function type.
+fn type_param_in_callback(mir: &Mir, ty: TypeId, name: Symbol) -> bool {
+    match mir.types.get(ty) {
+        Some(Type::Function(function)) => {
+            function
+                .params
+                .iter()
+                .any(|param| type_param_occurs(mir, *param, name))
+                || type_param_occurs(mir, function.return_ty, name)
+        }
+        Some(Type::List(item) | Type::Set(item) | Type::Optional(item) | Type::Future(item)) => {
+            type_param_in_callback(mir, *item, name)
+        }
+        Some(Type::Dict(key, value)) => {
+            type_param_in_callback(mir, *key, name)
+                || type_param_in_callback(mir, *value, name)
+        }
+        Some(Type::Tuple(items) | Type::Union(items)) => items
+            .iter()
+            .any(|item| type_param_in_callback(mir, *item, name)),
+        Some(Type::Class { args, .. }) => args
+            .iter()
+            .any(|arg| type_param_in_callback(mir, *arg, name)),
+        Some(
+            Type::TypeParam { .. }
+            | Type::Bool
+            | Type::Int
+            | Type::Float
+            | Type::String
+            | Type::Unknown
+            | Type::Never
+            | Type::None,
+        )
+        | None => false,
+    }
+}
+
+/// Return whether `name` occurs anywhere within `ty`, descending through every
+/// shape including function types. Used to detect a type parameter's presence
+/// inside a callback signature.
+fn type_param_occurs(mir: &Mir, ty: TypeId, name: Symbol) -> bool {
+    match mir.types.get(ty) {
+        Some(Type::TypeParam { name: param_name }) => *param_name == name,
+        Some(Type::List(item) | Type::Set(item) | Type::Optional(item) | Type::Future(item)) => {
+            type_param_occurs(mir, *item, name)
+        }
+        Some(Type::Dict(key, value)) => {
+            type_param_occurs(mir, *key, name) || type_param_occurs(mir, *value, name)
+        }
+        Some(Type::Tuple(items) | Type::Union(items)) => {
+            items.iter().any(|item| type_param_occurs(mir, *item, name))
+        }
+        Some(Type::Function(function)) => {
+            function
+                .params
+                .iter()
+                .any(|param| type_param_occurs(mir, *param, name))
+                || type_param_occurs(mir, function.return_ty, name)
+        }
+        Some(Type::Class { args, .. }) => {
+            args.iter().any(|arg| type_param_occurs(mir, *arg, name))
+        }
+        Some(
+            Type::Bool
+            | Type::Int
+            | Type::Float
+            | Type::String
+            | Type::Unknown
+            | Type::Never
+            | Type::None,
+        )
+        | None => false,
+    }
+}
+
+/// Render the bounded generic-parameter suffix for a generic free function.
+///
+/// A generic free function such as `function identity<T>(x: T): T` is emitted
+/// as `fn identity<T: ..>(x: T) -> T`. The bounds mirror generic class impl
+/// blocks (`Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'static`)
+/// so a `T`-typed value can be cloned, defaulted, and cross the erased boundary
+/// when it must. The returned text is empty for non-generic functions (and for
+/// functions with bounded parameters, which stay erased) so callers can splice
+/// it directly after the function name without branching.
+pub(crate) fn function_impl_generics_text(
+    mir: &Mir,
+    function: &MirFunction,
+) -> Result<String, EmitError> {
+    if !function_emits_rust_generics(mir, function) {
+        return Ok(String::new());
+    }
+    let params = function
+        .type_params
+        .iter()
+        .map(|param| {
+            mir.symbols
+                .get(param.name)
+                .map(|name| {
+                    format!(
+                        "{}: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'static",
+                        RustIdent::new(name).into_string()
+                    )
+                })
+                .ok_or_else(|| EmitError::new("function type parameter has unknown symbol"))
         })
         .collect::<Result<Vec<_>, _>>()?
         .join(", ");
@@ -269,8 +597,8 @@ pub(crate) fn inherited_trait_methods(mir: &Mir, class: &MirClass) -> Vec<smelt_
 )]
 pub(crate) fn class_type_text(
     mir: &Mir,
-    class_name: smelt_hir::Symbol,
-    class_args: &[smelt_hir::TypeId],
+    class_name: Symbol,
+    class_args: &[TypeId],
 ) -> Result<String, EmitError> {
     let name_text = RustIdent::new(
         mir.symbols

--- a/crates/smelt-codegen-rust/src/emitter/call.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call.rs
@@ -663,6 +663,8 @@ impl FunctionEmitter<'_> {
                         self.throwing_call_suffix(function)
                     ));
                 }
+                let free_function_type_params =
+                    self.callee_free_function_type_params(function);
                 let mut rendered_args = args
                     .iter()
                     .enumerate()
@@ -681,6 +683,23 @@ impl FunctionEmitter<'_> {
                             .ok_or_else(|| {
                                 EmitError::new("call argument has no target parameter")
                             })?;
+                        // A concrete argument bound to one of the callee's own
+                        // generic type parameters (`identity(3)` against
+                        // `x: T`) is passed through at its own type so Rust
+                        // monomorphizes `identity::<f64>`; erasing it against the
+                        // bare `T` target would mismatch the generic parameter.
+                        if matches!(
+                            self.mir.types.get(target_ty),
+                            Some(Type::TypeParam { name })
+                                if free_function_type_params.contains(name)
+                        ) {
+                            return self.callee_generic_argument_text(
+                                arg,
+                                function,
+                                target_ty,
+                                &free_function_type_params,
+                            );
+                        }
                         if matches!(self.mir.types.get(target_ty), Some(Type::Function(_)))
                             && param.is_some_and(|target_param| {
                                 !self
@@ -791,6 +810,49 @@ impl FunctionEmitter<'_> {
             .find(|class| class.name == class_name)
             .map(|class| class.type_params.iter().map(|param| param.name).collect())
             .unwrap_or_default()
+    }
+
+    /// Return the generic type parameters declared by a generic free function.
+    ///
+    /// A generic free function (`function identity<T>(x: T): T`) is emitted as
+    /// `fn identity<T: ..>(x: T) -> T`, so its parameter and return positions
+    /// reference `T` directly. Callers use this to detect arguments whose target
+    /// parameter is one of the callee's own type parameters, which must be
+    /// passed through concretely so Rust monomorphizes the call.
+    fn callee_free_function_type_params(&self, function: &MirFunction) -> HashSet<Symbol> {
+        // Only functions the crate decided to emit as real generics participate
+        // in argument pass-through. Using the crate-wide decision (rather than
+        // the signature-only predicate) keeps the call site in agreement with
+        // the emitted definition: a function whose body forced a fall back to
+        // erasure has erased (`SmeltUnknown`) parameters, so its arguments must
+        // be erased here too, not passed through concretely.
+        if !matches!(function.origin, HirOrigin::Body(_))
+            || !self.context.is_generic_function(function.id)
+        {
+            return HashSet::new();
+        }
+        function
+            .type_params
+            .iter()
+            .map(|param| param.name)
+            .collect()
+    }
+
+    /// Return whether a generic free function's declared return type is one of
+    /// its own type parameters.
+    ///
+    /// A call such as `identity(3)` monomorphizes `fn identity<T>(x: T) -> T` to
+    /// return `f64`, so the call value is already concrete at the site. The dest
+    /// local carries that concrete type from the frontend, so the return needs
+    /// no `SmeltUnknown` extraction. As with the argument pass-through, only a
+    /// bare `TypeParam` return is handled; nested shapes (`T[]`) are excluded to
+    /// keep the increment narrow and correct.
+    fn free_function_returns_own_type_param(&self, function: &MirFunction) -> bool {
+        matches!(
+            self.mir.types.get(function.return_ty),
+            Some(Type::TypeParam { name })
+                if self.callee_free_function_type_params(function).contains(name)
+        )
     }
 
     /// Return whether `function`'s declared return type is a generic type
@@ -955,6 +1017,15 @@ impl FunctionEmitter<'_> {
                     // as the source type: the call value is concrete and needs no
                     // `SmeltUnknown` extraction. Erasing here would emit an
                     // extraction match against a value that is not `SmeltUnknown`.
+                    dest_ty
+                } else if self.free_function_returns_own_type_param(function) {
+                    // A generic free function whose declared return type is one
+                    // of its own type parameters (`identity<T>(x: T): T`) is
+                    // monomorphized at this call site, so `identity(3)` yields a
+                    // concrete `f64`. The dest local carries that concrete type
+                    // from the frontend; use it as the source type so the value
+                    // passes through without a spurious `SmeltUnknown`
+                    // extraction against an already-concrete value.
                     dest_ty
                 } else if function.is_async {
                     self.type_id(Type::Future(function.return_ty))?

--- a/crates/smelt-codegen-rust/src/emitter/core.rs
+++ b/crates/smelt-codegen-rust/src/emitter/core.rs
@@ -48,6 +48,7 @@ impl<'mir> FunctionEmitter<'mir> {
                     end: 0,
                 },
             },
+            suppress_type_params: RefCell::new(false),
         })
     }
 
@@ -127,33 +128,70 @@ impl<'mir> FunctionEmitter<'mir> {
             } else {
                 out.push_str("fn main() {\n");
             }
-        } else {
-            let fn_params = self
-                .function
-                .params
-                .iter()
-                .map(|param| {
-                    let mutability = if self.local_binding_needs_mut(*param) {
-                        "mut "
-                    } else {
-                        ""
-                    };
-                    Ok(format!(
-                        "{mutability}{}: {}",
-                        self.local_name(*param)?,
-                        self.parameter_decl_type_text(*param)?
-                    ))
-                })
-                .collect::<Result<Vec<_>, EmitError>>()?
-                .join(", ");
-            out.push_str(&format!(
-                "{}fn {}({fn_params}) -> {} {{\n",
-                if self.function.is_async { "async " } else { "" },
-                self.function_rust_name(self.function)?,
-                self.return_type_text(self.function.return_ty)?
-            ));
+            self.emit_body(out)?;
+            out.push_str("}\n");
+            return Ok(());
         }
 
+        // Whether this free function emits real Rust generics was decided once,
+        // crate-wide, by `EmitContext::populate_generic_functions` (signature
+        // safety + a body-cleanliness trial). Suppressing the type parameters
+        // when the function is NOT in that set makes the signature, body, and
+        // every call site agree on the erased shape.
+        if !self.context.is_generic_function(self.function.id) {
+            *self.suppress_type_params.borrow_mut() = true;
+        }
+        let mut body = String::new();
+        self.emit_body(&mut body)?;
+
+        let fn_params = self
+            .function
+            .params
+            .iter()
+            .map(|param| {
+                let mutability = if self.local_binding_needs_mut(*param) {
+                    "mut "
+                } else {
+                    ""
+                };
+                Ok(format!(
+                    "{mutability}{}: {}",
+                    self.local_name(*param)?,
+                    self.parameter_decl_type_text(*param)?
+                ))
+            })
+            .collect::<Result<Vec<_>, EmitError>>()?
+            .join(", ");
+        // A generic free function emits real Rust generics
+        // (`fn identity<T: ..>(x: T) -> T`); the suffix is empty otherwise,
+        // including when the body-cleanliness trial forced a fall back to
+        // erasure (`suppress_type_params`). In that case the parameters and body
+        // are already rendered as `SmeltUnknown`, so declaring `<T>` would leave
+        // an unconstrained, uninferable type parameter on the signature.
+        let generics = if *self.suppress_type_params.borrow() {
+            String::new()
+        } else {
+            crate::classes::function_impl_generics_text(self.mir, self.function)?
+        };
+        out.push_str(&format!(
+            "{}fn {}{generics}({fn_params}) -> {} {{\n",
+            if self.function.is_async { "async " } else { "" },
+            self.function_rust_name(self.function)?,
+            self.return_type_text(self.function.return_ty)?
+        ));
+        out.push_str(&body);
+        out.push_str("}\n");
+        Ok(())
+    }
+
+    /// Emit a free function's body (parameter preludes, block, and fallthrough
+    /// return) without the signature or closing brace.
+    ///
+    /// Split out from [`FunctionEmitter::emit`] so a generic free function can
+    /// trial-render its body to decide whether real generics are safe (the body
+    /// must keep each type parameter opaque). The `main` and test-preamble paths
+    /// do not use this helper.
+    fn emit_body(&self, out: &mut String) -> Result<(), EmitError> {
         self.emit_shared_parameter_preludes(out)?;
         if self.function.is_test && self.context.needs_date_now_runtime {
             out.push_str("    SMELT_DATE_NOW.with(|value| value.set(None));\n");
@@ -171,8 +209,39 @@ impl<'mir> FunctionEmitter<'mir> {
         {
             self.emit_fallthrough_return(out)?;
         }
-        out.push_str("}\n");
         Ok(())
+    }
+
+    /// Reset the per-emission scratch state so a function body can be rendered
+    /// again (the generic body-cleanliness trial renders the body once to decide
+    /// on generics, then the real emit renders it again).
+    ///
+    /// Body rendering records which locals have already been declared; that must
+    /// start empty on the next pass or the re-rendered body would omit
+    /// declarations. Only the parameter locals are pre-declared at function
+    /// entry, matching [`FunctionEmitter::new`].
+    fn reset_body_emission_state(&self) {
+        let mut declared = self.declared_locals.borrow_mut();
+        declared.clear();
+        declared.extend(self.function.params.iter().copied());
+    }
+
+    /// Return whether this generic free function's body keeps every type
+    /// parameter opaque, so the function can emit real Rust generics.
+    ///
+    /// Trial-renders the body with the type parameters in scope and checks
+    /// whether the rendered body still needs the erased carrier (see
+    /// [`body_needs_erased_carrier`]). A clean body (pure passthrough) renders no
+    /// erased tokens and keeps its generics; a body that inspects, compares, or
+    /// erases a `T`-typed value falls back to full erasure. The scratch
+    /// declared-locals state is reset afterwards so the real emit renders from a
+    /// clean slate. The caller only invokes this for signature-generic-safe
+    /// functions, so the type parameters are in scope during the trial.
+    pub(crate) fn renders_real_generics(&self) -> Result<bool, EmitError> {
+        let mut body = String::new();
+        self.emit_body(&mut body)?;
+        self.reset_body_emission_state();
+        Ok(!body_needs_erased_carrier(&body))
     }
 
     /// Emits shared cells for parameters mutated through lexical closures.
@@ -2512,6 +2581,7 @@ impl<'mir> FunctionEmitter<'mir> {
                     end: 0,
                 },
             },
+            suppress_type_params: RefCell::new(false),
         }
         .type_text_with_impl_trait(ty, false)
     }
@@ -2554,6 +2624,7 @@ impl<'mir> FunctionEmitter<'mir> {
                     end: 0,
                 },
             },
+            suppress_type_params: RefCell::new(false),
         }
         .type_text_with_scoped_type_params(ty, false, scoped_type_params)
     }
@@ -2593,6 +2664,7 @@ impl<'mir> FunctionEmitter<'mir> {
                     end: 0,
                 },
             },
+            suppress_type_params: RefCell::new(false),
         }
         .default_value(ty)
     }
@@ -2629,6 +2701,7 @@ impl<'mir> FunctionEmitter<'mir> {
                     end: 0,
                 },
             },
+            suppress_type_params: RefCell::new(false),
         }
         .default_value_with_scoped_type_params(ty, scoped_type_params)
     }
@@ -4591,6 +4664,50 @@ fn emitted_tail_returns(out: &str) -> bool {
         .rev()
         .find(|line| !line.trim().is_empty())
         .is_some_and(|line| line.trim_start().starts_with("return "))
+}
+
+/// Tokens that mark a trial-rendered generic free-function body as needing the
+/// erased runtime, so real generics would produce type errors.
+///
+/// These are the erased carrier types and the JavaScript-semantics methods /
+/// conversions that are only implemented for `SmeltUnknown` (and primitives),
+/// not for an arbitrary generic `T`. A body that mentions any of them inspects,
+/// compares, hashes, keys, or erases a `T`-typed value — operations the generic
+/// bounds (`Clone + Default + IntoSmeltUnknown + SmeltFromUnknown`) do not
+/// support on a bare `T` (e.g. `js_strict_eq`, `same_js_key`) or that force a
+/// `T`-vs-`SmeltUnknown` mismatch.
+const ERASED_CARRIER_TOKENS: &[&str] = &[
+    "SmeltUnknown",
+    "SmeltObject",
+    "SmeltArray",
+    "SmeltRecord",
+    "SmeltJsMap",
+    "js_strict_eq",
+    "same_js_key",
+    "smelt_from_unknown",
+    "into_smelt_unknown",
+];
+
+/// Return whether a trial-rendered generic free-function body still needs the
+/// erased runtime carrier.
+///
+/// A generic free function only emits real Rust generics when its body keeps
+/// every type parameter opaque. If the body — rendered with the type parameters
+/// in scope — references any erased carrier type or JavaScript-semantics helper
+/// (see [`ERASED_CARRIER_TOKENS`]), the body inspects, compares, or erases a
+/// `T`-typed value (for example a null/undefined check, a deep-equality
+/// comparison, or a map-keying operation). Emitting real generics for such a
+/// body produces `T`-vs-`SmeltUnknown` mismatches or missing-trait errors, so
+/// the caller falls back to the fully erased signature.
+///
+/// This is a deliberately conservative textual check: any listed token in the
+/// trial body disqualifies generic emission. A pure passthrough body
+/// (`return x;`, `return xs.get(..)..;`) contains none of them and keeps its
+/// generics.
+fn body_needs_erased_carrier(body: &str) -> bool {
+    ERASED_CARRIER_TOKENS
+        .iter()
+        .any(|token| body.contains(token))
 }
 
 // Constant formatting continues in `literals.rs`.

--- a/crates/smelt-codegen-rust/src/emitter/list_query.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_query.rs
@@ -903,6 +903,7 @@ impl FunctionEmitter<'_> {
             let function = MirFunction {
                 id: FuncId(u32::MAX),
                 name: Symbol(u32::MAX),
+                type_params: Vec::new(),
                 origin: HirOrigin::Body(smelt_hir::BodyId(u32::MAX)),
                 is_async: false,
                 is_test: false,

--- a/crates/smelt-codegen-rust/src/emitter/mod.rs
+++ b/crates/smelt-codegen-rust/src/emitter/mod.rs
@@ -88,6 +88,17 @@ pub(crate) struct EmitContext {
     /// { .. }` factory expression. A `BTreeMap` keeps emitted order deterministic.
     pub(crate) function_item_erased_fn_accessors:
         ::std::cell::RefCell<::std::collections::BTreeMap<usize, String>>,
+    /// MIR ids of free functions that emit real Rust generics.
+    ///
+    /// A generic free function only keeps real generics when its signature is
+    /// generic-safe AND its body keeps every type parameter opaque (the body
+    /// trial in [`FunctionEmitter::emit`]). This decision must be identical at
+    /// the definition and at every call site — otherwise a call would pass an
+    /// argument through concretely to a parameter that was actually emitted as
+    /// erased `SmeltUnknown`. The set is computed once by
+    /// [`EmitContext::populate_generic_functions`] and read through
+    /// [`EmitContext::is_generic_function`].
+    generic_functions: RefCell<HashSet<FuncId>>,
 }
 
 impl EmitContext {
@@ -176,7 +187,40 @@ impl EmitContext {
             function_item_erased_fn_accessors: ::std::cell::RefCell::new(
                 ::std::collections::BTreeMap::new(),
             ),
+            generic_functions: RefCell::new(HashSet::new()),
         })
+    }
+
+    /// Compute, once, which free functions emit real Rust generics.
+    ///
+    /// Must be called after [`EmitContext::new`] and before any function is
+    /// emitted. For each free function whose signature is generic-safe, this
+    /// trial-renders the body with the type parameters in scope; the function
+    /// keeps real generics only when the rendered body does not need the erased
+    /// carrier (see `FunctionEmitter::renders_real_generics`). The result is
+    /// shared by the definition and all call sites through
+    /// [`EmitContext::is_generic_function`].
+    pub(crate) fn populate_generic_functions(&self, mir: &Mir) -> Result<(), EmitError> {
+        let mut generic = HashSet::new();
+        for function in &mir.functions {
+            if !matches!(function.origin, HirOrigin::Body(_)) {
+                continue;
+            }
+            if !crate::classes::function_emits_rust_generics(mir, function) {
+                continue;
+            }
+            let emitter = FunctionEmitter::new(mir, self, function)?;
+            if emitter.renders_real_generics()? {
+                generic.insert(function.id);
+            }
+        }
+        *self.generic_functions.borrow_mut() = generic;
+        Ok(())
+    }
+
+    /// Return whether the free function with `id` emits real Rust generics.
+    pub(crate) fn is_generic_function(&self, id: FuncId) -> bool {
+        self.generic_functions.borrow().contains(&id)
     }
 }
 
@@ -651,6 +695,17 @@ pub(crate) struct FunctionEmitter<'mir> {
     none_ty: TypeId,
     /// Synthetic unknown local used when malformed MIR references a missing local.
     unknown_local: LocalDecl,
+    /// When set, a generic free function's own type parameters are treated as
+    /// out of scope (erased to `SmeltUnknown`) even though the function declares
+    /// them.
+    ///
+    /// A generic free function only emits real Rust generics when its body keeps
+    /// each type parameter opaque. The emitter trial-renders the body with the
+    /// type parameters in scope; if the rendered body still references the erased
+    /// `SmeltUnknown` carrier (the body inspects, compares, or erases a
+    /// `T`-typed value), emission falls back to the fully erased signature by
+    /// setting this flag and re-rendering. See [`FunctionEmitter::emit`].
+    suppress_type_params: RefCell<bool>,
 }
 
 /// How to compute the default end bound for a slice.

--- a/crates/smelt-codegen-rust/src/emitter/place.rs
+++ b/crates/smelt-codegen-rust/src/emitter/place.rs
@@ -235,8 +235,20 @@ impl FunctionEmitter<'_> {
                         let base_text = self.local_mut_value_text(*base)?;
                         let index_text =
                             self.normalized_index_text(&format!("{base_text}.len()"), index)?;
-                        // JS out-of-bounds element access is `undefined`, not `null`.
-                        let missing = if matches!(
+                        // JS out-of-bounds element access is `undefined`, not
+                        // `null`. A type parameter that is in scope for the
+                        // current generic function is a real Rust generic, so
+                        // its missing value is `Default::default()` (a `T`), not
+                        // the erased `SmeltUnknown::Undefined` used for genuinely
+                        // erased element types.
+                        let item_is_in_scope_type_param = matches!(
+                            self.mir.types.get(*item_ty),
+                            Some(Type::TypeParam { name })
+                                if self.current_function_has_type_param(*name)
+                        );
+                        let missing = if item_is_in_scope_type_param {
+                            self.default_value(*item_ty)?
+                        } else if matches!(
                             self.mir.types.get(*item_ty),
                             Some(Type::Unknown | Type::TypeParam { .. } | Type::Union(_))
                         ) {

--- a/crates/smelt-codegen-rust/src/emitter/types.rs
+++ b/crates/smelt-codegen-rust/src/emitter/types.rs
@@ -576,23 +576,48 @@ impl FunctionEmitter<'_> {
         )
     }
 
-    /// Return type parameters declared by the current class function scope.
+    /// Return whether `param` is a type parameter in scope for the current
+    /// emitted function.
     ///
-    /// MIR does not model free-function generics yet, but class constructors
-    /// and methods are emitted inside `impl<T> Class<T>` blocks. Their
-    /// signatures must therefore keep class type parameters instead of erasing
-    /// them to `SmeltUnknown`.
+    /// Class constructors and methods are emitted inside `impl<T> Class<T>`
+    /// blocks, so class type parameters are in scope for them. A generic free
+    /// function (`fn identity<T>(x: T) -> T`) declares its own type parameters;
+    /// those are in scope only within that function. Either way, an in-scope
+    /// parameter keeps its generic shape instead of erasing to `SmeltUnknown`.
     pub(super) fn current_function_has_type_param(&self, param: Symbol) -> bool {
         self.current_function_type_params().contains(&param)
     }
 
-    /// Return type parameters declared by the current class function scope.
+    /// Return the type parameters in scope for the current emitted function.
+    ///
+    /// For a class member this is the owning class's generic parameters (the
+    /// member is emitted inside the class `impl<T>` block). For a module-level
+    /// free function it is the function's own declared type parameters, which
+    /// lets a generic free function emit real Rust generics rather than routing
+    /// its `T`-typed parameters and return through the runtime unknown carrier.
     fn current_function_type_params(&self) -> HashSet<Symbol> {
         let class_name = match self.function.origin {
             HirOrigin::ClassConstructor { class, .. }
             | HirOrigin::ClassMethod { class, .. }
             | HirOrigin::ClassStaticMethod { class, .. } => class,
-            HirOrigin::Body(_) => return HashSet::new(),
+            HirOrigin::Body(_) => {
+                // A free function emits real Rust generics only when its
+                // signature is generic-safe (see
+                // `classes::function_emits_rust_generics`) AND the body-cleanliness
+                // trial has not forced a fall back to erasure via
+                // `suppress_type_params`.
+                if *self.suppress_type_params.borrow()
+                    || !crate::classes::function_emits_rust_generics(self.mir, self.function)
+                {
+                    return HashSet::new();
+                }
+                return self
+                    .function
+                    .type_params
+                    .iter()
+                    .map(|param| param.name)
+                    .collect();
+            }
         };
         self.mir
             .classes

--- a/crates/smelt-codegen-rust/src/lib.rs
+++ b/crates/smelt-codegen-rust/src/lib.rs
@@ -377,6 +377,10 @@ fn emit_source_with_free_function_router(
 ) -> Result<String, EmitError> {
     let mut writer = CodeWriter::new();
     let context = EmitContext::new(mir)?;
+    // Decide, once, which free functions emit real Rust generics (signature
+    // safety plus a body-cleanliness trial) so the definition and every call
+    // site agree on the generic-vs-erased shape.
+    context.populate_generic_functions(mir)?;
     let needs_serde_json =
         stdlib::backend_dependencies(mir).contains(&smelt_stdlib::BackendDependency::SerdeJson);
     let needs_regex =

--- a/crates/smelt-codegen-rust/src/stdlib.rs
+++ b/crates/smelt-codegen-rust/src/stdlib.rs
@@ -194,10 +194,12 @@ pub(crate) fn needs_unknown_type(mir: &Mir) -> bool {
     // `Type::Unknown` in the table. Emit the carrier for unions too.
     // A generic class or interface emits inherent/impl blocks whose type
     // parameters are bounded by `IntoSmeltUnknown + SmeltFromUnknown` (see
-    // `classes::class_impl_generics_text`). Those bounds reference the erasure
-    // traits, so the carrier and its traits must be emitted even when a program
-    // has no explicit `unknown`/union value of its own — otherwise the generic
-    // `impl` block names traits that were never declared.
+    // `classes::class_impl_generics_text`). A generic free function emits the
+    // same bounds on its own `fn name<T: ..>` signature (see
+    // `classes::function_impl_generics_text`). Those bounds reference the
+    // erasure traits, so the carrier and its traits must be emitted even when a
+    // program has no explicit `unknown`/union value of its own — otherwise the
+    // generic signature names traits that were never declared.
     mir.classes
         .iter()
         .any(|class| !class.type_params.is_empty())
@@ -205,6 +207,10 @@ pub(crate) fn needs_unknown_type(mir: &Mir) -> bool {
             .interfaces
             .iter()
             .any(|interface| !interface.type_params.is_empty())
+        || mir
+            .functions
+            .iter()
+            .any(|function| !function.type_params.is_empty())
         || mir
             .types
             .all()

--- a/crates/smelt-codegen-rust/src/tests/generics_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/generics_tests.rs
@@ -88,6 +88,142 @@ function usePair(): string {
 }
 
 #[test]
+fn emits_generic_free_function_with_real_rust_generics() {
+    // Issue #99: a generic free function lowers to real Rust generics rather
+    // than erasing `T` to `SmeltUnknown`.
+    let source = source_for(
+        r"
+export function identity<T>(x: T): T {
+  return x;
+}
+",
+    );
+
+    // The signature carries a bounded generic parameter, and `T` appears in
+    // both the parameter and return positions.
+    assert!(source.contains(
+        "fn identity<T: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'static>(x: T) -> T"
+    ));
+    // `T` is NOT erased to the runtime carrier at either position.
+    assert!(!source.contains("fn identity(x: SmeltUnknown) -> SmeltUnknown"));
+}
+
+#[test]
+fn monomorphizes_generic_free_function_call_site() {
+    // Issue #99: calling a generic free function with a concrete argument passes
+    // the value through so Rust monomorphizes the call; the result is typed with
+    // the concrete instantiation and needs no `SmeltUnknown` extraction.
+    let source = source_for(
+        r"
+export function identity<T>(x: T): T {
+  return x;
+}
+export function useIdentity(): number {
+  return identity(3);
+}
+",
+    );
+
+    // The argument is passed through concretely (`3.0`), not wrapped in
+    // `SmeltUnknown::Number(..)`, so Rust infers `identity::<f64>`.
+    assert!(source.contains("identity(3.0)"));
+    assert!(!source.contains("identity(SmeltUnknown"));
+}
+
+#[test]
+fn emits_two_parameter_generic_free_function() {
+    // Issue #99: multiple type parameters each render as their own Rust generic
+    // in the parameter list and return position.
+    let source = source_for(
+        r"
+export function pair<A, B>(first: A, second: B): B {
+  return second;
+}
+",
+    );
+
+    assert!(source.contains(
+        "fn pair<A: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'static, B: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'static>(first: A, second: B) -> B"
+    ));
+}
+
+#[test]
+fn emits_generic_free_function_over_list_parameter() {
+    // Issue #99: a type parameter nested inside a `T[]` parameter still renders
+    // the parameter's generic shape (`SmeltList<T>`) instead of erasing it.
+    let source = source_for(
+        r"
+export function first<T>(xs: T[]): T {
+  return xs[0];
+}
+",
+    );
+
+    assert!(source.contains(
+        "fn first<T: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'static>(xs: SmeltList<T>) -> T"
+    ));
+}
+
+#[test]
+fn erases_generic_free_function_with_bounded_type_param() {
+    // Issue #99 (deferred slice): a BOUNDED type parameter still needs method
+    // dispatch through the erased boundary, so the function falls back to full
+    // erasure rather than emitting an unusable generic.
+    let source = source_for(
+        r"
+export function invalid<D extends Date>(value: D): boolean {
+  return isNaN(value.getTime());
+}
+",
+    );
+
+    // No real generic parameter is declared; the parameter is erased.
+    assert!(!source.contains("fn invalid<D"));
+    assert!(source.contains("fn invalid(value: SmeltUnknown) -> bool"));
+}
+
+#[test]
+fn erases_generic_free_function_when_body_inspects_type_param() {
+    // Issue #99 (safety fallback): a body that inspects, compares, or erases a
+    // `T`-typed value cannot keep real generics (the operations are only defined
+    // on the erased carrier), so the whole function falls back to erasure. Here
+    // the `===` comparison forces the erased path.
+    let source = source_for(
+        r"
+export function same<T>(a: T, b: T): boolean {
+  return a === b;
+}
+",
+    );
+
+    // The signature declares no real generic parameter; both parameters erase.
+    assert!(!source.contains("fn same<T"));
+    assert!(source.contains("fn same(a: SmeltUnknown, b: SmeltUnknown) -> bool"));
+}
+
+#[test]
+fn erases_generic_free_function_called_with_erased_argument() {
+    // Issue #99 (safety fallback): when a generic free function is invoked with
+    // an already-erased argument, Rust cannot infer its type parameter at the
+    // call site (`E0283`). The crate-wide decision demotes such a function to the
+    // erased signature so the argument binds directly.
+    let source = source_for(
+        r"
+export function identity<T>(x: T): T {
+  return x;
+}
+export function passErased(u: unknown): unknown {
+  return identity(u);
+}
+",
+    );
+
+    // `identity` is called with an erased `unknown`, so it is emitted erased.
+    assert!(source.contains("fn identity(x: SmeltUnknown) -> SmeltUnknown"));
+    assert!(!source.contains("fn identity<T"));
+}
+
+#[test]
 fn emits_generic_interface_type_params() {
     let source = source_for(
         r#"

--- a/crates/smelt-codegen-rust/src/tests/part_2_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_2_tests.rs
@@ -171,8 +171,15 @@ function invalid<ResultDate extends Date>(value: ResultDate): boolean {
 ",
     );
 
-    assert!(source.contains(".is_nan()"), "{source}");
-    assert!(!source.contains("return false;"), "{source}");
+    // Scope the negative assertion to the generated program: a bounded generic
+    // free function now emits the `SmeltUnknown` prelude (whose `for...in`
+    // helpers legitimately contain `return false;`), so the assertion must look
+    // only at the emitted `invalid` body, not the runtime prelude.
+    let program = source
+        .split_once(crate::PRELUDE_END_MARKER)
+        .map_or(source.as_str(), |(_, program)| program);
+    assert!(program.contains(".is_nan()"), "{source}");
+    assert!(!program.contains("return false;"), "{source}");
 }
 
 #[test]
@@ -331,14 +338,21 @@ function absent<ResultDate extends Date>(
 ",
     );
 
+    // Scope assertions to the generated program: a bounded generic free
+    // function now emits the `SmeltUnknown` prelude, whose match arms mention
+    // `Some(SmeltUnknown::Number(value))`, so the negative assertion must look
+    // only at the emitted `absent` body rather than the runtime prelude.
+    let program = source
+        .split_once(crate::PRELUDE_END_MARKER)
+        .map_or(source.as_str(), |(_, program)| program);
     assert!(
-        source.contains(
+        program.contains(
             "result.clone().as_ref().map_or(true, |value| matches!(value, SmeltUnknown::Null | SmeltUnknown::Undefined))"
         ),
         "{source}"
     );
     assert!(
-        !source.contains("Some(SmeltUnknown::Number(value))"),
+        !program.contains("Some(SmeltUnknown::Number(value))"),
         "{source}"
     );
 }

--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -739,6 +739,43 @@ export function makeOk(v: number): Outcome<number, string> {
 "#,
         },
         Case {
+            // Issue #99 (deferred piece of #102): generic FREE functions lower to
+            // real Rust generics rather than erasing `T` to `SmeltUnknown`.
+            // `identity<T>` emits `fn identity<T: ..>(x: T) -> T`; `first<T>`
+            // exercises a type parameter nested in a `T[]` parameter; `pair<A, B>`
+            // exercises multiple type parameters. The call sites (`identity(3)`,
+            // `first([...])`, `pair(1, "x")`) pass concrete arguments through so
+            // Rust monomorphizes each call, and the concrete results bind to the
+            // callers' concrete return types — all of which must compile.
+            name: "generic_free_functions",
+            area: "generics",
+            source: r#"
+export function identity<T>(x: T): T {
+  return x;
+}
+
+export function first<T>(xs: T[]): T {
+  return xs[0];
+}
+
+export function pair<A, B>(first: A, second: B): B {
+  return second;
+}
+
+export function useIdentity(): number {
+  return identity(3);
+}
+
+export function useFirst(): number {
+  return first([1, 2, 3]);
+}
+
+export function usePair(): string {
+  return pair(1, "x");
+}
+"#,
+        },
+        Case {
             // Issue #78: `switch` over non-literal case labels. Enum-member and
             // const-reference labels const-fold to the member's numeric/string
             // literal, and the enum type resolves to its underlying primitive so

--- a/crates/smelt-frontend-py/src/lowering/class.rs
+++ b/crates/smelt-frontend-py/src/lowering/class.rs
@@ -979,6 +979,8 @@ impl ModuleBuilder<'_> {
             let placeholder = Item::Function(Function {
                 name: method_sym,
                 span: self.span(func.range),
+                // Methods take generics from the owning class.
+                type_params: Vec::new(),
                 params: Vec::new(),
                 rest: None,
                 required_params: None,
@@ -1177,6 +1179,8 @@ impl ModuleBuilder<'_> {
         let item = Item::Function(Function {
             name: method_sym,
             span,
+            // Methods take generics from the owning class.
+            type_params: Vec::new(),
             params,
             rest: None,
             required_params: None,

--- a/crates/smelt-frontend-py/src/lowering/class_init.rs
+++ b/crates/smelt-frontend-py/src/lowering/class_init.rs
@@ -118,6 +118,8 @@ impl ModuleBuilder<'_> {
         let item = Item::Function(Function {
             name: init_sym,
             span,
+            // Constructors take generics from the owning class.
+            type_params: Vec::new(),
             params,
             rest: None,
             required_params: None,
@@ -164,6 +166,8 @@ return_ty: none_ty,
         self.ctx.krate.push_item(Item::Function(Function {
             name: init_sym,
             span,
+            // Constructors take generics from the owning class.
+            type_params: Vec::new(),
             params: Vec::new(),
             rest: None,
             required_params: None,

--- a/crates/smelt-frontend-py/src/lowering/function.rs
+++ b/crates/smelt-frontend-py/src/lowering/function.rs
@@ -237,6 +237,9 @@ impl ModuleBuilder<'_> {
         let item = Item::Function(Function {
             name,
             span: func_span,
+            // Generic free functions are a TypeScript-frontend feature; the
+            // Python frontend declares no free-function type params here.
+            type_params: Vec::new(),
             params: Vec::new(),
             rest: None,
             required_params: None,

--- a/crates/smelt-frontend-py/src/lowering/pytest.rs
+++ b/crates/smelt-frontend-py/src/lowering/pytest.rs
@@ -332,6 +332,8 @@ impl ModuleBuilder<'_> {
         let item = Item::Function(Function {
             name,
             span: func_span,
+            // Synthetic pytest wrapper carries no type params.
+            type_params: Vec::new(),
             params,
             rest: None,
             required_params: None,

--- a/crates/smelt-frontend-py/src/lowering/specialization.rs
+++ b/crates/smelt-frontend-py/src/lowering/specialization.rs
@@ -125,6 +125,8 @@ impl ModuleBuilder<'_> {
         let item = self.ctx.krate.push_item(Item::Function(Function {
             name: symbol,
             span,
+            // Specialized synthetic function carries no type params.
+            type_params: Vec::new(),
             params: Vec::new(),
             rest: None,
             required_params: None,

--- a/crates/smelt-frontend-py/src/lowering/type_helpers.rs
+++ b/crates/smelt-frontend-py/src/lowering/type_helpers.rs
@@ -229,6 +229,8 @@ impl ModuleBuilder<'_> {
         let item = Item::Function(Function {
             name,
             span,
+            // Synthetic type-helper function carries no type params.
+            type_params: Vec::new(),
             params: Vec::new(),
             rest: None,
             required_params: None,

--- a/crates/smelt-frontend-ts/src/lowering/decls/arrows.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/arrows.rs
@@ -333,6 +333,9 @@ impl ModuleBuilder<'_> {
         let item = self.ctx.krate.push_item(Item::Function(Function {
             name,
             span: self.span(arrow.span.start, arrow.span.end),
+            // Generic arrow functions are deferred; a lifted arrow item declares
+            // no free-function type params in this increment.
+            type_params: Vec::new(),
             params,
             rest: rest.map(|rest| rest.index),
             required_params: Some(
@@ -607,6 +610,8 @@ return_ty: target_function.return_ty,
         let item = self.ctx.krate.push_item(Item::Function(Function {
             name,
             span,
+            // Synthetic wrapper item carries no free-function type params.
+            type_params: Vec::new(),
             params: wrapper_params,
             rest: target_function.rest,
             required_params: None,

--- a/crates/smelt-frontend-ts/src/lowering/decls/constructor.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/constructor.rs
@@ -664,6 +664,9 @@ impl ModuleBuilder<'_> {
         Ok(self.ctx.krate.push_item(Item::Function(Function {
             name,
             span,
+            // Class constructors take their generics from the owning class, so
+            // the function item itself declares no free-function type params.
+            type_params: Vec::new(),
             params,
             rest: None,
             required_params: None,
@@ -802,6 +805,9 @@ impl ModuleBuilder<'_> {
         let item = self.ctx.krate.push_item(Item::Function(Function {
             name: method_symbol,
             span,
+            // Method generics come from the owning class; the function item
+            // declares no free-function type params.
+            type_params: Vec::new(),
             params,
             rest: None,
             required_params: None,

--- a/crates/smelt-frontend-ts/src/lowering/decls/functions.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/functions.rs
@@ -55,7 +55,11 @@ impl ModuleBuilder<'_> {
             ));
         };
         let name = self.intern_source_name(name_text);
-        let _type_params = self.push_type_parameter_scope(function.type_parameters.as_deref())?;
+        // Retain the declared type parameters so a generic free function such as
+        // `function identity<T>(x: T): T` lowers to real Rust generics instead
+        // of erasing `T` to `SmeltUnknown`. The scope is popped below like any
+        // other function scope; the lowered `TypeParamDef`s survive on the item.
+        let type_params = self.push_type_parameter_scope(function.type_parameters.as_deref())?;
         let assertion_return = match function
             .return_type
             .as_ref()
@@ -394,6 +398,7 @@ impl ModuleBuilder<'_> {
         let function_item = Function {
             name,
             span: self.span(function.span.start, function.span.end),
+            type_params,
             params,
             rest: rest.map(|rest| rest.index),
             required_params: Some(required_params),
@@ -607,7 +612,7 @@ impl ModuleBuilder<'_> {
         }
 
         let name = self.intern_exact_source_name(name_text);
-        let _type_params = self.push_type_parameter_scope(function.type_parameters.as_deref())?;
+        let type_params = self.push_type_parameter_scope(function.type_parameters.as_deref())?;
         let hinted_function =
             type_hint.and_then(|ty| match self.ctx.krate.types.get(ty).cloned() {
                 Some(Type::Function(function_ty)) => Some(function_ty),
@@ -770,6 +775,7 @@ impl ModuleBuilder<'_> {
         Ok(self.ctx.krate.push_item(Item::Function(Function {
             name,
             span: self.span(function.span.start, function.span.end),
+            type_params,
             params,
             rest: None,
             required_params: None,
@@ -1780,6 +1786,8 @@ impl ModuleBuilder<'_> {
         Ok(self.ctx.krate.push_item(Item::Function(Function {
             name,
             span,
+            // Synthetic default constructor takes generics from the class.
+            type_params: Vec::new(),
             params,
             rest: None,
             required_params: has_base.then_some(0),
@@ -2347,6 +2355,9 @@ impl ModuleBuilder<'_> {
         Ok(self.ctx.krate.push_item(Item::Function(Function {
             name: method_name,
             span: self.span(method.span.start, method.span.end),
+            // Class members take generics from the owning class; per-method
+            // generics are deferred alongside the generic-class increment.
+            type_params: Vec::new(),
             params,
             rest: None,
             required_params: None,

--- a/crates/smelt-frontend-ts/src/lowering/expr/references.rs
+++ b/crates/smelt-frontend-ts/src/lowering/expr/references.rs
@@ -1391,6 +1391,8 @@ return_ty: function.return_ty,
         self.ctx.krate.push_item(Item::Function(Function {
             name,
             span,
+            // Synthetic reference stub carries no free-function type params.
+            type_params: Vec::new(),
             params: Vec::new(),
             rest: None,
             required_params: None,

--- a/crates/smelt-frontend-ts/src/lowering/module_init.rs
+++ b/crates/smelt-frontend-ts/src/lowering/module_init.rs
@@ -1364,13 +1364,13 @@ impl<'ctx> ModuleBuilder<'ctx> {
         if self.local_function_items.contains_key(id.name.as_str()) {
             return Ok(());
         }
-        let _type_params = self.push_type_parameter_scope(function.type_parameters.as_deref())?;
+        let type_params = self.push_type_parameter_scope(function.type_parameters.as_deref())?;
         let predicate_return = function
             .return_type
             .as_ref()
             .and_then(|annotation| self.predicate_return_type(&annotation.type_annotation))
             .transpose();
-        let result = self.predeclared_function(function, id.name.as_str());
+        let result = self.predeclared_function(function, id.name.as_str(), type_params);
         let returns_date = result
             .as_ref()
             .is_ok_and(|predeclared| self.type_is_known_date_value(predeclared.return_ty));
@@ -1414,6 +1414,7 @@ impl<'ctx> ModuleBuilder<'ctx> {
         &mut self,
         function: &oxc::ast::ast::Function<'_>,
         name_text: &str,
+        type_params: Vec<smelt_hir::TypeParamDef>,
     ) -> Result<Function, SmeltError> {
         let name = self.intern_source_name(name_text);
         let mut params = Vec::new();
@@ -1495,6 +1496,7 @@ impl<'ctx> ModuleBuilder<'ctx> {
         Ok(Function {
             name,
             span: self.span(function.span.start, function.span.end),
+            type_params,
             params,
             rest: rest_index,
             required_params: Some(required_params),

--- a/crates/smelt-frontend-ts/src/lowering/testing/suites.rs
+++ b/crates/smelt-frontend-ts/src/lowering/testing/suites.rs
@@ -569,6 +569,8 @@ impl ModuleBuilder<'_> {
         let item = self.ctx.krate.push_item(Item::Function(Function {
             name,
             span,
+            // Synthetic test wrapper carries no free-function type params.
+            type_params: Vec::new(),
             params: Vec::new(),
             rest: None,
             required_params: None,
@@ -682,6 +684,8 @@ return_ty: none,
         let item = self.ctx.krate.push_item(Item::Function(Function {
             name,
             span,
+            // Synthetic test wrapper carries no free-function type params.
+            type_params: Vec::new(),
             params: Vec::new(),
             rest: None,
             required_params: None,

--- a/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
@@ -128,6 +128,46 @@ export function useContainer(): number {
 }
 
 #[test]
+fn lowers_generic_free_function_with_type_params() -> Result<(), String> {
+    // Issue #99: a generic free function retains its declared type parameters on
+    // the HIR `Function` item (they were previously dropped at
+    // `function_declaration_named`), so MIR and codegen can emit real Rust
+    // generics instead of erasing `T` to `SmeltUnknown`.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r"
+export function identity<T>(x: T): T {
+  return x;
+}
+"),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+
+    let identity = ctx
+        .krate
+        .items
+        .iter()
+        .find_map(|item| match item {
+            Item::Function(function)
+                if ctx.krate.symbols.get(function.name) == Some("identity") =>
+            {
+                Some(function)
+            }
+            _ => None,
+        })
+        .ok_or_else(|| "identity function not lowered".to_owned())?;
+    ensure_eq!(identity.type_params.len(), 1);
+    let type_param = identity
+        .type_params
+        .first()
+        .ok_or_else(|| "identity has no type parameter".to_owned())?;
+    ensure_eq!(ctx.krate.symbols.get(type_param.name), Some("T"));
+    Ok(())
+}
+
+#[test]
 fn lowers_numeric_property_keys() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-hir/src/format/types.rs
+++ b/crates/smelt-hir/src/format/types.rs
@@ -34,7 +34,8 @@ pub(super) fn item_text(krate: &Crate, item: ItemId) -> String {
     match item_value {
         Item::Function(function) => {
             let name = krate.symbols.get(function.name).unwrap_or("<unknown>");
-            format!("fn {name} owner {:?}", function.owner)
+            let type_params = type_params_text(krate, &function.type_params);
+            format!("fn {name}{type_params} owner {:?}", function.owner)
         }
         Item::Class(class) => class_item_text(krate, class),
         Item::Interface(interface) => interface_item_text(krate, interface),

--- a/crates/smelt-hir/src/item.rs
+++ b/crates/smelt-hir/src/item.rs
@@ -62,6 +62,14 @@ pub struct Function {
     pub name: Symbol,
     /// Source location of the function declaration.
     pub span: Span,
+    /// Generic type parameters declared by the function.
+    ///
+    /// A generic free function such as `function identity<T>(x: T): T` carries
+    /// its declared type parameters here so MIR and codegen can emit real Rust
+    /// generics (`fn identity<T>(x: T) -> T`) instead of erasing `T` to
+    /// `SmeltUnknown`. Non-generic functions and class members (whose generics
+    /// come from the owning class) leave this empty.
+    pub type_params: Vec<TypeParamDef>,
     /// Parameters of the function.
     pub params: Vec<Param>,
     /// Index of the rest parameter, if this function declares one.

--- a/crates/smelt-mir/src/lib.rs
+++ b/crates/smelt-mir/src/lib.rs
@@ -391,4 +391,37 @@ async function run(): Promise<number> {
             "the class type parameter name is preserved in MIR"
         );
     }
+
+    #[test]
+    fn propagates_generic_free_function_type_params_into_mir() {
+        // Issue #99: HIR generic free-function type parameters survive into
+        // `MirFunction` so codegen can emit `fn identity<T>(x: T) -> T`.
+        let mut ctx = HirCtx::new();
+        ok_or_panic(
+            to_hir(
+                "export function identity<T>(x: T): T {\n  return x;\n}\n",
+                FileId(0),
+                &mut ctx,
+            ),
+            "HIR",
+        );
+
+        let mir = ok_or_panic(lower_hir(&ctx.krate), "MIR");
+        let identity = mir
+            .functions
+            .iter()
+            .find(|function| mir.symbols.get(function.name) == Some("identity"))
+            .unwrap_or_else(|| {
+                std::panic::resume_unwind(Box::new("identity function lowered to MIR".to_owned()))
+            });
+        assert_eq!(identity.type_params.len(), 1);
+        let type_param = identity.type_params.first().unwrap_or_else(|| {
+            std::panic::resume_unwind(Box::new("identity has a type parameter".to_owned()))
+        });
+        assert_eq!(
+            mir.symbols.get(type_param.name),
+            Some("T"),
+            "the free-function type parameter name is preserved in MIR"
+        );
+    }
 }

--- a/crates/smelt-mir/src/lower/context.rs
+++ b/crates/smelt-mir/src/lower/context.rs
@@ -192,6 +192,12 @@ impl<'hir> LoweringCtx<'hir> {
         if let Some(hir_function) = function_item_for_body(shared.krate, body_id) {
             function.is_test = hir_function.is_test;
             function.rest = hir_function.rest;
+            // Propagate a generic free function's declared type parameters so
+            // codegen can emit real Rust generics rather than erasing `T` to
+            // `SmeltUnknown`.
+            function
+                .type_params
+                .clone_from(&hir_function.type_params);
         }
         let locals = build_locals(&mut function, body)?;
 

--- a/crates/smelt-mir/src/type_normalize.rs
+++ b/crates/smelt-mir/src/type_normalize.rs
@@ -40,6 +40,7 @@ pub fn normalize_operational_types(mir: &mut Mir) {
 
 /// Normalize one MIR function signature, locals, and typed statements.
 fn normalize_function(mir: &mut Mir, function: &mut MirFunction) {
+    normalize_type_params(mir, &mut function.type_params);
     function.return_ty = normalize(mir, function.return_ty);
     for local in &mut function.locals {
         local.ty = normalize(mir, local.ty);

--- a/crates/smelt-mir/src/types.rs
+++ b/crates/smelt-mir/src/types.rs
@@ -265,6 +265,13 @@ pub struct MirFunction {
     pub id: FuncId,
     /// Name of the function.
     pub name: Symbol,
+    /// Generic type parameters declared by a generic free function.
+    ///
+    /// Propagated from HIR so codegen can emit real Rust generics
+    /// (`fn identity<T>(x: T) -> T`) for a generic free function and keep `T`
+    /// in scope while rendering its parameter and return types. Class members
+    /// carry no entries here; their generics come from the owning `MirClass`.
+    pub type_params: Vec<smelt_hir::TypeParamDef>,
     /// Origin information (from HIR).
     pub origin: HirOrigin,
     /// Whether this is an async function.
@@ -299,6 +306,7 @@ impl MirFunction {
         Self {
             id,
             name,
+            type_params: Vec::new(),
             origin,
             is_async: false,
             is_test: false,


### PR DESCRIPTION
## Summary

Lands the deferred piece of #102: **generic free functions**
(`function identity<T>(x: T): T`) now lower to real, monomorphizable Rust
generics (`fn identity<T: ..>(x: T) -> T`) instead of erasing `T` to
`SmeltUnknown`. Concrete arguments pass through so Rust infers the instantiation
(`identity(3)` → `identity::<f64>`).

PR #102 landed generic classes/interfaces but deferred free functions because
HIR/MIR `Function` did not carry `type_params` (the TS frontend dropped them at
`function_declaration_named`). This threads them through and emits typed
generics, keeping genuine dynamic boundaries erased.

## What changed

**Threading `type_params`**
- HIR `Function` and MIR `MirFunction` carry `type_params`; the TS frontend no
  longer drops them (declaration + predeclare paths). All other `Function`
  construction sites (class members, arrows, synthetic/test/Python) set empty.
- MIR propagates the HIR function's type params and normalizes their
  constraints/defaults like class/interface params.

**Codegen — typed generics + call-site monomorphization**
- New `function_impl_generics_text` renders `<T: Clone + Default +
  IntoSmeltUnknown + SmeltFromUnknown + 'static>`, mirroring generic class impl
  blocks. The scoped-type-param machinery now keeps a free function's own type
  params in scope, so `T` renders as `T` in params/return.
- Call sites pass concrete arguments through to a type-param position, and a
  function returning its own type param uses the dest's concrete type as the
  source (no spurious `SmeltUnknown` extraction), matching the generic-class
  approach. `needs_unknown_type` accounts for generic free functions.

**Soundness gating (no faking with SmeltUnknown)**
A free function emits real generics ONLY when provably safe for Rust inference at
every site. The crate decides this once (`EmitContext::populate_generic_functions`)
so the definition and all call sites agree. It is demoted to full erasure when:
- a type parameter is bounded (`<D extends Date>`), used only in the return, or
  nested inside a callback parameter;
- the rendered body still needs the erased carrier (it inspects/compares/erases a
  `T`-typed value — `===`, deep-equality, map keying);
- any call site passes an already-erased argument (`SmeltUnknown`/union) into a
  type-param position (would otherwise be `E0283`).

## Scope covered vs deferred

**Covered:** unconstrained single- and multi-parameter generic free functions
with `T` in direct value parameter positions (`T`, `T[]`, `Option<T>`, …) and in
the return; concrete-argument monomorphization at call sites — all as typed Rust,
no `SmeltUnknown` shortcut.

**Deferred (documented):** bounded type params (`<D extends Date>`), higher-order
(type param inside a callback parameter), return-only type params (type
predicates `data is T`), generic arrow functions, and per-method class generics.
These stay fully erased.

## Tests

- Frontend: HIR type-param retention on a generic free function.
- MIR: type-param propagation into `MirFunction`.
- Codegen: real-generics regressions (single/multi-param, `T[]` parameter) plus
  the three erasure fallbacks (bounded param, body inspects `T`, erased-argument
  call site).
- Compile-corpus: new `generic_free_functions` case that `cargo check`s the
  emitted crate clean.

Full `smelt-hir` (4), `smelt-mir` (12), `smelt-frontend-ts` (759),
`smelt-frontend-py` (186), and `smelt-codegen-rust` (491) suites pass; `cargo
check` on the whole workspace and `cargo clippy` on the touched crates are clean.
**Remeda gate stays 1789/0.**

Part of #99 (object model / #18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)