### PR TITLE
fix(frontend-ts): resolve undeclared class/interface field access (#114)

### DIFF
--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -918,6 +918,32 @@ export function drive(data: Iterable<unknown>): unknown[] {
 }
 ",
         },
+        Case {
+            // Issue #114 (follow-up to #83/#84): dotted access to an *undeclared*
+            // member of a class with an index signature used to hit the
+            // `unknown class or interface field` gate. It now resolves through
+            // the index signature's value type: a dotted read is a keyed lookup
+            // into the runtime store (issue #84), typed as the index value `T`
+            // rather than an erased `Unknown`, and the emitted Rust must
+            // compile. Declared named members (`bag.size`) still use the
+            // concrete struct access; only undeclared names route to the store.
+            name: "undeclared_index_signature_field_access",
+            area: "field_access",
+            source: r"
+class StringBag {
+  size: number = 0;
+  [key: string]: string | number;
+}
+
+export function readNamed(bag: StringBag): number {
+  return bag.size;
+}
+
+export function readDynamic(bag: StringBag): string | number {
+  return bag.anything;
+}
+",
+        },
         // --- array literals with function / this / class elements ------------
         Case {
             name: "array_literal_expr_elements",

--- a/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
@@ -1291,6 +1291,35 @@ impl<'builder> ModuleBuilder<'builder> {
         })))
     }
 
+    /// Return whether a static-member expression names `Class.staticMethod` on a
+    /// bare, unshadowed class identifier.
+    ///
+    /// This mirrors the preconditions of [`Self::class_static_method_call`] so
+    /// other member-call dispatchers can defer such calls to it instead of
+    /// lowering them as callable-field reads (which would erase the concrete
+    /// associated function to the runtime `SmeltUnknown` call ABI). It is a
+    /// read-only check: the receiver identifier must resolve to a declared class
+    /// (not a local) whose `static_methods` include the accessed property.
+    fn static_member_is_class_static_method(
+        &self,
+        member: &oxc::ast::ast::StaticMemberExpression<'_>,
+    ) -> bool {
+        let Expression::Identifier(object) = &member.object else {
+            return false;
+        };
+        if self.locals.contains_key(object.name.as_str()) {
+            return false;
+        }
+        let Some(class_item) = self.classes.get(object.name.as_str()).copied() else {
+            return false;
+        };
+        let Item::Class(class) = self.item_ref(class_item) else {
+            return false;
+        };
+        self.resolve_class_static_method(&class.static_methods.clone(), member.property.name.as_str())
+            .is_some()
+    }
+
     /// Return the static method item on a class matching `method_name`, if any.
     fn resolve_class_static_method(
         &self,
@@ -1319,6 +1348,20 @@ impl<'builder> ModuleBuilder<'builder> {
         let Expression::StaticMemberExpression(member) = &call.callee else {
             return Ok(None);
         };
+        // `Class.staticMethod(...)` is a receiver-free associated-function call,
+        // resolved authoritatively by `class_static_method_call` (dispatched
+        // right after this helper). It must not be lowered here as a callable
+        // *field* read on the class value: the callee-field lowering below would
+        // route it through the erased `SmeltUnknown` call ABI instead of the
+        // concrete `Class::staticMethod` associated function. This guard used to
+        // be implicit — undeclared field access on a `Type::Class` receiver hard-
+        // errored, so `static_member_no_absent_fallback` failed and this helper
+        // bailed. Issue #114 made that access route to the dynamic boundary
+        // instead of erroring, so the deferral is now made explicit here rather
+        // than relying on the removed hard error.
+        if self.static_member_is_class_static_method(member) {
+            return Ok(None);
+        }
         if member.property.name == "call" {
             let callable = self.expression(&member.object, body)?;
             let callable_ty = Self::expr_ty(body, callable);

--- a/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
@@ -1956,7 +1956,6 @@ return_ty: function.return_ty,
                     })))
                 });
                 let interface = self.find_interface(name).cloned();
-                let interface_exists = interface.is_some();
                 let interface_field = if let Some(interface) = interface {
                     let substitutions = self.type_argument_substitution(
                         &interface.type_params,
@@ -2076,40 +2075,28 @@ return_ty: function.return_ty,
                 {
                     return Ok(ty);
                 }
-                if self.class_by_symbol(name).is_none()
-                    && class_name.as_deref().is_none_or(|sidecar_name| {
-                        !self.class_fields.contains_key(sidecar_name)
-                    })
-                    && !interface_exists
-                {
-                    return Ok(self.ctx.krate.types.intern(Type::Unknown));
-                }
-                if self
-                    .class_by_symbol(name)
-                    .is_some_and(|class| class.base.is_some())
-                    || self
-                        .ctx
-                        .krate
-                        .symbols
-                        .get(name)
-                        .is_some_and(|base_lookup_name| {
-                            self.class_bases.contains_key(base_lookup_name)
-                        })
-                {
-                    return Ok(self.ctx.krate.types.intern(Type::Unknown));
-                }
-                let field_name = self.ctx.krate.symbols.get(field).unwrap_or("<unknown>");
-                if field_name == "id" {
-                    return Ok(self.ctx.krate.types.intern(Type::Unknown));
-                }
-                if interface_exists {
-                    return Ok(self.ctx.krate.types.intern(Type::Unknown));
-                }
-                let receiver_name = self.ctx.krate.symbols.get(name).unwrap_or("<unknown>");
-                Err(SmeltError::unsupported(
-                    self.span(0, 0),
-                    format!("unknown class or interface field `{field_name}` on `{receiver_name}`"),
-                ))
+                // Static resolution is exhausted: the field is not a declared
+                // named field/method, an index-signature value, a builtin
+                // member, or reachable through the base class or interface
+                // heritage chains. In valid TypeScript, dot access still type-
+                // checks in exactly one situation — the receiver's static shape
+                // is *widened* or *dynamic*: an index signature on a base type,
+                // an `any`-typed heritage clause, a declaration-merged member,
+                // or (during isolated per-file lowering, where cross-module
+                // classes expose no fields here) a class whose full member set
+                // is simply not visible yet. Routing these to the `Unknown`
+                // dynamic boundary is the honest lowering; hard-erroring would
+                // reject source TypeScript accepts. This is not SmeltUnknown
+                // *widening* of statically-typed access — every static resolver
+                // above is tried first, so declared members keep their concrete
+                // types and only genuinely-unresolvable dynamic access lands
+                // here. Issue #114 (follow-up to #83/#84): resolvable
+                // undeclared-field access now flows through the index signature
+                // (`class_index_field`/`interface_index_values`) above, and the
+                // residual unresolvable case falls through to the boundary
+                // instead of the old per-field (`id`) / interface-exists /
+                // has-base escape hatches.
+                Ok(self.ctx.krate.types.intern(Type::Unknown))
             }
             _ => Err(SmeltError::unsupported(
                 self.span(0, 0),

--- a/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
@@ -622,3 +622,118 @@ export function area(radius: number): number {
     ));
     Ok(())
 }
+
+/// Issue #114 (follow-up to #83/#84): dotted access to an *undeclared* member of
+/// a class that carries a string index signature resolves through the index
+/// signature's value type, not the erased `Unknown` boundary. `bag.anything`
+/// is a keyed store read whose static type is the index value `string`, so the
+/// function that returns it type-checks concretely. This is the statically
+/// resolvable case the blocker used to reject; it must lower without error and
+/// keep its concrete type.
+#[test]
+fn resolves_dot_access_on_class_index_signature() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+class StringBag {
+  [key: string]: string;
+}
+export function readBag(bag: StringBag): string {
+  return bag.anything;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    // The undeclared dotted read stays concretely typed as the index value
+    // (`string`), never widened to `Unknown`.
+    let read_bag = module
+        .items
+        .iter()
+        .find_map(|item| match ctx.krate.items.get(item.0 as usize)? {
+            Item::Function(function)
+                if ctx.krate.symbols.get(function.name) == Some("read_bag") =>
+            {
+                Some(function)
+            }
+            _ => None,
+        })
+        .ok_or_else(|| "missing read_bag function".to_owned())?;
+    ensure!(matches!(
+        ctx.krate.types.get(read_bag.return_ty),
+        Some(Type::String)
+    ));
+    Ok(())
+}
+
+/// Issue #114: dotted access to an undeclared member of a class whose base type
+/// carries an index signature resolves through the *inherited* index value
+/// type. `derived.dynamic` finds no named field on `Derived` and no index
+/// signature on `Derived` itself, but the base `Bag`'s string index signature
+/// supplies the value type. The subclass access must not hard-error.
+#[test]
+fn resolves_dot_access_through_inherited_index_signature() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+class Bag {
+  [key: string]: string;
+}
+class Derived extends Bag {
+  size: number = 0;
+}
+export function readDynamic(derived: Derived): string {
+  return derived.dynamic;
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+/// Issue #114: an undeclared dotted read on a concrete class with neither an
+/// index signature nor a resolvable base no longer aborts lowering with the
+/// `unknown class or interface field` blocker. Static resolution (declared
+/// fields, methods, index signatures, base/interface heritage, builtins) is
+/// exhausted, so the access routes to the explicit `Unknown` dynamic boundary
+/// (mirroring how interface receivers and `id`-named reads were already handled
+/// through ad-hoc escape hatches that this general rule replaces). In valid
+/// TypeScript this only type-checks for widened/dynamic receivers or — as under
+/// isolated per-file lowering — a receiver whose full member set is not visible
+/// here; either way the honest lowering is the boundary, not a hard error. This
+/// is not SmeltUnknown *widening* of statically-typed access: every static
+/// resolver is tried first, so the declared field `x` keeps its concrete type.
+#[test]
+fn routes_unresolved_class_field_to_dynamic_boundary_without_error() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+class Point {
+  x: number = 0;
+}
+export function readDynamic(p: Point): unknown {
+  return p.y;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    // Lowering succeeds (no `unknown class or interface field` abort); the
+    // declared field `x` is untouched and stays concrete `Float`.
+    let point = module
+        .items
+        .iter()
+        .find_map(|item| match ctx.krate.items.get(item.0 as usize)? {
+            Item::Class(class) if ctx.krate.names.get(class.name) == Some("Point") => Some(class),
+            _ => None,
+        })
+        .ok_or_else(|| "missing Point class".to_owned())?;
+    ensure!(point.fields.iter().any(|field| {
+        ctx.krate.symbols.get(field.name) == Some("x")
+            && matches!(ctx.krate.types.get(field.ty), Some(Type::Float))
+    }));
+    Ok(())
+}


### PR DESCRIPTION
Closes #114.

## Problem
Undeclared dotted field access on a concrete class/interface hard-errored with `unknown class or interface field \`X\` on \`X\``, aborting `smelt build` on valid es-toolkit + neverthrow source. #83 deferred this pending class index-signature support, which landed in #84 (a runtime keyed store on the generated struct).

## Fix
`class_field_type`'s resolution ladder already tries every static resolver first — declared field/method, index-signature value (`class_index_field` / `interface_index_values`), builtin member, base class, interface heritage — so declared members keep their concrete types. This replaces the ad-hoc final tail (the per-field `id` allowance, the `interface_exists` allowance, and the has-base allowance, each side-stepping the error for one narrow shape) with one general rule:

> When static resolution is exhausted, route to the explicit `Unknown` dynamic boundary instead of hard-erroring.

In valid TypeScript, dot access only type-checks past this point on a widened/dynamic receiver (index-signature'd base, `any` heritage, declaration merge, or — under isolated per-file lowering — a cross-module class whose members are not visible here). The honest lowering is the boundary, not an abort. **No SmeltUnknown widening of statically-typed access**: index-signature-backed access still resolves through the index value type; only genuinely-unresolvable dynamic access lands at the boundary.

### Ordering fix uncovered by removing the error
`callable_static_member_call` implicitly relied on `class_field_type` erroring so it would bail and let `class_static_method_call` claim `Class.staticMethod(..)`. With the error gone it began lowering static-method calls as erased callable-field reads (runtime `SmeltUnknown` call ABI instead of the concrete `Class::staticMethod` associated function). Made that deferral explicit with a new `static_member_is_class_static_method` guard.

## Tests
- Frontend regression tests: class index-signature dot access keeps its concrete index value type; access resolves through an inherited base index signature; an unresolved concrete-class field routes to the dynamic boundary without error (and the declared field stays concrete).
- Compile-corpus case `undeclared_index_signature_field_access` (class named + undeclared dot reads) whose emitted Rust `cargo check`s clean.
- `cargo check` / `cargo clippy` clean on both touched crates; `smelt-frontend-ts` (762) and `smelt-codegen-rust` lib (491) suites pass.

## Deferred
Interface index signatures have no runtime keyed store (that machinery is class-only from #84), so an undeclared dotted read on an interface-index receiver still cannot be emitted as a keyed lookup. Extending #84's store to interface structs is a separate follow-up; this PR delivers the class-backed path and the general no-abort fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)