### PR TITLE
build: use crates.io ruff parser crates (0.0.3) so Python-without-ty can publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5700,11 +5700,11 @@ dependencies = [
  "ruff_diagnostics",
  "ruff_memory_usage",
  "ruff_notebook",
- "ruff_python_ast",
- "ruff_python_parser",
- "ruff_python_trivia",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_python_ast 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_python_parser 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_python_trivia 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_source_file 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "rustc-hash 2.1.3",
  "salsa",
  "same-file",
@@ -5727,7 +5727,7 @@ source = "git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d
 dependencies = [
  "get-size2",
  "is-macro",
- "ruff_text_size",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "serde",
 ]
 
@@ -5751,7 +5751,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "ruff_python_trivia",
+ "ruff_python_trivia 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "syn 2.0.118",
 ]
 
@@ -5772,8 +5772,8 @@ dependencies = [
  "itertools 0.15.0",
  "rand 0.10.2",
  "ruff_diagnostics",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_source_file 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5788,6 +5788,27 @@ source = "git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d
 [[package]]
 name = "ruff_python_ast"
 version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10ab966362319801f5e85ce5c6aeac69f0cf50936a31e888f5d004e9279f337"
+dependencies = [
+ "aho-corasick",
+ "arrayvec",
+ "bitflags 2.13.0",
+ "compact_str",
+ "get-size2",
+ "is-macro",
+ "memchr",
+ "ruff_python_trivia 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruff_source_file 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruff_text_size 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 2.1.3",
+ "thin-vec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ruff_python_ast"
+version = "0.0.3"
 source = "git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938#f82a36b6baf8c0547a17bbde6c0d927ccd45d938"
 dependencies = [
  "aho-corasick",
@@ -5798,9 +5819,9 @@ dependencies = [
  "is-macro",
  "memchr",
  "ruff_cache",
- "ruff_python_trivia",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_python_trivia 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_source_file 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "rustc-hash 2.1.3",
  "salsa",
  "serde",
@@ -5816,7 +5837,29 @@ dependencies = [
  "bitflags 2.13.0",
  "icu_properties",
  "itertools 0.15.0",
- "ruff_python_ast",
+ "ruff_python_ast 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+]
+
+[[package]]
+name = "ruff_python_parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3b8436fb010636ea79ce545acc3e391296ef4e804f7cef336dd5f9c8a4aa3a"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "compact_str",
+ "get-size2",
+ "memchr",
+ "ruff_python_ast 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruff_python_trivia 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruff_text_size 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 2.1.3",
+ "static_assertions",
+ "thin-vec",
+ "unicode-ident",
+ "unicode-normalization",
+ "unicode_names2",
 ]
 
 [[package]]
@@ -5829,9 +5872,9 @@ dependencies = [
  "compact_str",
  "get-size2",
  "memchr",
- "ruff_python_ast",
- "ruff_python_trivia",
- "ruff_text_size",
+ "ruff_python_ast 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_python_trivia 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "rustc-hash 2.1.3",
  "static_assertions",
  "thin-vec",
@@ -5852,11 +5895,23 @@ dependencies = [
 [[package]]
 name = "ruff_python_trivia"
 version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "969e4a14b2550818efea99b9e2361c714c72e4f1fb94799251d55aed20345189"
+dependencies = [
+ "itertools 0.15.0",
+ "ruff_source_file 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruff_text_size 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ruff_python_trivia"
+version = "0.0.3"
 source = "git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938#f82a36b6baf8c0547a17bbde6c0d927ccd45d938"
 dependencies = [
  "itertools 0.15.0",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_source_file 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "unicode-ident",
 ]
 
@@ -5867,9 +5922,19 @@ source = "git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d
 dependencies = [
  "get-size2",
  "ruff_db",
- "ruff_text_size",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "serde",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "ruff_source_file"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c194e02d121e4a1744464ce3a982c4c196eb039bbf67532d18c8ce09f8da6381"
+dependencies = [
+ "memchr",
+ "ruff_text_size 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5879,8 +5944,17 @@ source = "git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d
 dependencies = [
  "get-size2",
  "memchr",
- "ruff_text_size",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "serde",
+]
+
+[[package]]
+name = "ruff_text_size"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91652ad39be604bc4d5299a5d19feccdd89e255609d89a031e7bb8e0d0aef9f"
+dependencies = [
+ "get-size2",
 ]
 
 [[package]]
@@ -6618,9 +6692,9 @@ name = "smelt-frontend-py"
 version = "0.1.0"
 dependencies = [
  "pico-args",
- "ruff_python_ast",
- "ruff_python_parser",
- "ruff_text_size",
+ "ruff_python_ast 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruff_python_parser 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruff_text_size 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smelt-asyncio",
  "smelt-hir",
  "smelt-py-types",
@@ -6674,7 +6748,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ruff_db",
- "ruff_python_ast",
+ "ruff_python_ast 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "ty_project",
  "ty_python_semantic",
 ]
@@ -6685,9 +6759,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ruff_db",
- "ruff_python_ast",
- "ruff_python_parser",
- "ruff_text_size",
+ "ruff_python_ast 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_python_parser 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "ty_project",
  "ty_python_semantic",
 ]
@@ -7634,7 +7708,7 @@ source = "git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d
 dependencies = [
  "ordermap",
  "ruff_db",
- "ruff_python_ast",
+ "ruff_python_ast 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "ruff_ranged_value",
 ]
 
@@ -7651,7 +7725,7 @@ dependencies = [
  "regex-syntax",
  "ruff_db",
  "ruff_memory_usage",
- "ruff_python_ast",
+ "ruff_python_ast 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "ruff_python_stdlib",
  "rustc-hash 2.1.3",
  "salsa",
@@ -7685,9 +7759,9 @@ dependencies = [
  "ruff_macros",
  "ruff_memory_usage",
  "ruff_options_metadata",
- "ruff_python_ast",
+ "ruff_python_ast 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "ruff_ranged_value",
- "ruff_text_size",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "rustc-hash 2.1.3",
  "salsa",
  "serde",
@@ -7720,9 +7794,9 @@ dependencies = [
  "ruff_index",
  "ruff_macros",
  "ruff_memory_usage",
- "ruff_python_ast",
- "ruff_python_parser",
- "ruff_text_size",
+ "ruff_python_ast 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_python_parser 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "rustc-hash 2.1.3",
  "salsa",
  "serde",
@@ -7755,13 +7829,13 @@ dependencies = [
  "ruff_index",
  "ruff_macros",
  "ruff_memory_usage",
- "ruff_python_ast",
+ "ruff_python_ast 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "ruff_python_literal",
- "ruff_python_parser",
+ "ruff_python_parser 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "ruff_python_stdlib",
- "ruff_python_trivia",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_python_trivia 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_source_file 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "rustc-hash 2.1.3",
  "salsa",
  "serde",
@@ -7787,10 +7861,10 @@ dependencies = [
  "indexmap",
  "ruff_annotate_snippets",
  "ruff_db",
- "ruff_python_ast",
- "ruff_python_trivia",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_python_ast 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_python_trivia 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_source_file 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
+ "ruff_text_size 0.0.3 (git+https://github.com/astral-sh/ruff?rev=f82a36b6baf8c0547a17bbde6c0d927ccd45d938)",
  "strum 0.28.0",
  "strum_macros 0.28.0",
  "tracing",

--- a/crates/smelt-codegen-rust/Cargo.toml
+++ b/crates/smelt-codegen-rust/Cargo.toml
@@ -20,6 +20,11 @@ default = ["ty"]
 # annotation-free Python that lowers via `ty`-resolved types (issue #93). ON by
 # default; the corpus's Python cases now run under a plain `--ignored` run.
 # Build with `--no-default-features` to drop the ty dependency tree.
+#
+# This feature is stripped from the crates.io release (`ty_project` is git-only,
+# not on crates.io). It only forwards into `smelt-frontend-py`, which is a
+# dev-dependency here, so it never affects the published library — see
+# `scripts/publish-crates.sh`.
 ty = ["smelt-frontend-py/ty"]
 
 [dependencies]

--- a/crates/smelt-frontend-py/Cargo.toml
+++ b/crates/smelt-frontend-py/Cargo.toml
@@ -3,13 +3,14 @@ name = "smelt-frontend-py"
 version.workspace = true
 edition.workspace = true
 autoexamples = false
-# NOT published to crates.io: this crate depends on the Ruff parser via a git
-# dependency (only empty 0.0.3 placeholders of `ruff_python_parser` et al. exist
-# on crates.io), which crates.io forbids. Consumers of the published
-# `smelt-transpiler`/`smelt-gui` get a TypeScript-only build; build from a
-# source checkout with `--features python` for the Python frontend. Revisit once
-# astral-sh/ruff#43 publishes real component-crate releases.
-publish = false
+# Publishable on the NON-ty path only. The Ruff parser crates now come from
+# crates.io (real `0.0.3` releases), so the default+`--no-default-features`
+# (ty-off) build has no git dependency and can be published. The `ty` feature
+# still pulls the git-pinned `smelt-py-types`/`ty_project` tree, which is NOT on
+# crates.io — so `scripts/publish-crates.sh` strips the `ty` feature and the
+# optional `smelt-py-types` dep before uploading (consumers publish with the
+# `python` feature but never `ty`). Revisit the `ty` split once `ty_project`
+# ships to crates.io (astral-sh/ruff#43).
 
 [lints]
 workspace = true
@@ -25,22 +26,30 @@ default = ["ty"]
 ty = ["dep:smelt-py-types"]
 
 [dependencies]
-smelt-asyncio = { path = "../smelt-asyncio" }
-smelt-hir = { path = "../smelt-hir" }
-smelt-specialize = { path = "../smelt-specialize" }
-smelt-stdlib = { path = "../smelt-stdlib" }
+smelt-asyncio = { path = "../smelt-asyncio", version = "0.1.0" }
+smelt-hir = { path = "../smelt-hir", version = "0.1.0" }
+smelt-specialize = { path = "../smelt-specialize", version = "0.1.0" }
+smelt-stdlib = { path = "../smelt-stdlib", version = "0.1.0" }
 
 # Optional `ty`-backed Python type resolution, gated behind the `ty` feature.
 smelt-py-types = { path = "../smelt-py-types", optional = true }
 
-# Python parsing via Astral's Ruff parser. Not published to crates.io, so we
-# pull it from the upstream git repo — the same approach `ty` (Astral's type
-# checker) takes. Type-checking is deferred to a later milestone; here we only
-# need the parser + AST + text-size primitives.
+# Python parsing via Astral's Ruff parser, pulled from crates.io. These are the
+# real published `0.0.3` parser crates (`ruff_python_ast` 141 KB /
+# `ruff_python_parser` 559 KB, published 2026-06-25), not the empty placeholders
+# earlier work assumed — so this crate is publishable on the non-ty path.
 #
-ruff_python_parser = { git = "https://github.com/astral-sh/ruff", rev = "f82a36b6baf8c0547a17bbde6c0d927ccd45d938" }
-ruff_python_ast    = { git = "https://github.com/astral-sh/ruff", rev = "f82a36b6baf8c0547a17bbde6c0d927ccd45d938" }
-ruff_text_size     = { git = "https://github.com/astral-sh/ruff", rev = "f82a36b6baf8c0547a17bbde6c0d927ccd45d938" }
+# IMPORTANT: the `ty` feature pulls in `smelt-py-types`, whose `ty_project` /
+# `ruff_db` tree is git-pinned and transitively carries its OWN copy of the Ruff
+# crates at the same `0.0.3` version but a DIFFERENT source (git rev). Cargo
+# treats those as distinct crates, so their `TextSize`/AST types are NOT
+# interchangeable with these crates.io ones. The frontend-py ↔ smelt-py-types
+# boundary therefore exchanges only plain `u32` byte offsets (never a Ruff
+# type), so the two Ruff checkouts never have to unify. Do not re-introduce a
+# `ruff_*` type into that boundary or the `ty`-on build breaks with E0308.
+ruff_python_parser = "0.0.3"
+ruff_python_ast    = "0.0.3"
+ruff_text_size     = "0.0.3"
 
 [dev-dependencies]
 pico-args = "0.5"

--- a/crates/smelt-frontend-py/src/ty_resolve.rs
+++ b/crates/smelt-frontend-py/src/ty_resolve.rs
@@ -71,11 +71,16 @@ impl ResolvedTypes {
 
     /// Return the `ty`-resolved return-type spelling for the function whose
     /// definition starts at `offset`, if any.
+    ///
+    /// `offset` is this crate's own `ruff_text_size::TextSize` (from the
+    /// crates.io Ruff parser). It is converted to a plain `u32` before crossing
+    /// into `smelt_py_types`, whose git-pinned Ruff `TextSize` is a *different*
+    /// crate and would not type-check here. See [`ResolvedTypes`] docs.
     #[must_use]
     pub(crate) fn return_type_at(&self, offset: TextSize) -> Option<&str> {
         #[cfg(feature = "ty")]
         {
-            self.inner.as_ref()?.return_type_at(offset)
+            self.inner.as_ref()?.return_type_at(offset.to_u32())
         }
         #[cfg(not(feature = "ty"))]
         {
@@ -86,11 +91,14 @@ impl ResolvedTypes {
 
     /// Return the `ty`-resolved parameter-type spelling for the parameter whose
     /// declaration starts at `offset`, if any.
+    ///
+    /// `offset` is converted to a plain `u32` before crossing into
+    /// `smelt_py_types`; see [`Self::return_type_at`] for why.
     #[must_use]
     pub(crate) fn param_type_at(&self, offset: TextSize) -> Option<&str> {
         #[cfg(feature = "ty")]
         {
-            self.inner.as_ref()?.param_type_at(offset)
+            self.inner.as_ref()?.param_type_at(offset.to_u32())
         }
         #[cfg(not(feature = "ty"))]
         {

--- a/crates/smelt-gui/Cargo.toml
+++ b/crates/smelt-gui/Cargo.toml
@@ -16,11 +16,12 @@ name = "smelt-gui"
 path = "src/main.rs"
 
 [features]
-# Python frontend support. ON by default in this repository; DISABLED for the
-# crates.io release because `smelt-frontend-py` depends on the Ruff parser via a
-# git dependency that crates.io forbids. A TypeScript-only build reports Python
-# input as a stage failure. Build from source with `--features python` for the
-# full pipeline.
+# Python frontend support. ON by default. `smelt-frontend-py`'s Ruff parser now
+# comes from crates.io, so this parser-based Python path is publishable and the
+# crates.io release KEEPS `python` (see `scripts/publish-crates.sh`). Only the
+# `ty` type-resolution path (git-only `ty_project` tree) is excluded from the
+# release; the GUI does not expose a `ty` feature, so nothing to strip here
+# beyond giving the `smelt-frontend-py` dep a crates.io version at publish time.
 default = ["python"]
 python = ["dep:smelt-frontend-py"]
 

--- a/crates/smelt-py-types/src/lib.rs
+++ b/crates/smelt-py-types/src/lib.rs
@@ -72,7 +72,7 @@ use ruff_db::files::system_path_to_file;
 use ruff_db::parsed::parsed_module;
 use ruff_db::system::{OsSystem, SystemPathBuf};
 use ruff_python_ast::{Stmt, StmtFunctionDef};
-use ruff_text_size::{Ranged, TextSize};
+use ruff_text_size::Ranged;
 use ty_project::{ProjectDatabase, ProjectMetadata};
 use ty_python_semantic::types::Type;
 use ty_python_semantic::{HasType, SemanticModel};
@@ -99,17 +99,27 @@ pub struct ResolvedModuleTypes {
 
 impl ResolvedModuleTypes {
     /// Return the resolved return-type spelling for the function whose
-    /// definition starts at `offset`, if `ty` resolved one.
+    /// definition starts at byte `offset`, if `ty` resolved one.
+    ///
+    /// `offset` is a plain `u32` byte offset (the value of a Ruff `TextSize`,
+    /// via `TextSize::to_u32`) rather than a `ruff_text_size::TextSize`. Keeping
+    /// no Ruff type in this crate's public API lets the Python frontend use the
+    /// published crates.io Ruff while this crate keeps the git-pinned `ty` Ruff:
+    /// the two Ruff checkouts are distinct crates whose `TextSize` types would
+    /// not unify, so only the raw offset crosses the boundary.
     #[must_use]
-    pub fn return_type_at(&self, offset: TextSize) -> Option<&str> {
-        self.return_types.get(&offset.to_u32()).map(String::as_str)
+    pub fn return_type_at(&self, offset: u32) -> Option<&str> {
+        self.return_types.get(&offset).map(String::as_str)
     }
 
     /// Return the resolved type spelling for the parameter whose declaration
-    /// starts at `offset`, if `ty` resolved one.
+    /// starts at byte `offset`, if `ty` resolved one.
+    ///
+    /// `offset` is a plain `u32` byte offset; see [`Self::return_type_at`] for
+    /// why the boundary uses `u32` instead of a Ruff `TextSize`.
     #[must_use]
-    pub fn param_type_at(&self, offset: TextSize) -> Option<&str> {
-        self.param_types.get(&offset.to_u32()).map(String::as_str)
+    pub fn param_type_at(&self, offset: u32) -> Option<&str> {
+        self.param_types.get(&offset).map(String::as_str)
     }
 
     /// Number of resolved return types (used by tests / diagnostics).
@@ -502,7 +512,7 @@ mod tests {
         let resolved = resolve_module_types("def inc(x: int):\n    return x + 1\n", "m")?;
         let parsed = ruff_python_parser::parse_module("def inc(x: int):\n    return x + 1\n")?;
         let func = parsed.syntax().body[0].as_function_def_stmt().unwrap();
-        assert_eq!(resolved.return_type_at(func.start()), Some("int"));
+        assert_eq!(resolved.return_type_at(func.start().to_u32()), Some("int"));
         Ok(())
     }
 
@@ -511,7 +521,7 @@ mod tests {
         let resolved = resolve_module_types("def noop():\n    pass\n", "m")?;
         let parsed = ruff_python_parser::parse_module("def noop():\n    pass\n")?;
         let func = parsed.syntax().body[0].as_function_def_stmt().unwrap();
-        assert_eq!(resolved.return_type_at(func.start()), Some("None"));
+        assert_eq!(resolved.return_type_at(func.start().to_u32()), Some("None"));
         Ok(())
     }
 
@@ -522,7 +532,7 @@ mod tests {
         let parsed = ruff_python_parser::parse_module(src)?;
         let func = parsed.syntax().body[0].as_function_def_stmt().unwrap();
         let x = func.parameters.iter().next().unwrap().as_parameter();
-        assert_eq!(resolved.param_type_at(x.start()), Some("int"));
+        assert_eq!(resolved.param_type_at(x.start().to_u32()), Some("int"));
         Ok(())
     }
 

--- a/crates/smelt-transpiler/Cargo.toml
+++ b/crates/smelt-transpiler/Cargo.toml
@@ -18,11 +18,11 @@ workspace = true
 [features]
 # Python frontend support. ON by default in this repository (via the `ty`
 # default feature below) so `cargo build`/`cargo test`/CI exercise the Python
-# pipeline unchanged. It pulls in `smelt-frontend-py`, which depends on the Ruff
-# parser via a git dependency that crates.io forbids, so the published crate is
-# built with this feature DISABLED (a TypeScript-only `smelt` binary). To use
-# Python from a published install, build from a source checkout with
-# `--features python` (or `--features ty`).
+# pipeline unchanged. It pulls in `smelt-frontend-py`, whose Ruff parser now
+# comes from crates.io, so this parser-based Python path IS publishable: the
+# release keeps `python` (and retargets `default` to it) — see
+# `scripts/publish-crates.sh`. Only the `ty` feature below is stripped for the
+# release, because it pulls the git-only `ty_project` tree (not on crates.io).
 default = ["ty"]
 python = ["dep:smelt-frontend-py"]
 

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -2,25 +2,44 @@
 #
 # Publish the Smelt crates to crates.io in dependency order.
 #
-# The Python frontend (`smelt-frontend-py`) depends on the Ruff parser via a git
-# dependency, which crates.io forbids, so it is never published. Three crates
-# reference it and must have those references stripped from the manifest that is
-# uploaded (the working-tree manifests keep them so `--features python` still
-# builds from source):
+# Python is publishable on the NON-`ty` path. `smelt-frontend-py` now pulls the
+# Ruff parser from crates.io (real `ruff_python_ast`/`ruff_python_parser`/
+# `ruff_text_size` `0.0.3` releases), so the parser-based Python frontend can be
+# uploaded. What is NOT publishable is the `ty` feature: it pulls
+# `smelt-py-types`, whose `ty_project`/`ruff_db`/`ty_python_semantic` tree is
+# git-pinned (not on crates.io). So the published crates keep the `python`
+# feature but have every `ty` reference stripped:
 #
-#   * smelt-transpiler  — optional `smelt-frontend-py` dep + `python`/`ty` features
-#   * smelt-gui         — optional `smelt-frontend-py` dep + `python` feature
-#   * smelt-codegen-rust — `ty` feature forwarding `smelt-frontend-py/ty`
-#                          (its Python dev-dependencies are path-only and cargo
-#                          drops them from the published package automatically)
+#   * smelt-frontend-py  — strip the `ty` feature + the optional git-only
+#                          `smelt-py-types` dep (keeps the crates.io Ruff deps).
+#   * smelt-transpiler   — strip the `ty` feature + retarget `default` to
+#                          `python`; keep the optional `smelt-frontend-py` dep
+#                          (given a crates.io version).
+#   * smelt-gui          — keep `python`/`smelt-frontend-py` as-is (no `ty`);
+#                          only the dep needs a crates.io version.
+#   * smelt-codegen-rust — strip the `ty` feature (which forwarded
+#                          `smelt-frontend-py/ty`) and empty its `default`. Its
+#                          `smelt-frontend-py` is a dev-dependency, which cargo
+#                          drops from the published package automatically, so it
+#                          needs no version.
+#
+# The working-tree manifests keep the `ty` surface so `--features ty` still
+# builds the full pipeline from a source checkout; the strips below apply only to
+# the manifests that are uploaded and are reverted right after.
+#
+# Because `cargo package -p <crate>` resolves the WHOLE workspace, a dangling
+# `smelt-frontend-py/ty` reference in any sibling manifest fails resolution even
+# while packaging a different crate. All manifests are therefore stripped ONCE
+# up front (before the packaging loop) and restored ONCE at the end, rather than
+# per-crate.
 #
 # Usage:
 #   scripts/publish-crates.sh            # dry run: `cargo package` each crate
 #   scripts/publish-crates.sh --execute  # real `cargo publish` (needs a token)
 #
-# Re-runnable: crates already at the current version on crates.io are skipped by
-# cargo with an "already uploaded" error, which this script tolerates in
-# --execute mode is left to the operator (publish one version once).
+# Re-runnable: crates already at the current version on crates.io are skipped in
+# --execute mode (new-crate publishing is rate-limited, so a batch may need more
+# than one pass).
 
 set -euo pipefail
 
@@ -32,7 +51,11 @@ if [[ "${1:-}" == "--execute" ]]; then
   EXECUTE=1
 fi
 
+VERSION="0.1.0"
+
 # Publish order: every crate appears after all of its path dependencies.
+# `smelt-frontend-py` sits after its deps (smelt-hir/stdlib/specialize/asyncio)
+# and before the crates that depend on it (codegen-rust/transpiler/gui).
 CRATES=(
   smelt-hir
   smelt-stdlib
@@ -40,6 +63,7 @@ CRATES=(
   smelt-asyncio
   smelt-test
   smelt-specialize
+  smelt-frontend-py
   smelt-mir
   smelt-codegen-rust
   smelt-frontend-ts
@@ -47,9 +71,9 @@ CRATES=(
   smelt-gui
 )
 
-# Manifests that need Python references stripped before packaging/publishing.
-# Backups are stored OUTSIDE the crate directories (under target/) so they are
-# never packaged into the crate; each entry is "backupfile|manifestpath".
+# Manifests whose `ty`/git-only surface must be stripped before packaging.
+# Backups live OUTSIDE the crate directories (under target/) so they are never
+# packaged into a crate; each entry is "backupfile|manifestpath".
 BAKDIR="$ROOT/target/publish-bak"
 mkdir -p "$BAKDIR"
 BACKUPS=()
@@ -60,47 +84,64 @@ restore_manifests() {
     local target="${entry##*|}"
     [[ -e "$backup" ]] && mv -f "$backup" "$target"
   done
+  BACKUPS=()
 }
 trap restore_manifests EXIT
 
-strip_python() {
+# Back up a manifest before editing so it can be restored after packaging.
+backup_manifest() {
   local crate="$1"
   local manifest="$ROOT/crates/$crate/Cargo.toml"
   local backup="$BAKDIR/$crate.Cargo.toml.bak"
   cp "$manifest" "$backup"
   BACKUPS+=("$backup|$manifest")
-  case "$crate" in
-    smelt-transpiler)
-      sed -i \
-        -e '/^smelt-frontend-py = { path = "\.\.\/smelt-frontend-py", optional = true }$/d' \
-        -e '/^default = \["ty"\]$/d' \
-        -e '/^python = \["dep:smelt-frontend-py"\]$/d' \
-        -e '/^ty = \["python", "smelt-frontend-py\/ty"\]$/d' \
-        "$manifest"
-      ;;
-    smelt-gui)
-      sed -i \
-        -e '/^smelt-frontend-py = { path = "\.\.\/smelt-frontend-py", optional = true }$/d' \
-        -e '/^default = \["python"\]$/d' \
-        -e '/^python = \["dep:smelt-frontend-py"\]$/d' \
-        "$manifest"
-      ;;
-    smelt-codegen-rust)
-      sed -i \
-        -e '/^ty = \["smelt-frontend-py\/ty"\]$/d' \
-        "$manifest"
-      ;;
-  esac
 }
 
-needs_strip() {
-  case "$1" in
-    smelt-transpiler|smelt-gui|smelt-codegen-rust) return 0 ;;
-    *) return 1 ;;
-  esac
-}
+# Strip every `ty`/git-only reference from the manifests that are uploaded.
+# `python` (parser-based Python) is intentionally KEPT.
+strip_ty_surface() {
+  local fpy="$ROOT/crates/smelt-frontend-py/Cargo.toml"
+  local transpiler="$ROOT/crates/smelt-transpiler/Cargo.toml"
+  local gui="$ROOT/crates/smelt-gui/Cargo.toml"
+  local codegen="$ROOT/crates/smelt-codegen-rust/Cargo.toml"
 
-VERSION="0.1.0"
+  backup_manifest smelt-frontend-py
+  backup_manifest smelt-transpiler
+  backup_manifest smelt-gui
+  backup_manifest smelt-codegen-rust
+
+  # smelt-frontend-py: drop its own `ty` feature and the git-only
+  # `smelt-py-types` dep; the default was `["ty"]`, drop it too (publish uses
+  # --no-default-features so the default is irrelevant, but it must not name a
+  # removed feature). Keeps the crates.io `ruff_*` deps.
+  sed -i \
+    -e '/^default = \["ty"\]$/d' \
+    -e '/^ty = \["dep:smelt-py-types"\]$/d' \
+    -e '/^smelt-py-types = { path = "\.\.\/smelt-py-types", optional = true }$/d' \
+    "$fpy"
+
+  # smelt-transpiler: keep `python`; drop the `ty` feature; retarget the default
+  # from `ty` to `python`; give the optional frontend-py dep a crates.io version.
+  sed -i \
+    -e 's/^default = \["ty"\]$/default = ["python"]/' \
+    -e '/^ty = \["python", "smelt-frontend-py\/ty"\]$/d' \
+    -e 's|^smelt-frontend-py = { path = "\.\./smelt-frontend-py", optional = true }$|smelt-frontend-py = { path = "../smelt-frontend-py", version = "'"$VERSION"'", optional = true }|' \
+    "$transpiler"
+
+  # smelt-gui: `python` is already the default and there is no `ty` feature; just
+  # give the optional frontend-py dep a crates.io version.
+  sed -i \
+    -e 's|^smelt-frontend-py = { path = "\.\./smelt-frontend-py", optional = true }$|smelt-frontend-py = { path = "../smelt-frontend-py", version = "'"$VERSION"'", optional = true }|' \
+    "$gui"
+
+  # smelt-codegen-rust: drop the `ty` feature (it forwarded frontend-py/ty) and
+  # empty its `default`. The frontend-py reference is a dev-dependency, which
+  # cargo drops from the published package, so it needs no version rewrite.
+  sed -i \
+    -e 's/^default = \["ty"\]$/default = []/' \
+    -e '/^ty = \["smelt-frontend-py\/ty"\]$/d' \
+    "$codegen"
+}
 
 # Returns 0 if <crate> already has VERSION on crates.io (so a resumed run can
 # skip it — new-crate publishing is rate-limited, so a batch may need >1 pass).
@@ -112,6 +153,10 @@ already_published() {
   [[ "$code" == "200" ]]
 }
 
+# Strip once, up front — a sibling's dangling `ty` reference would otherwise
+# break `cargo package -p <other-crate>` (workspace-wide resolution).
+strip_ty_surface
+
 for crate in "${CRATES[@]}"; do
   echo "==============================================================="
   echo ">>> $crate"
@@ -122,25 +167,19 @@ for crate in "${CRATES[@]}"; do
     continue
   fi
 
-  if needs_strip "$crate"; then
-    strip_python "$crate"
-  fi
-
   if [[ "$EXECUTE" -eq 1 ]]; then
-    # --allow-dirty: stripping Python references leaves the manifest modified in
-    # the working tree; that is intentional and restored right after.
+    # --allow-dirty: the up-front strips leave manifests modified in the working
+    # tree; that is intentional and restored on exit.
     cargo publish -p "$crate" --no-default-features --allow-dirty
   else
     # --no-verify checks manifest publishability (versions present, no git deps)
     # without needing the dependency crates to already be on crates.io.
     cargo package -p "$crate" --no-default-features --no-verify --allow-dirty
   fi
-
-  if needs_strip "$crate"; then
-    restore_manifests
-    BACKUPS=()
-  fi
 done
+
+# Restore every stripped manifest (also runs on the EXIT trap for safety).
+restore_manifests
 
 echo
 if [[ "$EXECUTE" -eq 1 ]]; then


### PR DESCRIPTION
Closes #112.

## Feasibility verdict: FEASIBLE (with a small boundary change)

crates.io really does host the recent Ruff parser crates (`ruff_python_ast` / `ruff_python_parser` / `ruff_text_size` `0.0.3`), and they compile against the code written for git `f82a36b6` with **no API break**. Only the `ty` tree (`ty_project` / `ruff_db` / `ty_python_semantic`) remains git-only.

## The two-Ruff-source risk — confirmed, then resolved

The predicted conflict is real. `smelt-py-types` keeps the git-pinned `ty` tree, which transitively carries its own git `ruff_text_size` at the same `0.0.3` version but a different **source**. Cargo treats crates.io `0.0.3` and the git-rev `0.0.3` as **distinct crates**, so the `TextSize` that `smelt-frontend-py` passed across the resolver boundary into `smelt_py_types` no longer type-checked:

```
error[E0308]: mismatched types
   --> crates/smelt-frontend-py/src/ty_resolve.rs:78
      expected `ruff_text_size::size::TextSize`, found `TextSize`
      note: there are multiple different versions of crate `ruff_text_size`
```

This broke the **default** dev config (`ty` on). The `ty`-off path already compiled cleanly against crates.io `0.0.3`.

**Fix — decouple the boundary so no Ruff type crosses it.** `smelt-py-types` already stored offsets as `u32` internally (`HashMap<u32, String>`, `offset.to_u32()` on the first line of each accessor), so its public `return_type_at` / `param_type_at` now take a plain `u32`; `smelt-frontend-py` converts its own `TextSize` via `to_u32()` at the call site. The two Ruff checkouts never have to unify, and **both `ty`-on and `ty`-off builds compile**.

## Is `smelt-frontend-py` now publishable? Yes (non-ty)

`cargo package -p smelt-frontend-py --no-default-features` succeeds (50 files, ~747 KiB, no git dependency). Publishing keeps the `python` (parser-based) frontend on consumers; only the `ty` feature (git-only) is stripped.

## Changes
- `smelt-frontend-py/Cargo.toml`: ruff parser crates → `"0.0.3"`; dropped `publish = false`; added crates.io versions to internal path deps.
- `smelt-py-types/src/lib.rs`: `return_type_at` / `param_type_at` take `u32` (was `TextSize`); tests updated.
- `smelt-frontend-py/src/ty_resolve.rs`: pass `offset.to_u32()` across the boundary.
- `scripts/publish-crates.sh`: publish `smelt-frontend-py`; keep `python` on transpiler/gui/codegen-rust, strip only the `ty` feature + git-only `smelt-py-types` dep; strips applied once up front (cargo package resolves the whole workspace).
- Refreshed stale "TypeScript-only / never published" comments in transpiler / gui / codegen-rust manifests.

## Verification
- `cargo check` (default = ty+python, two Ruff sources coexisting) — green
- `cargo check --no-default-features -p smelt-transpiler` (TS-only) — green
- `cargo test` — green (7 transient failures were tmpfs `No space left on device`, confirmed passing with `TMPDIR` on a larger disk)
- `cargo clippy` on `smelt-frontend-py` / `smelt-py-types` (both configs) — clean
- remeda regression gate — **1789 passed, 0 failed**
- publish dry-run — `smelt-frontend-py` packages cleanly with crates.io Ruff (transpiler/gui only "fail" the dry-run because `smelt-frontend-py` isn't on the index yet — inherent to first-time ordered publishing; resolves under `--execute`)

Follow-up to #111. Did **not** publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)