### PR TITLE
frontend-ts: fold symbol-backed computed property keys (#115)

### DIFF
--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -559,10 +559,19 @@ export function readMixed(bag: MixedBag, key: string): number | undefined {
             // synthetic member spelling. All three become ordinary named
             // members so the emitted Rust compiles, and reading the folded
             // class field back through its concrete member type stays concrete.
+            //
+            // Issue #115 extends the folding to more symbol-backed keys, all of
+            // which must likewise become ordinary named members: a well-known
+            // `[Symbol.asyncIterator]` method, an inline `[Symbol.for("k")]`
+            // field, and a `Symbol.for("k")`-aliased-const key (`[matcher]`).
+            // Registry symbols fold to the same stable synthetic spelling
+            // regardless of how they are spelled, so `matcher` and the inline
+            // `Symbol.for` key naming the same description name the same member.
             name: "computed_property_names",
             area: "interfaces",
             source: r#"
 const TAG = "tag";
+const matcher = Symbol.for("@ts-pattern/matcher");
 
 enum Kind {
   First = "first",
@@ -579,6 +588,15 @@ interface ByKind {
 
 interface Seq {
   [Symbol.iterator](): number;
+  [Symbol.asyncIterator](): number;
+}
+
+interface Matcher {
+  [matcher](): number;
+}
+
+interface Override {
+  [Symbol.for("@ts-pattern/override")]: number;
 }
 
 export function makeTagged(): Tagged {

--- a/crates/smelt-frontend-ts/src/lowering.rs
+++ b/crates/smelt-frontend-ts/src/lowering.rs
@@ -75,12 +75,21 @@ impl ConstLiteral {
     /// Return the JavaScript property-member name this constant would name when
     /// used as a computed key (`{ [K]: v }` / `class C { [K]: T }`).
     ///
-    /// JavaScript coerces a computed key to a string member name, so only string
-    /// and numeric constants resolve to a stable static identifier here. A whole
+    /// JavaScript coerces a computed key to a string member name, so string and
+    /// numeric constants resolve to a stable static identifier here. A whole
     /// finite number is rendered without a fractional part (`0` -> "0") to match
-    /// the numeric-literal key spelling. Boolean/null/symbol constants have no
-    /// well-defined static member spelling for Smelt's named-field model and
-    /// return `None`, leaving genuinely dynamic keys on the runtime-keyed path.
+    /// the numeric-literal key spelling.
+    ///
+    /// A `Symbol.for(<description>)` registry symbol also folds: registry symbols
+    /// are globally interned by description, so every reference names the same
+    /// member (issue #115). It maps to the stable synthetic spelling shared with
+    /// inline `[Symbol.for(...)]` keys via
+    /// [`crate::lowering::ty::computed_key_symbols::registry_symbol_key`]. A
+    /// *unique* `Symbol(...)` value has fresh identity each time and never folds.
+    ///
+    /// Boolean/null constants have no well-defined static member spelling for
+    /// Smelt's named-field model and return `None`, leaving genuinely dynamic
+    /// keys on the runtime-keyed path.
     fn computed_member_name(&self) -> Option<String> {
         match &self.literal {
             Literal::String(value) => Some(value.clone()),
@@ -88,7 +97,28 @@ impl ConstLiteral {
             Literal::Float(value) => {
                 Some(ModuleBuilder::numeric_property_key_name(*value))
             }
-            Literal::Bool(_) | Literal::Symbol(_) | Literal::Undefined | Literal::None => None,
+            Literal::Symbol(value) => {
+                ty::computed_key_symbols::registry_description_of_symbol_literal(value)
+                    .map(ty::computed_key_symbols::registry_symbol_key)
+            }
+            Literal::Bool(_) | Literal::Undefined | Literal::None => None,
+        }
+    }
+
+    /// Return the synthetic registry member key when this constant is a
+    /// `Symbol.for(<description>)` registry symbol.
+    ///
+    /// Registry-backed keys are interned verbatim (they are synthetic member
+    /// spellings, not source names), so computed-key resolution uses this to
+    /// decide whether a folded const key is a symbol key. Returns `None` for
+    /// every non-registry-symbol constant.
+    fn symbol_registry_name(&self) -> Option<String> {
+        match &self.literal {
+            Literal::Symbol(value) => {
+                ty::computed_key_symbols::registry_description_of_symbol_literal(value)
+                    .map(ty::computed_key_symbols::registry_symbol_key)
+            }
+            _ => None,
         }
     }
 }

--- a/crates/smelt-frontend-ts/src/lowering/decls/arrows.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/arrows.rs
@@ -841,12 +841,44 @@ return_ty: target_function.return_ty,
     ///   through the builtin path instead.
     pub(in crate::lowering) fn is_known_non_importable_exported_const(expression: &Expression<'_>) -> bool {
         if let Expression::CallExpression(call) = expression
-            && let Expression::StaticMemberExpression(member) = &call.callee
-            && let Expression::Identifier(object) = &member.object
+            && Self::is_symbol_for_call(call)
         {
-            return object.name == "Symbol" && member.property.name == "for";
+            return true;
         }
         Self::is_host_constructor_presence_alias(expression)
+    }
+
+    /// Return whether a call expression is `Symbol.for(...)`.
+    ///
+    /// Recognizes the global registry constructor by its `Symbol.for` callee
+    /// shape, independent of the argument, so both the const-folding path and the
+    /// non-importable-const check agree on what a registry symbol looks like.
+    fn is_symbol_for_call(call: &oxc::ast::ast::CallExpression<'_>) -> bool {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return false;
+        };
+        let Expression::Identifier(object) = &member.object else {
+            return false;
+        };
+        object.name == "Symbol" && member.property.name == "for"
+    }
+
+    /// Return the string-literal description of a `Symbol.for("desc")` call.
+    ///
+    /// Only a single string-literal argument folds to a stable registry
+    /// description; a non-literal argument (a computed description) has no
+    /// compile-time spelling and returns `None`, leaving the const on the runtime
+    /// value path.
+    pub(in crate::lowering) fn symbol_for_call_description<'a>(
+        call: &'a oxc::ast::ast::CallExpression<'a>,
+    ) -> Option<&'a str> {
+        if !Self::is_symbol_for_call(call) {
+            return None;
+        }
+        let [Argument::StringLiteral(description)] = call.arguments.as_slice() else {
+            return None;
+        };
+        Some(description.value.as_str())
     }
 
     /// Return whether an initializer is a `globalThis.X`-presence host-constructor
@@ -1064,10 +1096,24 @@ return_ty: target_function.return_ty,
     }
 
     /// Fold supported pure calls inside exported const initializers.
+    ///
+    /// `Symbol.for(<string literal>)` folds to a stable registry-symbol literal
+    /// (`Symbol.for(<description>)`), matching the string the runtime `Symbol.for`
+    /// value path produces. Registry symbols are globally interned by
+    /// description, so this shared spelling lets a `const K = Symbol.for("k")`
+    /// alias fold to the same synthetic computed-key member as an inline
+    /// `[Symbol.for("k")]` key (issue #115). A unique `Symbol(...)` gets a fresh
+    /// span-tagged spelling because it has fresh identity each evaluation.
     pub(in crate::lowering) fn call_literal_const_expression(
         &mut self,
         call: &oxc::ast::ast::CallExpression<'_>,
     ) -> Result<ConstLiteral, SmeltError> {
+        if let Some(description) = Self::symbol_for_call_description(call) {
+            return Ok(ConstLiteral {
+                literal: Literal::Symbol(format!("Symbol.for({description})")),
+                ty: self.ctx.krate.types.intern(Type::Unknown),
+            });
+        }
         if matches!(&call.callee, Expression::Identifier(callee) if callee.name == "Symbol") {
             if call.arguments.len() > 1 {
                 return Err(SmeltError::unsupported(

--- a/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
@@ -18,9 +18,6 @@ use smelt_hir::{
 };
 
 impl ModuleBuilder<'_> {
-    /// Runtime key used for JavaScript's well-known `Symbol.iterator` value.
-    pub(in crate::lowering) const SYMBOL_ITERATOR_KEY: &'static str = "__smelt_symbol_iterator";
-
     /// Lower supported namespace member calls into the matching HIR operation.
     pub(in crate::lowering) fn namespace_member_call(
         &mut self,
@@ -422,6 +419,13 @@ impl ModuleBuilder<'_> {
     }
 
     /// Lower supported well-known `Symbol.<name>` member reads.
+    ///
+    /// Each modeled well-known symbol resolves to the same stable synthetic
+    /// member spelling that computed property-key declaration uses (see
+    /// [`crate::lowering::ty::computed_key_symbols::well_known_symbol_key`]), so a
+    /// read such as `obj[Symbol.asyncIterator]` indexes the field declared by
+    /// `[Symbol.asyncIterator]()` (issue #115). `Symbol.iterator` keeps its
+    /// established `__smelt_symbol_iterator` spelling.
     pub(in crate::lowering) fn symbol_static_member(
         &mut self,
         member: &oxc::ast::ast::StaticMemberExpression<'_>,
@@ -430,12 +434,15 @@ impl ModuleBuilder<'_> {
         let Expression::Identifier(object) = &member.object else {
             return None;
         };
-        if object.name != "Symbol" || member.property.name != "iterator" {
+        if object.name != "Symbol" {
             return None;
         }
+        let key = crate::lowering::ty::computed_key_symbols::well_known_symbol_key(
+            member.property.name.as_str(),
+        )?;
         let ty = self.ctx.krate.types.intern(Type::String);
         Some(body.push_expr(Expr {
-            kind: ExprKind::Literal(Literal::String(Self::SYMBOL_ITERATOR_KEY.to_owned())),
+            kind: ExprKind::Literal(Literal::String(key)),
             ty,
             span: self.span(member.span.start, member.span.end),
         }))

--- a/crates/smelt-frontend-ts/src/lowering/ty.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty.rs
@@ -3,5 +3,6 @@
 
 mod annotations;
 mod assignability;
+pub(in crate::lowering) mod computed_key_symbols;
 mod generics;
 mod interface_lookup;

--- a/crates/smelt-frontend-ts/src/lowering/ty/computed_key_symbols.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/computed_key_symbols.rs
@@ -1,0 +1,214 @@
+//! Symbol-backed computed property-key folding helpers.
+//!
+//! A computed property key such as `[Symbol.asyncIterator]`, `[matcher]`, or
+//! `[symbols.override]` names a *static* member whenever the underlying symbol
+//! is globally fixed:
+//!
+//! * a **well-known symbol** (`Symbol.iterator`, `Symbol.asyncIterator`, …) is a
+//!   constant of the language, so every reference names the same member, and
+//! * a **registry symbol** (`Symbol.for("desc")`) is looked up in the process
+//!   global symbol registry keyed by its description string, so every
+//!   `Symbol.for("desc")` — whether spelled inline, aliased to a `const`, or
+//!   read through a namespace import — is the same symbol.
+//!
+//! Both map deterministically to a stable synthetic member spelling that member
+//! access and member declaration agree on, so they fold to named members exactly
+//! like a spelled-out string key instead of hitting the dynamic-key gate
+//! (issue #115, follow-up to #96).
+//!
+//! A *unique* symbol (`Symbol("desc")` without `.for`, or an opaque runtime
+//! symbol value) is a fresh identity every time it is evaluated and has no
+//! stable static spelling, so it deliberately does not fold here and stays on
+//! the runtime-keyed path.
+
+/// Synthetic member-name prefix for well-known ECMAScript symbols.
+///
+/// The historical `Symbol.iterator` key (`__smelt_symbol_iterator`) predates
+/// this table and keeps its exact spelling for source compatibility; every other
+/// well-known symbol derives its key from this prefix plus the snake-cased
+/// symbol name so the spellings never collide with ordinary string members.
+const WELL_KNOWN_SYMBOL_PREFIX: &str = "__smelt_symbol_";
+
+/// Synthetic member-name prefix for `Symbol.for(...)` registry symbols.
+///
+/// The registry description string is sanitized into an identifier-safe suffix
+/// (see [`registry_key_suffix`]) so, for example,
+/// `Symbol.for("@ts-pattern/matcher")` and a `const matcher = Symbol.for(...)`
+/// alias both resolve to `__smelt_symbol_for_ts_pattern_matcher`.
+const REGISTRY_SYMBOL_PREFIX: &str = "__smelt_symbol_for_";
+
+/// Return the stable synthetic member key for a well-known `Symbol.<name>`.
+///
+/// Returns `None` for symbol names Smelt does not model as static members, which
+/// keeps genuinely unsupported symbol keys on the honest dynamic-key path.
+///
+/// `Symbol.iterator` retains its established `__smelt_symbol_iterator` spelling
+/// so previously-lowered iterator members keep matching; the remaining
+/// well-known symbols use the shared `__smelt_symbol_<name>` scheme.
+pub(in crate::lowering) fn well_known_symbol_key(name: &str) -> Option<String> {
+    let modeled = matches!(
+        name,
+        "iterator"
+            | "asyncIterator"
+            | "hasInstance"
+            | "isConcatSpreadable"
+            | "match"
+            | "matchAll"
+            | "replace"
+            | "search"
+            | "species"
+            | "split"
+            | "toPrimitive"
+            | "toStringTag"
+            | "unscopables"
+    );
+    if !modeled {
+        return None;
+    }
+    if name == "iterator" {
+        // Keep the pre-existing spelling that member access and the coercion
+        // emitter already read (`__smelt_symbol_iterator`).
+        return Some(format!("{WELL_KNOWN_SYMBOL_PREFIX}iterator"));
+    }
+    Some(format!(
+        "{WELL_KNOWN_SYMBOL_PREFIX}{}",
+        camel_to_snake_ascii(name)
+    ))
+}
+
+/// Return the stable synthetic member key for a `Symbol.for(description)`.
+///
+/// The description string is sanitized so the resulting key is a valid,
+/// collision-resistant identifier while remaining a pure function of the
+/// registry description (every reference to the same registry symbol folds to
+/// the same key).
+pub(in crate::lowering) fn registry_symbol_key(description: &str) -> String {
+    format!("{REGISTRY_SYMBOL_PREFIX}{}", registry_key_suffix(description))
+}
+
+/// Extract the registry description from a lowered `Symbol.for(...)` literal.
+///
+/// `Symbol.for(desc)` values lower to the stable literal string
+/// `"Symbol.for(<desc>)"` (see the `Symbol` call dispatch), while unique
+/// `Symbol(...)` values carry an unstable span-tagged spelling. Only the
+/// registry form yields a stable key, so this returns `Some(desc)` for the
+/// former and `None` for the latter.
+pub(in crate::lowering) fn registry_description_of_symbol_literal(value: &str) -> Option<&str> {
+    value
+        .strip_prefix("Symbol.for(")
+        .and_then(|rest| rest.strip_suffix(')'))
+}
+
+/// Sanitize a `Symbol.for` description into an identifier-safe key suffix.
+///
+/// Non-alphanumeric characters collapse to single underscores and leading and
+/// trailing underscores are trimmed, so `"@ts-pattern/matcher"` becomes
+/// `"ts_pattern_matcher"`. An empty or all-symbol description falls back to
+/// `"anonymous"` so the produced key is always a valid identifier.
+fn registry_key_suffix(description: &str) -> String {
+    let mut suffix = String::with_capacity(description.len());
+    let mut pending_underscore = false;
+    for ch in description.chars() {
+        if ch.is_ascii_alphanumeric() {
+            if pending_underscore && !suffix.is_empty() {
+                suffix.push('_');
+            }
+            pending_underscore = false;
+            suffix.push(ch.to_ascii_lowercase());
+        } else {
+            pending_underscore = true;
+        }
+    }
+    if suffix.is_empty() {
+        "anonymous".to_owned()
+    } else {
+        suffix
+    }
+}
+
+/// Lower-case an ASCII `camelCase` symbol name into `snake_case`.
+///
+/// Well-known symbol names are fixed ASCII identifiers (`asyncIterator`,
+/// `toStringTag`, …), so this is a small dedicated converter rather than a reuse
+/// of the general source-name folding, keeping the synthetic spelling stable and
+/// independent of source-name interning rules.
+fn camel_to_snake_ascii(name: &str) -> String {
+    let mut output = String::with_capacity(name.len() + 4);
+    for (index, ch) in name.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if index != 0 {
+                output.push('_');
+            }
+            output.push(ch.to_ascii_lowercase());
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iterator_keeps_established_spelling() {
+        assert_eq!(
+            well_known_symbol_key("iterator").as_deref(),
+            Some("__smelt_symbol_iterator")
+        );
+    }
+
+    #[test]
+    fn async_iterator_uses_snake_case_scheme() {
+        assert_eq!(
+            well_known_symbol_key("asyncIterator").as_deref(),
+            Some("__smelt_symbol_async_iterator")
+        );
+        assert_eq!(
+            well_known_symbol_key("toStringTag").as_deref(),
+            Some("__smelt_symbol_to_string_tag")
+        );
+    }
+
+    #[test]
+    fn unmodeled_symbol_name_does_not_fold() {
+        assert_eq!(well_known_symbol_key("madeUpSymbol"), None);
+    }
+
+    #[test]
+    fn registry_key_is_deterministic_and_sanitized() {
+        assert_eq!(
+            registry_symbol_key("@ts-pattern/matcher"),
+            "__smelt_symbol_for_ts_pattern_matcher"
+        );
+        assert_eq!(
+            registry_symbol_key("@ts-pattern/override"),
+            "__smelt_symbol_for_ts_pattern_override"
+        );
+        // Same description -> same key, regardless of how it was referenced.
+        assert_eq!(
+            registry_symbol_key("app.event"),
+            registry_symbol_key("app.event")
+        );
+    }
+
+    #[test]
+    fn empty_registry_description_falls_back() {
+        assert_eq!(registry_symbol_key(""), "__smelt_symbol_for_anonymous");
+        assert_eq!(registry_symbol_key("///"), "__smelt_symbol_for_anonymous");
+    }
+
+    #[test]
+    fn registry_description_extraction() {
+        assert_eq!(
+            registry_description_of_symbol_literal("Symbol.for(@ts-pattern/matcher)"),
+            Some("@ts-pattern/matcher")
+        );
+        // Unique symbols carry an unstable span tag and must not fold.
+        assert_eq!(
+            registry_description_of_symbol_literal("Symbol(desc)@42"),
+            None
+        );
+    }
+}

--- a/crates/smelt-frontend-ts/src/lowering/ty/interface_lookup.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/interface_lookup.rs
@@ -61,16 +61,25 @@ impl ModuleBuilder<'_> {
 
     /// Resolve a computed property key to its static string member name.
     ///
-    /// Returns `Some((name, is_well_known_symbol))` when the key is a
+    /// Returns `Some((name, is_symbol_backed))` when the key is a
     /// statically-resolvable computed key:
     /// * a const reference whose value folds to a string/number literal
     ///   (`const K = "id"; { [K]: v }`),
     /// * an enum member (`enum E { A = "a" }; { [E.A]: v }`) or a foldable
-    ///   `Number`/`Math` numeric constant, or
-    /// * a well-known symbol member (`[Symbol.iterator]`), which maps to a stable
-    ///   synthetic member spelling that member access already understands.
+    ///   `Number`/`Math` numeric constant,
+    /// * a well-known symbol member (`[Symbol.iterator]`,
+    ///   `[Symbol.asyncIterator]`, …), which maps to a stable synthetic member
+    ///   spelling that member access already understands, or
+    /// * a `Symbol.for(<description>)` registry symbol — spelled inline
+    ///   (`[Symbol.for("k")]`), aliased to a `const` (`[matcher]`), or read
+    ///   through a namespace import (`[symbols.override]`) — which folds to a
+    ///   stable synthetic spelling derived from the registry description because
+    ///   registry symbols are globally interned (issue #115).
     ///
-    /// Returns `None` for genuinely dynamic keys (arbitrary expressions, opaque
+    /// The boolean is `true` when the resolved name is a synthetic symbol key
+    /// (interned verbatim) rather than an ordinary source-name-folded key.
+    ///
+    /// Returns `None` for genuinely dynamic keys (arbitrary expressions, unique
     /// `Symbol(...)` brands, boolean/null constants), leaving them on the
     /// explicit runtime-keyed path.
     pub(in crate::lowering) fn resolve_static_computed_key_name(
@@ -78,22 +87,28 @@ impl ModuleBuilder<'_> {
         key: &PropertyKey<'_>,
     ) -> Option<(String, bool)> {
         match key {
-            // A well-known `Symbol.<name>` key names a stable synthetic member.
+            // A well-known / registry `Symbol.<name>` or `Symbol.for(...)` member
+            // key names a stable synthetic member; otherwise a foldable const
+            // member (enum member, Number/Math constant) resolves normally.
             PropertyKey::StaticMemberExpression(member) => {
-                if let Expression::Identifier(object) = &member.object
-                    && object.name == "Symbol"
-                    && member.property.name == "iterator"
-                {
-                    return Some((Self::SYMBOL_ITERATOR_KEY.to_owned(), true));
+                if let Some(symbol_key) = self.symbol_member_key(member) {
+                    return Some((symbol_key, true));
                 }
                 let literal = self.member_literal_const_expression(member).ok()?;
                 literal.computed_member_name().map(|name| (name, false))
             }
-            // A bare identifier reference folds to its const value when known.
+            // An inline `[Symbol.for("k")]` call key folds to its registry key.
+            PropertyKey::CallExpression(call) => {
+                Self::symbol_for_call_key(call).map(|symbol_key| (symbol_key, true))
+            }
+            // A bare identifier reference folds to its const value when known;
+            // a `Symbol.for(...)`-aliased const yields a synthetic symbol key.
             PropertyKey::Identifier(identifier) => self
                 .resolve_const_literal_by_name(identifier.name.as_str())
-                .and_then(|literal| literal.computed_member_name())
-                .map(|name| (name, false)),
+                .and_then(|literal| {
+                    let is_symbol = literal.symbol_registry_name().is_some();
+                    literal.computed_member_name().map(|name| (name, is_symbol))
+                }),
             // Erased type-level wrappers around any of the above still name the
             // inner static key (`[K as const]`, `[(K)]`, `[K!]`).
             PropertyKey::ParenthesizedExpression(inner) => {
@@ -121,19 +136,21 @@ impl ModuleBuilder<'_> {
     ) -> Option<(String, bool)> {
         match expression {
             Expression::StaticMemberExpression(member) => {
-                if let Expression::Identifier(object) = &member.object
-                    && object.name == "Symbol"
-                    && member.property.name == "iterator"
-                {
-                    return Some((Self::SYMBOL_ITERATOR_KEY.to_owned(), true));
+                if let Some(symbol_key) = self.symbol_member_key(member) {
+                    return Some((symbol_key, true));
                 }
                 let literal = self.member_literal_const_expression(member).ok()?;
                 literal.computed_member_name().map(|name| (name, false))
             }
+            Expression::CallExpression(call) => {
+                Self::symbol_for_call_key(call).map(|symbol_key| (symbol_key, true))
+            }
             Expression::Identifier(identifier) => self
                 .resolve_const_literal_by_name(identifier.name.as_str())
-                .and_then(|literal| literal.computed_member_name())
-                .map(|name| (name, false)),
+                .and_then(|literal| {
+                    let is_symbol = literal.symbol_registry_name().is_some();
+                    literal.computed_member_name().map(|name| (name, is_symbol))
+                }),
             Expression::StringLiteral(literal) => Some((literal.value.to_string(), false)),
             Expression::ParenthesizedExpression(inner) => {
                 self.resolve_static_computed_key_name_expr(&inner.expression)
@@ -149,6 +166,58 @@ impl ModuleBuilder<'_> {
             }
             _ => None,
         }
+    }
+
+    /// Resolve a member expression that names a symbol into its stable synthetic
+    /// member key.
+    ///
+    /// Handles two shapes:
+    /// * a well-known symbol access (`Symbol.iterator`, `Symbol.asyncIterator`, …)
+    ///   folds to the per-name synthetic key (see
+    ///   [`crate::lowering::ty::computed_key_symbols::well_known_symbol_key`]),
+    ///   and
+    /// * a namespace-member alias of a `Symbol.for(...)` registry const
+    ///   (`import * as s from "..."; [s.override]`) folds to the registry key by
+    ///   resolving the const behind the qualified name.
+    ///
+    /// Returns `None` when the member is not a modeled symbol key, leaving the
+    /// caller to try const/enum folding or reject the key as dynamic.
+    fn symbol_member_key(
+        &self,
+        member: &oxc::ast::ast::StaticMemberExpression<'_>,
+    ) -> Option<String> {
+        if let Expression::Identifier(object) = &member.object
+            && object.name == "Symbol"
+        {
+            return crate::lowering::ty::computed_key_symbols::well_known_symbol_key(
+                member.property.name.as_str(),
+            );
+        }
+        // `namespace.member` alias of an imported `Symbol.for(...)` const: resolve
+        // the const behind the qualified name and fold its registry description.
+        if let Expression::Identifier(object) = &member.object {
+            let qualified = format!("{}.{}", object.name, member.property.name);
+            if let Some(name) = self
+                .resolve_const_literal_by_name(&qualified)
+                .and_then(|literal| literal.symbol_registry_name())
+            {
+                return Some(name);
+            }
+        }
+        None
+    }
+
+    /// Resolve an inline `Symbol.for(<string literal>)` call key to its registry
+    /// member key.
+    ///
+    /// Reuses [`Self::symbol_for_call_description`] so the inline-key path and the
+    /// const-folding path agree on what a foldable registry call looks like. Only
+    /// the registry form with a string-literal description folds; a unique
+    /// `Symbol(...)` call or a non-literal description has no stable static
+    /// spelling and returns `None`.
+    fn symbol_for_call_key(call: &oxc::ast::ast::CallExpression<'_>) -> Option<String> {
+        Self::symbol_for_call_description(call)
+            .map(crate::lowering::ty::computed_key_symbols::registry_symbol_key)
     }
 
     /// Return whether a computed property key resolves to a static member name.

--- a/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
@@ -622,3 +622,146 @@ export function area(radius: number): number {
     ));
     Ok(())
 }
+
+/// A well-known `[Symbol.asyncIterator]` interface method resolves to a stable
+/// synthetic member spelling and lowers to a named method rather than hitting
+/// the "property names must be static" gate (issue #115, neverthrow residual).
+#[test]
+fn lowers_symbol_async_iterator_computed_interface_method() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export interface Seq {
+  [Symbol.asyncIterator](): number;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    let seq = interface_named(&ctx, module, "Seq")?;
+    ensure!(
+        seq.methods.iter().any(|method| ctx.krate.symbols.get(method.name)
+            == Some("__smelt_symbol_async_iterator")),
+        "expected a `__smelt_symbol_async_iterator` method, got {:?}",
+        seq.methods
+    );
+    Ok(())
+}
+
+/// A `Symbol.for(<literal>)`-aliased const used as a computed interface method
+/// key (`const matcher = Symbol.for("k"); { [matcher](): T }`) folds to the
+/// registry synthetic member spelling (issue #115, ts-pattern residual). This is
+/// the const-alias shape ts-pattern uses for its `[matcher]()` protocol methods.
+#[test]
+fn lowers_symbol_for_const_keyed_interface_method() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+const matcher = Symbol.for('@ts-pattern/matcher');
+
+export interface Matcher {
+  [matcher](): number;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    let matcher = interface_named(&ctx, module, "Matcher")?;
+    ensure!(
+        matcher.methods.iter().any(|method| ctx.krate.symbols.get(method.name)
+            == Some("__smelt_symbol_for_ts_pattern_matcher")),
+        "expected a `__smelt_symbol_for_ts_pattern_matcher` method, got {:?}",
+        matcher.methods
+    );
+    Ok(())
+}
+
+/// An inline `[Symbol.for("k")]` computed interface field folds to the same
+/// registry synthetic member spelling as a `Symbol.for`-aliased const, since
+/// registry symbols are interned by description (issue #115).
+#[test]
+fn lowers_inline_symbol_for_computed_interface_field() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export interface Branded {
+  [Symbol.for('@ts-pattern/override')]: number;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    let branded = interface_named(&ctx, module, "Branded")?;
+    ensure!(
+        branded.fields.iter().any(|field| ctx.krate.symbols.get(field.name)
+            == Some("__smelt_symbol_for_ts_pattern_override")),
+        "expected a `__smelt_symbol_for_ts_pattern_override` field, got {:?}",
+        branded.fields
+    );
+    Ok(())
+}
+
+/// A `Symbol.for(<literal>)`-aliased const referenced through a namespace import
+/// (`import * as symbols; { [symbols.override]: T }`) folds to the registry
+/// synthetic member spelling — the exact shape ts-pattern's `Pattern.ts` uses
+/// (issue #115). The registry const is declared and re-exported by an earlier
+/// module so it resolves through the cross-module const machinery.
+#[test]
+fn lowers_namespace_symbol_for_computed_interface_field() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_path_ok(
+        ts!(r#"
+export const override = Symbol.for('@ts-pattern/override');
+"#),
+        "symbols.ts",
+        &mut ctx,
+    )?;
+    let module_id = lower_path_ok(
+        ts!(r#"
+import * as symbols from './symbols';
+
+export interface Override {
+  [symbols.override]: number;
+}
+"#),
+        "Pattern.ts",
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    let override_iface = interface_named(&ctx, module, "Override")?;
+    ensure!(
+        override_iface.fields.iter().any(|field| ctx.krate.symbols.get(field.name)
+            == Some("__smelt_symbol_for_ts_pattern_override")),
+        "expected a `__smelt_symbol_for_ts_pattern_override` field, got {:?}",
+        override_iface.fields
+    );
+    Ok(())
+}
+
+/// A *unique* `Symbol("desc")` (no `.for`) aliased to a const has fresh identity
+/// each evaluation and is not a stable static key, so using it as a computed
+/// property name still reports the dynamic-key diagnostic (issue #115 folds only
+/// globally-interned registry symbols, not unique brands).
+#[test]
+fn rejects_unique_symbol_const_computed_property_name() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let errors = lowering_errors(
+        ts!(r#"
+const brand = Symbol('brand');
+
+class Branded {
+  [brand]: number = 0;
+}
+"#),
+        &mut ctx,
+    )?;
+    assert_unsupported_ts(
+        &errors,
+        "dynamic computed property names are not lowered yet",
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Follow-up to #96. Extends static computed property-name resolution to the residual symbol-backed key shapes used by **neverthrow** and **ts-pattern**, so they no longer hit the `property names must be static identifiers or string literals` gate. All folding reuses #96's const/enum resolution engine — no per-library special cases, no `SmeltUnknown` shortcut.

## Investigation

Fetched the pinned probe sources and found exactly three residual shapes:

- **neverthrow** `src/result-async.ts`: `async *[Symbol.asyncIterator]()` — a well-known symbol (#96 only handled `Symbol.iterator`).
- **ts-pattern** `src/types/Pattern.ts`: `[matcher]()` and `[symbols.override]` / `[symbols.isVariadic]`, where `matcher`/`override`/`isVariadic` are all `export const X = Symbol.for('@ts-pattern/…')` registry symbols (in `src/internals/symbols.ts`), referenced as a bare const alias or through a namespace import.

All three are statically foldable: well-known symbols are language constants, and `Symbol.for(desc)` symbols are globally interned by description, so every reference names the same member.

## What landed

- **More well-known symbols**: `[Symbol.asyncIterator]` and the rest of the ECMAScript well-known symbols fold to per-name synthetic keys. `Symbol.iterator` keeps its established `__smelt_symbol_iterator` spelling; the read side (`symbol_static_member`) uses the same table so declarations and reads agree.
- **`Symbol.for(<string literal>)` registry symbols**: fold to a stable synthetic key derived from the description — spelled inline (`[Symbol.for("k")]`), aliased to a const (`[matcher]`), or read through a namespace import (`[symbols.override]`). `Symbol.for(...)` now const-folds to the same stable `Symbol.for(<desc>)` literal the runtime value path already emits, so the existing const machinery carries it with **no new tracking state**.
- New folding helpers live in a documented `ty::computed_key_symbols` module with unit tests.

## Stays dynamic (correct)

A unique `Symbol("desc")` brand (no `.for`) has fresh identity each evaluation and does **not** fold; arbitrary/computed keys still report the dynamic-key diagnostic. Covered by a rejection regression test.

## Tests

- Frontend regressions: well-known async iterator, `Symbol.for`-aliased-const key, inline `Symbol.for` key, namespace-member key, unique-`Symbol` rejection.
- `computed_key_symbols` unit tests (key spellings, sanitization, determinism).
- Extended the `computed_property_names` compile-corpus case with the new keys; emitted Rust compiles (`SMELT_CORPUS_ONLY=computed_property_names … --ignored` passes).
- `cargo check`/`clippy` clean; full `smelt-frontend-ts` (770) and `smelt-codegen-rust` (491) lib suites green.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)