### PR TITLE
frontend-ts: lower array reduce callbacks returning a reconcilable type

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/list_query.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_query.rs
@@ -517,6 +517,19 @@ impl FunctionEmitter<'_> {
     }
 
     /// Converts an array reduce callback into Rust `fold` text.
+    ///
+    /// The emitted `fold` threads the accumulator through as `acc: dest_ty` and
+    /// invokes the callback with only as many of `(acc, item, index, array)` as
+    /// the callback declares — a JS `reduce` callback commonly takes fewer than
+    /// the four arguments the runtime supplies (e.g. a named `step(acc, x)` or an
+    /// arrow `(acc, value) => …`). Each supplied argument is coerced to the
+    /// callback parameter's type, and the callback result is coerced back to the
+    /// accumulator type `dest_ty` through the shared coercion seam, so a callback
+    /// whose declared return type merely reconciles with (rather than equals) the
+    /// accumulator — a concrete-union member, an optional/`unknown` widening —
+    /// still folds into a value the next step accepts (issue #113). The frontend
+    /// (`lower_list_reduce`) picks `dest_ty` so this reconciliation is statically
+    /// valid; here we only render the arity- and type-matched call.
     pub(super) fn list_reduce_text(
         &self,
         list: &Operand,
@@ -529,12 +542,36 @@ impl FunctionEmitter<'_> {
             return Err(EmitError::new("array reduce receiver must be a list"));
         };
         let element_ty = *list_element_ty;
-        if let Some(initial_operand) = initial {
-            if self.operand_ty(initial_operand)? != dest_ty {
+        let Some(Type::Function(function_ty)) = self.mir.types.get(self.operand_ty(callback)?)
+        else {
+            return Err(EmitError::new("array reduce callback must be a function"));
+        };
+        let callback_return_ty = function_ty.return_ty;
+        // The four values the JS runtime would pass, paired with the source type
+        // of the Rust expression that produces each. Only the leading prefix the
+        // callback actually declares is forwarded (and coerced) below.
+        let float_ty = self.type_id(Type::Float)?;
+        let candidate_args: [(&str, TypeId); 4] = [
+            ("acc", dest_ty),
+            ("item", element_ty),
+            ("index as f64", float_ty),
+            ("array", list_ty),
+        ];
+        let mut call_args = Vec::with_capacity(function_ty.params.len());
+        for (index, param_ty) in function_ty.params.iter().copied().enumerate() {
+            let Some((value_text, source_ty)) = candidate_args.get(index).copied() else {
                 return Err(EmitError::new(
-                    "array reduce initial value and callback result must match the destination type",
+                    "array reduce callback declares more parameters than reduce supplies",
                 ));
-            }
+            };
+            call_args.push(self.value_at_type_text(value_text, source_ty, param_ty)?);
+        }
+        if let Some(initial_operand) = initial
+            && self.operand_ty(initial_operand)? != dest_ty
+        {
+            return Err(EmitError::new(
+                "array reduce initial value and callback result must match the destination type",
+            ));
         }
         let owned_list_text = self.operand_text(list)?;
         let borrowed_list_text = match list {
@@ -549,9 +586,13 @@ impl FunctionEmitter<'_> {
             // the reduce body to a default value.
             Err(_) => self.operand_text(callback)?,
         };
-        let callback_text = format!(
-            "{{ let smelt_callback = {callback_closure}; (smelt_callback)(acc, item, index, array) }}"
-        );
+        // Coerce the callback result to the accumulator type so a reconcilable
+        // (but not identical) return type still produces the next `acc` value.
+        let call_expr = format!("(smelt_callback)({})", call_args.join(", "));
+        let callback_result_text =
+            self.value_at_type_text(&call_expr, callback_return_ty, dest_ty)?;
+        let callback_text =
+            format!("{{ let smelt_callback = {callback_closure}; {callback_result_text} }}");
         if let Some(initial_operand) = initial {
             let initial_text = self.operand_text(initial_operand)?;
             Ok(format!(

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -6249,3 +6249,104 @@ def area(radius: float) -> float:
     assert!(source.contains("fn __smelt_static_PI"), "{source}");
     assert!(source.contains(" 3"), "{source}");
 }
+
+/// Issue #113: a named `reduce` callback whose declared return type is not
+/// identical to the initial value's type but statically reconciles with it must
+/// not be rejected with "array reduce callback returns an unsupported type". The
+/// accumulator widens to the reconciled type (`string | number`), the initial
+/// `0` is coerced into that concrete union, and the emitted `fold` invokes the
+/// callback with only the two arguments it declares (not the four the runtime
+/// supplies) so the closure call type-checks.
+#[test]
+fn reduce_named_callback_reconciles_union_return_type() {
+    let source = source_for(
+        r"
+function step(acc: string | number, value: number): string | number {
+  return acc;
+}
+export function run(values: number[]): string | number {
+  return values.reduce(step, 0);
+}
+",
+    );
+    assert!(source.contains(".iter().enumerate().fold("), "{source}");
+    // The named callback declares two parameters, so the emitted fold calls it
+    // with exactly two arguments rather than the runtime's `(acc, item, index,
+    // array)` four-argument shape.
+    assert!(
+        source.contains("(smelt_callback)(acc, item)"),
+        "reduce should call the two-parameter callback with two args: {source}"
+    );
+    assert!(source.contains("fn run("), "{source}");
+}
+
+/// Issue #113: a named `reduce` callback whose declared accumulator parameter is
+/// wider than both the seed and the callback return type resolves the reduce
+/// result to that declared accumulator type (TypeScript's `U`). The callback
+/// returns a `number` that must be coerced back into the `string | number`
+/// accumulator on each fold step, so the emitted fold both seeds and folds
+/// through the concrete union.
+#[test]
+fn reduce_named_callback_uses_declared_accumulator_type() {
+    let source = source_for(
+        r#"
+function step(acc: string | number, value: number): number {
+  return value;
+}
+export function run(values: number[]): string | number {
+  return values.reduce(step, "seed");
+}
+"#,
+    );
+    assert!(source.contains(".iter().enumerate().fold("), "{source}");
+    assert!(source.contains("(smelt_callback)(acc, item)"), "{source}");
+    assert!(source.contains("fn run("), "{source}");
+}
+
+/// Issue #113: a named `reduce` callback that widens a concrete seed into an
+/// erased `unknown` accumulator (a genuine dynamic boundary) still lowers; the
+/// accumulator is the callback's `unknown` return type and the numeric seed is
+/// coerced into it.
+#[test]
+fn reduce_named_callback_widens_to_unknown_accumulator() {
+    let source = source_for(
+        r"
+function step(acc: number, value: number): unknown {
+  return acc + value;
+}
+export function run(values: number[]): unknown {
+  return values.reduce(step, 0);
+}
+",
+    );
+    assert!(source.contains(".iter().enumerate().fold("), "{source}");
+    assert!(source.contains("fn run("), "{source}");
+}
+
+/// Issue #113: a genuinely irreconcilable named `reduce` callback — a `string`
+/// accumulator with a `boolean` return type that shares no common concrete
+/// shape — is still rejected, so the reconciliation does not silently widen
+/// unrelated types through a `SmeltUnknown` shortcut.
+#[test]
+fn reduce_named_callback_rejects_irreconcilable_return_type() {
+    let mut ctx = HirCtx::new();
+    let result = to_hir(
+        r#"
+function step(acc: string, value: number): boolean {
+  return true;
+}
+export function run(values: number[]): string {
+  return values.reduce(step, "seed");
+}
+"#,
+        FileId(0),
+        &mut ctx,
+    );
+    let errors = result.expect_err("irreconcilable reduce callback must be rejected");
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.message.contains("callback returns an unsupported type")),
+        "expected the reduce return-type rejection, got: {errors:?}"
+    );
+}

--- a/crates/smelt-codegen-rust/tests/compile_corpus.rs
+++ b/crates/smelt-codegen-rust/tests/compile_corpus.rs
@@ -267,6 +267,66 @@ function byLocal(values: number[]): number[] {
 }
 ",
         },
+        Case {
+            name: "reduce_callback_return_reconciliation",
+            area: "closures",
+            // A named/opaque `reduce` callback whose declared return type is not
+            // identical to the initial value's type but statically reconciles
+            // with it must not be rejected with "array reduce callback returns an
+            // unsupported type" (issue #113). TypeScript threads a single
+            // accumulator type `U` through `reduce<U>`, so the accumulator widens
+            // to the callback's return type and the seed is coerced into it. Each
+            // form must emit a `fold` that compiles: `intoUnion` seeds a `0`
+            // number into a `string | number` concrete-union accumulator;
+            // `intoRecord`/`intoList` seed an empty object/array into a wider
+            // container; `intoOptional` seeds `undefined` into an optional; and
+            // `intoUnknown` widens a concrete seed into an erased accumulator.
+            source: r#"
+function unionStep(acc: string | number, value: number): string | number {
+  return acc;
+}
+function intoUnion(values: number[]): string | number {
+  return values.reduce(unionStep, 0);
+}
+
+function recordStep(acc: Record<string, number>, value: string): Record<string, number> {
+  acc[value] = 1;
+  return acc;
+}
+function intoRecord(values: string[]): Record<string, number> {
+  return values.reduce(recordStep, {});
+}
+
+function listStep(acc: (string | number)[], value: number): (string | number)[] {
+  acc.push(value);
+  return acc;
+}
+function intoList(values: number[]): (string | number)[] {
+  return values.reduce(listStep, []);
+}
+
+function optionalStep(acc: number | undefined, value: number): number | undefined {
+  return acc;
+}
+function intoOptional(values: number[]): number | undefined {
+  return values.reduce(optionalStep, undefined);
+}
+
+function unknownStep(acc: number, value: number): unknown {
+  return acc + value;
+}
+function intoUnknown(values: number[]): unknown {
+  return values.reduce(unknownStep, 0);
+}
+
+function narrowReturnStep(acc: string | number, value: number): number {
+  return value;
+}
+function narrowReturn(values: number[]): string | number {
+  return values.reduce(narrowReturnStep, "seed");
+}
+"#,
+        },
         // --- string / list operations ----------------------------------------
         Case {
             name: "list_collection",

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/list_ops.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/list_ops.rs
@@ -804,26 +804,67 @@ impl ModuleBuilder<'_> {
                 list_ty = asserted_ty;
                 item_ty
             };
-        let initial = if let Some(initial_argument) = initial_argument {
+        let mut initial = if let Some(initial_argument) = initial_argument {
             Some(self.argument(initial_argument, body)?)
         } else {
             None
         };
-        let accumulator_ty = initial.map_or(element_ty, |initial| Self::expr_ty(body, initial));
+        // The accumulator seed type: the initial value's type, or (with no
+        // initial) the element type, which seeds the fold from the first element.
+        let seed_ty = initial.map_or(element_ty, |initial| Self::expr_ty(body, initial));
         let index_ty = self.ctx.krate.types.intern(Type::Int);
-        let callback_param_tys = [accumulator_ty, element_ty, index_ty, list_ty];
-        let callback_expr = if let Argument::ArrowFunctionExpression(arrow) = callback_argument {
-            self.arrow_closure_body_expr(arrow, &callback_param_tys, accumulator_ty, body)?
-        } else {
-            let callback = self.callback_argument(
-                callback_argument,
-                &callback_param_tys,
-                "array reduce",
-                body,
-            )?;
-            self.require_callback_ty(callback.return_ty, accumulator_ty, call, "array reduce")?;
-            callback.expr
-        };
+        // Contextual callback parameter types `(acc, cur, index, array)`. The
+        // arrow path lowers its body with `seed_ty` as the return hint; the
+        // named path resolves the accumulator type from the callback's own
+        // declared signature via `reduce_accumulator_ty` below.
+        let callback_param_tys = [seed_ty, element_ty, index_ty, list_ty];
+        let (callback_expr, accumulator_ty) =
+            if let Argument::ArrowFunctionExpression(arrow) = callback_argument {
+                let callback_expr =
+                    self.arrow_closure_body_expr(arrow, &callback_param_tys, seed_ty, body)?;
+                (callback_expr, seed_ty)
+            } else {
+                let callback = self.callback_argument(
+                    callback_argument,
+                    &callback_param_tys,
+                    "array reduce",
+                    body,
+                )?;
+                // TypeScript threads the accumulator type `U` through
+                // `reduce<U>(cb: (acc: U, cur, i, arr) => U, initial: U): U`,
+                // unifying it from the callback's declared accumulator parameter,
+                // its return type, and the initial value. When a named/opaque
+                // callback's declared return type is not identical to the seed
+                // but the two statically reconcile (concrete unions, optionals,
+                // `unknown`/generic surfaces, numeric widening; see #71's shared
+                // reconciler), pick `U` and coerce the seed/callback result into
+                // it in the emitter, rather than rejecting the reduce.
+                let declared_acc_ty = self.callback_declared_accumulator_ty(callback.expr, body);
+                let accumulator_ty = self.reduce_accumulator_ty(
+                    seed_ty,
+                    declared_acc_ty,
+                    callback.return_ty,
+                    call,
+                    initial.is_some(),
+                )?;
+                (callback.expr, accumulator_ty)
+            };
+        // When the accumulator type was widened past the seed's own type, coerce
+        // the initial value into it so the emitted fold seeds with the exact
+        // destination type (the emitter injects concrete-union members, boxes
+        // into optionals, etc. through the same `TypeAssert` coercion seam other
+        // array callbacks use for element-type coercions).
+        if let (Some(initial_expr), Some(initial_argument)) = (initial.as_mut(), initial_argument)
+            && Self::expr_ty(body, *initial_expr) != accumulator_ty
+        {
+            *initial_expr = body.push_expr(Expr {
+                kind: ExprKind::TypeAssert {
+                    value: *initial_expr,
+                },
+                ty: accumulator_ty,
+                span: self.span(initial_argument.span().start, initial_argument.span().end),
+            });
+        }
         Ok(Some(body.push_expr(Expr {
             kind: ExprKind::ListReduce {
                 list,
@@ -833,6 +874,97 @@ impl ModuleBuilder<'_> {
             ty: accumulator_ty,
             span: self.span(call.span.start, call.span.end),
         })))
+    }
+
+    /// Return a callback expression's declared accumulator (first) parameter type.
+    ///
+    /// A named or local reduce callback lowers to a value whose HIR type is its
+    /// declared `Type::Function`; its first parameter is the accumulator slot
+    /// `acc`. This surfaces that type so [`Self::reduce_accumulator_ty`] can use
+    /// the callback's declared accumulator as the reduce result type `U` when it
+    /// is wider than the seed. Returns `None` when the callback is not a plain
+    /// function value (e.g. an opaque erased value with no static signature).
+    fn callback_declared_accumulator_ty(
+        &self,
+        callback_expr: smelt_hir::ExprId,
+        body: &Body,
+    ) -> Option<smelt_hir::TypeId> {
+        let ty = Self::expr_ty(body, callback_expr);
+        match self.ctx.krate.types.get(self.type_param_constraint_or_self(ty)) {
+            Some(Type::Function(function)) => function.params.first().copied(),
+            _ => None,
+        }
+    }
+
+    /// Reconcile the reduce accumulator type from the seed and callback types.
+    ///
+    /// `reduce` threads an accumulator of a single type `U` through the fold: the
+    /// initial value, every callback result, and the final result all have type
+    /// `U`. `U` is unified from the seed (the initial value's type, or the
+    /// element type when there is no initial), the callback's declared
+    /// accumulator (first) parameter type, and the callback's return type. This
+    /// picks `U` and lets the emitter coerce the seed and each callback result
+    /// into it:
+    ///
+    /// - When the seed already equals the callback return type (the common case),
+    ///   `U` is that type unchanged.
+    /// - Otherwise, when the callback declares an accumulator parameter type that
+    ///   both the seed and the return type are assignable to — e.g.
+    ///   `step(acc: string | number, x): number` folded from `"seed"` — that
+    ///   declared type is `U`. This matches how TypeScript resolves `reduce<U>`.
+    /// - Failing a usable declared parameter, the seed and return type are
+    ///   reconciled through the shared conditional-branch reconciler
+    ///   ([`Self::conditional_branch_type`]) used by #71 (numeric widening, list
+    ///   element unification, concrete unions). A genuinely irreconcilable pair
+    ///   surfaces the existing "array reduce callback returns an unsupported
+    ///   type" error.
+    ///
+    /// With no initial value the fold seeds from the first element, so the
+    /// accumulator must stay the element type: a widening callback return is
+    /// rejected because there is no seed to coerce into the wider type.
+    fn reduce_accumulator_ty(
+        &mut self,
+        seed_ty: smelt_hir::TypeId,
+        declared_acc_ty: Option<smelt_hir::TypeId>,
+        callback_return_ty: smelt_hir::TypeId,
+        call: &oxc::ast::ast::CallExpression<'_>,
+        has_initial: bool,
+    ) -> Result<smelt_hir::TypeId, SmeltError> {
+        if seed_ty == callback_return_ty {
+            return Ok(seed_ty);
+        }
+        if has_initial {
+            // Prefer the callback's declared accumulator type when both the seed
+            // and the return type flow into it: that is exactly TypeScript's `U`.
+            if let Some(declared_acc_ty) = declared_acc_ty
+                && declared_acc_ty != seed_ty
+                && self.type_assignable_to(seed_ty, declared_acc_ty)
+                && self.type_assignable_to(callback_return_ty, declared_acc_ty)
+            {
+                return Ok(declared_acc_ty);
+            }
+            // A callback with no distinct declared accumulator (or an opaque one)
+            // whose return type simply subsumes the seed uses the return type.
+            if self.type_assignable_to(seed_ty, callback_return_ty) {
+                return Ok(callback_return_ty);
+            }
+            // Fall back to the shared reconciler; only accept a result the
+            // callback result can be coerced into (its own return type flows in
+            // by construction, so require the seed to as well).
+            if let Ok(reconciled) = self.conditional_branch_type(
+                seed_ty,
+                callback_return_ty,
+                None,
+                call.span.start,
+                call.span.end,
+            ) && self.type_assignable_to(callback_return_ty, reconciled)
+                && self.type_assignable_to(seed_ty, reconciled)
+            {
+                return Ok(reconciled);
+            }
+        }
+        self.require_callback_ty(callback_return_ty, seed_ty, call, "array reduce")?;
+        Ok(seed_ty)
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes the cross-library (es-toolkit + radash) blocker **`array reduce callback returns an unsupported type`** (#113). A `.reduce((acc, x) => ...)` / `.reduce(namedStep, initial)` whose callback return type was not *identical* to the accumulator seed was rejected outright, even when the two are statically reconcilable.

## What changed

**Frontend — `lower_list_reduce` (`crates/smelt-frontend-ts/src/lowering/callbacks/list_ops.rs`)**
- Resolve the reduce accumulator type `U` the way TypeScript's `reduce<U>(cb: (acc: U, cur, i, arr) => U, initial: U): U` does: unified from the seed (initial value / element type), the callback's **declared accumulator parameter**, and the callback **return type** — instead of requiring exact seed/return equality.
- Statically reconcilable returns now pick `U` and coerce the initial value into it through the existing `TypeAssert` coercion seam other array callbacks use:
  - concrete unions (`reduce(step, 0)` where `step` returns `string | number`)
  - optionals (`number | undefined`), wider containers (`Record`, `(string|number)[]`)
  - `unknown`/generic surfaces (genuine dynamic boundaries)
  - the shared conditional-branch reconciler from #71 (numeric widening, list element unification)
- Genuinely irreconcilable pairs (e.g. `string` accumulator / `boolean` return) still surface the original error. No `SmeltUnknown` widening of values that keep a concrete static shape.

**Emitter — `list_reduce_text` (`crates/smelt-codegen-rust/src/emitter/list_query.rs`)**
- Made the emitted `fold` **arity-aware**, mirroring the existing map/forEach path: it now forwards only the leading `(acc, item, index, array)` arguments the callback actually declares (a named `step(acc, x)` takes two, not four) and coerces each argument and the callback result to the accumulator type.
- This fixes a **latent `E0057`** that made named/opaque reduce callbacks uncompilable regardless of the return-type gate — the old code always called with four arguments against a two-parameter closure.

## Tests
- 4 codegen regression tests in `part_7_tests.rs` (union-return reconciliation, declared-accumulator resolution, `unknown` widening, and the irreconcilable-rejection guard).
- New `reduce_callback_return_reconciliation` compile-corpus case; verified to compile via `SMELT_CORPUS_ONLY=reduce_callback_return_reconciliation cargo test -p smelt-codegen-rust --test compile_corpus -- --ignored`.
- `cargo check` + `cargo clippy` clean on both touched crates; existing `emits_array_callback_methods` reduce text test still passes.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)