### PR TITLE
feat(frontend-ts): narrow union locals in switch(typeof x) arms

### DIFF
--- a/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
@@ -903,6 +903,17 @@ impl ModuleBuilder<'_> {
                 // are left untouched: the fact only projects concrete union arms.
                 let discriminant_narrowing =
                     self.switch_discriminant_narrowing(&switch_stmt.discriminant, body);
+                // A `switch (typeof x)` discriminates a union the way a chain of
+                // `if (typeof x === 'k')` guards would: each labeled arm proves
+                // `x` is the member(s) whose runtime `typeof` matches that arm's
+                // label. Unlike the field-discriminant fact above, this narrowing
+                // is per-arm, so the arm's own label(s) drive it. `pending_kinds`
+                // accumulates the string labels of grouped empty cases
+                // (`case 'a': case 'b':`) sharing the next arm's body; a `None`
+                // entry marks a label we could not read as a `typeof` kind, which
+                // disables narrowing for that group.
+                let typeof_switch_local = Self::typeof_identifier_name(&switch_stmt.discriminant);
+                let mut pending_kinds: Vec<Option<String>> = Vec::new();
                 let mut arms = Vec::new();
                 let mut default = None;
                 let mut pending_empty_labels = Vec::new();
@@ -911,6 +922,9 @@ impl ModuleBuilder<'_> {
                 for (case_index, case) in switch_stmt.cases.iter().enumerate() {
                     if case.consequent.is_empty() {
                         if let Some(test) = &case.test {
+                            if typeof_switch_local.is_some() {
+                                pending_kinds.push(Self::string_literal_value(test));
+                            }
                             pending_empty_labels.push(self.literal_case_label(test)?);
                             continue;
                         }
@@ -919,13 +933,35 @@ impl ModuleBuilder<'_> {
                     // arm handles the "no label matched" path and must not assume
                     // the discriminant property is present.
                     let narrowing_pushed = if case.test.is_some() {
-                        if let Some((name, target)) = discriminant_narrowing.clone() {
+                        // Prefer the per-arm `typeof` fact when the discriminant is
+                        // `typeof x`; otherwise project the shared field-discriminant
+                        // fact. Grouped labels for this arm (`pending_kinds`) union
+                        // with the arm's own label, and a group we could not read as
+                        // kinds records no fact.
+                        let typeof_fact = typeof_switch_local.as_ref().and_then(|name| {
+                            let group = std::mem::take(&mut pending_kinds);
+                            let current = case.test.as_ref().and_then(Self::string_literal_value);
+                            match current {
+                                Some(current) if group.iter().all(Option::is_some) => {
+                                    let mut kinds: Vec<String> =
+                                        group.into_iter().flatten().collect();
+                                    kinds.push(current);
+                                    self.switch_typeof_case_narrowing(name, &kinds, body)
+                                }
+                                _ => None,
+                            }
+                        });
+                        let fact = typeof_fact.or_else(|| discriminant_narrowing.clone());
+                        if let Some((name, target)) = fact {
                             self.apply_narrowing_scope(name, target);
                             true
                         } else {
                             false
                         }
                     } else {
+                        // The `default` arm proves no discriminant fact; drop any
+                        // pending `typeof` group kinds that fell through to it.
+                        pending_kinds.clear();
                         false
                     };
                     let case_block = body.push_block(self.span(case.span.start, case.span.end));

--- a/crates/smelt-frontend-ts/src/lowering/testing/matchers.rs
+++ b/crates/smelt-frontend-ts/src/lowering/testing/matchers.rs
@@ -1277,6 +1277,17 @@ impl ModuleBuilder<'_> {
         }
     }
 
+    /// Return a string literal's value, if the expression is one.
+    ///
+    /// Used to read `switch (typeof x)` case labels (`case 'string':`) as raw
+    /// `typeof` kind strings for per-arm narrowing.
+    pub(in crate::lowering) fn string_literal_value(expression: &Expression<'_>) -> Option<String> {
+        match expression {
+            Expression::StringLiteral(literal) => Some(literal.value.to_string()),
+            _ => None,
+        }
+    }
+
     /// Return the identifier operand of a `typeof name` expression.
     pub(in crate::lowering) fn typeof_identifier_name(expression: &Expression<'_>) -> Option<String> {
         let Expression::UnaryExpression(unary) = expression else {
@@ -1649,6 +1660,62 @@ impl ModuleBuilder<'_> {
         })?;
         let narrowed = self.intern_filtered_union(retained)?;
         Some((name, narrowed))
+    }
+
+    /// Compute the fact proven inside a `switch (typeof x) { case 'k': … }` arm.
+    ///
+    /// A `typeof` switch discriminates the same union that a chain of
+    /// `if (typeof x === 'k')` guards would: each arm proves `x` is the
+    /// member(s) whose runtime `typeof` matches the arm's label(s). Grouped
+    /// labels (`case 'a': case 'b':`) union their matching members. When `x`'s
+    /// static type is a union (optionally wrapped in `Optional`), the members are
+    /// filtered structurally via [`Self::type_matches_typeof`] so a
+    /// `case 'object'` arm keeps the array/record/class members instead of
+    /// widening to `unknown`; a non-union local falls back to the canonical
+    /// single-kind type from [`Self::typeof_matched_type`] (a narrowing no-op
+    /// when the local already has that type). `kinds` are the arm's string
+    /// labels; an empty result (no member matches, or grouped labels we cannot
+    /// read as kinds) records no fact.
+    pub(in crate::lowering) fn switch_typeof_case_narrowing(
+        &mut self,
+        name: &str,
+        kinds: &[String],
+        body: &Body,
+    ) -> Option<(String, smelt_hir::TypeId)> {
+        let local = self.locals.get(name).copied()?;
+        let current_ty = self
+            .narrowed_type(name)
+            .unwrap_or_else(|| Self::local_ty(body, local));
+        // Look through an `Optional` wrapper: a `typeof` case label never matches
+        // the absent (`undefined`) member unless it is an explicit
+        // `case 'undefined'`, handled by the single-kind fallback below.
+        let inner_ty = match self.ctx.krate.types.get(current_ty) {
+            Some(Type::Optional(inner)) => *inner,
+            _ => current_ty,
+        };
+        if let Some(Type::Union(items)) = self.ctx.krate.types.get(inner_ty).cloned() {
+            let retained = items
+                .into_iter()
+                .filter(|item| {
+                    // `typeof null === 'object'`, so a `None` member matches the
+                    // `'object'` kind — but a value proven present enough to be
+                    // indexed/field-accessed in this arm is never nullish (that is
+                    // the null guards' domain). Drop `None` so a `case 'object'`
+                    // narrows to the real object-shaped arm, not `string[] | null`.
+                    !matches!(self.ctx.krate.types.get(*item), Some(Type::None))
+                        && kinds.iter().any(|kind| self.type_matches_typeof(*item, kind))
+                })
+                .collect::<Vec<_>>();
+            if let Some(narrowed) = self.intern_filtered_union(retained) {
+                return Some((name.to_owned(), narrowed));
+            }
+        }
+        // Non-union local (or no arm matched the label): the canonical primitive
+        // for a single kind still narrows a widened scrutinee usefully.
+        if let [kind] = kinds {
+            return self.typeof_matched_type(name, kind, body);
+        }
+        None
     }
 
     /// Recognize `value instanceof Class` and retain matching concrete class arms.

--- a/crates/smelt-frontend-ts/src/tests/part02_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part02_tests.rs
@@ -957,6 +957,45 @@ function isUndefined(value?: number): boolean {
 }
 
 #[test]
+fn narrows_union_param_in_switch_typeof_cases() -> Result<(), String> {
+    // `switch (typeof x)` narrows the `string | string[]` union per arm the way
+    // a chain of `if (typeof x === 'k')` guards would: the `'string'` arm proves
+    // `chars` is a `string` (so `.length` and `=== chars` type-check) and the
+    // `'object'` arm proves it is the `string[]` member (so `.includes` does).
+    // Without per-arm `typeof` switch narrowing these member accesses hit the
+    // union receiver and fail to lower. Mirrors es-toolkit `string/trimStart.ts`.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function trimStartLike(str: string, chars: string | string[]): number {
+  let startIndex = 0;
+  switch (typeof chars) {
+    case 'string': {
+      if (chars.length !== 1) {
+        return -1;
+      }
+      while (startIndex < str.length && str[startIndex] === chars) {
+        startIndex++;
+      }
+      break;
+    }
+    case 'object': {
+      while (startIndex < str.length && chars.includes(str[startIndex])) {
+        startIndex++;
+      }
+    }
+  }
+  return startIndex;
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn lowers_typeof_bigint_guard() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(


### PR DESCRIPTION
## What

Adds **`switch (typeof x)` value-narrowing** — the missing piece of flow-sensitive union narrowing that the es-toolkit `compat/` (lodash) layer's dynamic-iteratee dispatch is built on.

Narrowing already covered:
- `if (typeof x === 'k')` guards (`typeof_guard`)
- `Array.isArray(x)`, `x instanceof C`
- field-discriminant switches (`switch (x.kind)`)

But **not** `switch (typeof x)` — the switch path only projected the shared field-discriminant fact. So this failed to lower:

```ts
switch (typeof chars) {          // chars: string | string[]
  case 'string': chars.length;    // receiver was the whole union → error
  case 'object': chars.includes(x);
}
```

## How

When the switch discriminant is `typeof <local>`, each labeled arm narrows the local to the union member(s) whose runtime `typeof` matches the arm's string label(s):

- Grouped labels (`case 'a': case 'b':`) union their matching members; a group whose labels can't be read as `typeof` kinds records no fact.
- The narrowed type is computed by filtering the union structurally through the existing `type_matches_typeof`, so `case 'object'` keeps the array/record/class member instead of widening to `unknown`.
- `None` members are dropped from the filter — `typeof null === 'object'`, but an arm you then index/field-access is never nullish (that's the null guards' domain), so `case 'object'` narrows to the real object arm, not `T | null`.

Reuses the existing `narrowed_locals` scope stack. New helpers: `switch_typeof_case_narrowing`, `string_literal_value`.

## Impact

Advances the whole-crate **es-toolkit build** past several previously-aborting compat files — `compat/array/dropWhile.ts`, `compat/util/iteratee.ts`, and everything between them — to the next, unrelated blocker (a `Uint8Array` stdlib gap). General: helps every library using `switch(typeof x)` dispatch.

## Verification

- New test `narrows_union_param_in_switch_typeof_cases` (mirrors es-toolkit `string/trimStart.ts`).
- `cargo test -p smelt-frontend-ts` — 774/0.
- `cargo test -p smelt-codegen-rust` — 495+7+1/0 (no golden/snapshot drift).
- `cargo clippy -p smelt-frontend-ts` — clean.
- Remeda gate validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)