### PR TITLE
feat(typed-arrays): resolve JS typed-array views as modeled stdlib classes

### DIFF
--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -819,6 +819,42 @@ export function make(count: number): number[] {
 }
 
 #[test]
+fn emits_bigint_typed_array_constructor_as_numeric_list() {
+    // `BigInt64Array` / `BigUint64Array` were previously omitted from the
+    // typed-array recognizer, so `new BigUint64Array(...)` aborted the build as
+    // an "unresolved class". They now share the numeric-list model with the
+    // other views: the element form emits a `Vec` literal and `.length` reads a
+    // list length.
+    let source = source_for(
+        r"
+export function make(): number {
+  const values = new BigUint64Array([1, 2, 3]);
+  return values.length;
+}
+",
+    );
+
+    assert!(source.contains("vec!["), "{source}");
+    assert!(!source.contains("unresolved"), "{source}");
+}
+
+#[test]
+fn emits_typed_array_from_element_literal_as_vec_literal() {
+    // `new Uint8Array([1, 2, 3])` reuses the array-literal lowering, so it emits
+    // a concrete `Vec` literal that supports `.length` and integer indexing.
+    let source = source_for(
+        r"
+export function first(): number {
+  const values = new Uint8Array([10, 20, 30]);
+  return values[0];
+}
+",
+    );
+
+    assert!(source.contains("vec![10.0, 20.0, 30.0]"), "{source}");
+}
+
+#[test]
 fn inserts_unknown_iterable_values_into_typed_sets() {
     let source = source_for(
         r"

--- a/crates/smelt-frontend-ts/src/lowering/expr/references.rs
+++ b/crates/smelt-frontend-ts/src/lowering/expr/references.rs
@@ -95,6 +95,27 @@ impl ModuleBuilder<'_> {
                 span: self.span(start, end),
             }));
         }
+        // A typed-array constructor used as a bare *value* rather than through
+        // `new` — e.g. an `instanceof Uint8Array` / `toBeInstanceOf(Uint8Array)`
+        // target, or a constructor passed to a helper. Mirror the `Date` model:
+        // resolve the name to a `Type::Class` marker value so it is a first-class
+        // constructor reference instead of an unresolved identifier. A
+        // user-declared class of the same name is handled by the branch above and
+        // takes priority. Smelt has no first-class class objects, so the value
+        // itself carries no callable payload; the `instanceof`/matcher lowering
+        // reads the class *name*, not this placeholder.
+        if smelt_stdlib::is_typed_array_class_name(name) {
+            let symbol = self.intern_type_name(name);
+            let ty = self.ctx.krate.types.intern(Type::Class {
+                name: symbol,
+                args: Vec::new(),
+            });
+            return Ok(body.push_expr(Expr {
+                kind: ExprKind::Literal(Literal::None),
+                ty,
+                span: self.span(start, end),
+            }));
+        }
         if matches!(name, "RegExp" | "Temporal") {
             let ty = self.ctx.krate.types.intern(Type::Unknown);
             return Ok(body.push_expr(Expr {

--- a/crates/smelt-frontend-ts/src/lowering/guards.rs
+++ b/crates/smelt-frontend-ts/src/lowering/guards.rs
@@ -49,6 +49,33 @@ impl ModuleBuilder<'_> {
             ));
         };
         let class_text = class_ident.name.as_str();
+        // `x instanceof Uint8Array` (any typed-array view). Smelt models a typed
+        // array as a plain numeric list, so identity is only recoverable from the
+        // static type: a list-typed operand *is* a typed array in this model and
+        // folds to `true`, while any other concrete or erased operand carries no
+        // typed-array identity and folds to `false`. This deliberately cannot
+        // distinguish a typed array from a plain `number[]` — the numeric-list
+        // representation erases that distinction — but it keeps the check honest
+        // for the common concrete cases and never aborts the build. A
+        // user-declared class of the same name owns the name and is handled by
+        // the ordinary class path below.
+        if smelt_stdlib::is_typed_array_class_name(class_text)
+            && !self.classes.contains_key(class_text)
+        {
+            let result = matches!(
+                self.ctx
+                    .krate
+                    .types
+                    .get(self.type_param_constraint_or_self(value_ty)),
+                Some(Type::List(_))
+            );
+            let ty = self.ctx.krate.types.intern(Type::Bool);
+            return Ok(body.push_expr(Expr {
+                kind: ExprKind::Literal(Literal::Bool(result)),
+                ty,
+                span: self.span(binary.span.start, binary.span.end),
+            }));
+        }
         if Self::is_ts_stdlib_class_name(class_text, smelt_stdlib::StdlibClass::Date)
             && self.expression_is_known_date_value(value, body)
         {
@@ -125,6 +152,12 @@ impl ModuleBuilder<'_> {
     /// Return true when an expression is a built-in constructor target.
     pub(super) fn instanceof_builtin_target(target: &str) -> bool {
         smelt_stdlib::typescript_stdlib_class(target).is_some()
+            // Typed-array views (`x instanceof Uint8Array`). Smelt backs a typed
+            // array with a plain numeric list, so a *concrete* list-typed operand
+            // resolves through the list check below and an erased/other operand
+            // folds to `false` (see `instanceof_fold_false_builtin_target`) —
+            // either way the target is recognized instead of aborting the build.
+            || smelt_stdlib::is_typed_array_class_name(target)
             || Self::marker_only_builtin_marker(target).is_some()
             || matches!(
                 target,

--- a/crates/smelt-frontend-ts/src/lowering/new_expr.rs
+++ b/crates/smelt-frontend-ts/src/lowering/new_expr.rs
@@ -177,7 +177,9 @@ impl ModuleBuilder<'_> {
         if callee.name == "AbortController" && !self.classes.contains_key("AbortController") {
             return self.abort_controller_constructor_expression(new_expr, body);
         }
-        if Self::is_numeric_typed_array_constructor(callee.name.as_str()) {
+        if Self::is_numeric_typed_array_constructor(callee.name.as_str())
+            && !self.classes.contains_key(callee.name.as_str())
+        {
             return self.numeric_typed_array_constructor_expression(new_expr, body);
         }
         if callee.name == "URLSearchParams" {
@@ -692,20 +694,16 @@ impl ModuleBuilder<'_> {
         }))
     }
 
-    /// Return whether a global constructor creates a numeric typed array.
+    /// Return whether a global constructor creates a JavaScript typed array.
+    ///
+    /// Delegates to the shared `smelt_stdlib` recognizer so all eleven typed
+    /// array names — including the BigInt-backed `BigInt64Array` /
+    /// `BigUint64Array`, which the previous inline `matches!` omitted and which
+    /// therefore aborted the es-toolkit build as an "unresolved class" — are
+    /// recognized from one registry. Smelt backs every view with the same
+    /// numeric-list model, so all eleven share this construction path.
     pub(super) fn is_numeric_typed_array_constructor(name: &str) -> bool {
-        matches!(
-            name,
-            "Int8Array"
-                | "Uint8Array"
-                | "Uint8ClampedArray"
-                | "Int16Array"
-                | "Uint16Array"
-                | "Int32Array"
-                | "Uint32Array"
-                | "Float32Array"
-                | "Float64Array"
-        )
+        smelt_stdlib::is_typed_array_class_name(name)
     }
 
     /// Lower `new URLSearchParams(init)` to an object carrying observable `size`.

--- a/crates/smelt-frontend-ts/src/tests/category_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/category_tests.rs
@@ -696,3 +696,128 @@ export function make(): Object {
     );
     Ok(())
 }
+
+/// Every typed-array view constructor — including the BigInt-backed
+/// `BigInt64Array` / `BigUint64Array` that the previous inline recognizer
+/// omitted and which aborted the es-toolkit build as `unresolved class
+/// BigUint64Array` — lowers without a missing-stdlib blocker. Smelt models a
+/// typed array as a plain numeric list, so the constructed value is a `List`.
+#[test]
+fn typed_array_constructors_lower_to_numeric_lists() -> Result<(), String> {
+    for name in smelt_stdlib::TYPED_ARRAY_CLASS_NAMES {
+        let source = format!("const value = new {name}(8);");
+        let mut ctx = HirCtx::new();
+        let module_id = lower_ok(&source, &mut ctx)?;
+        let module = module(&ctx, module_id)?;
+        let body = module_body(&ctx, module)?;
+        ensure!(
+            body.exprs.iter().any(|expr| matches!(
+                ctx.krate.types.get(expr.ty),
+                Some(Type::List(_))
+            )),
+            "expected `new {name}(8)` to lower to a numeric list",
+        );
+    }
+    Ok(())
+}
+
+/// `new Uint8Array([1, 2, 3])` lowers to a list literal (the numeric-list
+/// model reuses the array-expression lowering for the element form).
+#[test]
+fn typed_array_from_literal_lowers_to_list_literal() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(ts!("const value = new Uint8Array([1, 2, 3]);"), &mut ctx)?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+    ensure!(
+        body.exprs.iter().any(|expr| matches!(
+            (&expr.kind, ctx.krate.types.get(expr.ty)),
+            (ExprKind::ListLit(_), Some(Type::List(_)))
+        )),
+        "expected `new Uint8Array([1, 2, 3])` to lower to a list literal",
+    );
+    Ok(())
+}
+
+/// A typed-array constructor used as a bare *value* (an `instanceof` /
+/// `toBeInstanceOf` target, or a helper argument) resolves to a `Type::Class`
+/// reference instead of failing as an `unresolved identifier`, mirroring the
+/// `Date` bare-value model. This is the fix for the `unresolved identifier
+/// Uint8Array` blocker in `clone.spec.ts`.
+#[test]
+fn typed_array_name_resolves_as_bare_value() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!("function ctor(): unknown { return Uint8Array; }"),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = named_function_item(&ctx, module, "ctor")?;
+    let body = function_body(&ctx, function)?;
+    ensure!(
+        body.exprs.iter().any(|expr| matches!(
+            ctx.krate.types.get(expr.ty),
+            Some(Type::Class { name, .. }) if ctx.krate.symbols.get(*name) == Some("Uint8Array")
+        )),
+        "expected a bare `Uint8Array` to resolve to a Uint8Array class reference",
+    );
+    Ok(())
+}
+
+/// `x instanceof Uint8Array` folds to a boolean instead of aborting: a
+/// list-typed operand (a typed array in Smelt's numeric-list model) folds to
+/// `true`, while an unrelated concrete operand folds to `false`. The
+/// numeric-list model cannot distinguish a typed array from a plain `number[]`,
+/// but the check is honest for the common concrete cases and never blocks.
+#[test]
+fn instanceof_typed_array_folds_to_boolean() -> Result<(), String> {
+    for (source, expected) in [
+        (
+            "function check(x: number[]): boolean { return x instanceof Uint8Array; }",
+            true,
+        ),
+        (
+            "function check(x: string): boolean { return x instanceof Uint8Array; }",
+            false,
+        ),
+    ] {
+        let mut ctx = HirCtx::new();
+        let module_id = lower_ok(source, &mut ctx)?;
+        let module = module(&ctx, module_id)?;
+        let function = named_function_item(&ctx, module, "check")?;
+        let body = function_body(&ctx, function)?;
+        ensure!(
+            body.exprs.iter().any(|expr| matches!(
+                &expr.kind,
+                ExprKind::Literal(Literal::Bool(value)) if *value == expected
+            )),
+            "expected `{source}` to fold `instanceof Uint8Array` to `{expected}`",
+        );
+        ensure!(
+            !body.exprs.iter().any(|expr| matches!(
+                &expr.kind,
+                ExprKind::InstanceOf { class, .. }
+                    if ctx.krate.symbols.get(*class) == Some("Uint8Array")
+            )),
+            "expected `{source}` to fold the check instead of emitting an InstanceOf",
+        );
+    }
+    Ok(())
+}
+
+/// The es-toolkit `isTypedArray` body (`ArrayBuffer.isView(x) && !(x instanceof
+/// DataView)`) lowers without a blocker, exercising the typed-array
+/// `ArrayBuffer.isView` and `instanceof DataView` paths together.
+#[test]
+fn is_typed_array_predicate_body_lowers() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+export function isTypedArray(x: unknown): boolean {
+  return ArrayBuffer.isView(x) && !(x instanceof DataView);
+}
+"#),
+        &mut ctx,
+    )?;
+    Ok(())
+}

--- a/crates/smelt-stdlib/src/classes.rs
+++ b/crates/smelt-stdlib/src/classes.rs
@@ -54,6 +54,44 @@ pub fn typescript_stdlib_class(name: &str) -> Option<StdlibClass> {
     }
 }
 
+/// The JavaScript typed-array view constructor names, in a stable order.
+///
+/// These are the eleven `TypedArray` element-view classes (`Uint8Array`,
+/// `Int8Array`, ..., `BigInt64Array`, `BigUint64Array`). Smelt models a typed
+/// array as a plain numeric list (so `.length`, integer indexing, iteration and
+/// value-equality reuse the list machinery), while this shared name list is the
+/// single source of truth every frontend/codegen site consults to decide
+/// whether a constructor / bare identifier / `instanceof` target names a typed
+/// array. Keeping the set here — rather than re-spelling the `matches!(...)` arm
+/// in each site — stops the construction side, the value-resolution side, and
+/// the `instanceof` side from drifting apart.
+pub const TYPED_ARRAY_CLASS_NAMES: [&str; 11] = [
+    "Int8Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+    "Int16Array",
+    "Uint16Array",
+    "Int32Array",
+    "Uint32Array",
+    "Float32Array",
+    "Float64Array",
+    "BigInt64Array",
+    "BigUint64Array",
+];
+
+/// Return whether a class name is one of the JavaScript typed-array views.
+///
+/// Consulted by the TypeScript frontend (constructor lowering, bare-value
+/// resolution, `instanceof` targeting) and codegen so the eleven typed-array
+/// names are recognized from one place. `BigInt64Array` / `BigUint64Array` are
+/// included even though their elements are `BigInt` values: Smelt's minimum-viable
+/// typed array model backs every view with the same numeric list, so they share
+/// the recognizer with the numeric views.
+#[must_use]
+pub fn is_typed_array_class_name(name: &str) -> bool {
+    TYPED_ARRAY_CLASS_NAMES.contains(&name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -84,6 +122,25 @@ mod tests {
     fn rejects_user_class_names() {
         for name in ["Regexp", "RegExpLike", "Dates", "HashMap", "MyClass"] {
             assert_eq!(typescript_stdlib_class(name), None);
+        }
+    }
+
+    /// Every typed-array view constructor is recognized, including the BigInt
+    /// views, while plain `Array` and lookalikes are not.
+    #[test]
+    fn recognizes_typed_array_class_names() {
+        for name in TYPED_ARRAY_CLASS_NAMES {
+            assert!(
+                is_typed_array_class_name(name),
+                "expected `{name}` to be recognized as a typed array"
+            );
+        }
+        assert!(is_typed_array_class_name("BigUint64Array"));
+        for name in ["Array", "Uint8", "TypedArray", "Float16Array", "MyUint8Array"] {
+            assert!(
+                !is_typed_array_class_name(name),
+                "did not expect `{name}` to be recognized as a typed array"
+            );
         }
     }
 }

--- a/crates/smelt-stdlib/src/lib.rs
+++ b/crates/smelt-stdlib/src/lib.rs
@@ -17,7 +17,8 @@ pub mod runtime_symbols;
 
 pub use category::DiagnosticCategory;
 pub use classes::{
-    MATCH_CLASS_NAME, MATCH_GROUPS_CLASS_NAME, StdlibClass, typescript_stdlib_class,
+    MATCH_CLASS_NAME, MATCH_GROUPS_CLASS_NAME, StdlibClass, TYPED_ARRAY_CLASS_NAMES,
+    is_typed_array_class_name, typescript_stdlib_class,
 };
 pub use deps::BackendDependency;
 pub use diagnostics::{StdlibDiagnostic, UnsupportedForm};


### PR DESCRIPTION
## Summary

Adds JavaScript **typed array** support to smelt's stdlib model so es-toolkit's build stops aborting on them.

es-toolkit's `smelt build` aborted on two typed-array blockers:
- `unresolved class ` + "`BigUint64Array`" + ` in predicate/isTypedArray.spec.ts`
- `unresolved identifier ` + "`Uint8Array`" + ` in object/clone.spec.ts`

Smelt already lowered the nine numeric typed-array constructors to plain numeric lists, but the recognizer omitted the two BigInt views (`BigInt64Array`/`BigUint64Array`), and the eleven names never resolved as bare values or `instanceof` targets.

## Design

Smelt models a typed array as a **plain numeric list** (`Vec<f64>`), so `.length`, integer index get/set, iteration and value-equality reuse the existing list machinery — this is why the nine numeric views already constructed. This PR completes *resolution* rather than introducing a new type-system feature:

- **`smelt-stdlib`**: new shared `is_typed_array_class_name` / `TYPED_ARRAY_CLASS_NAMES` registry — one source of truth for all eleven view names, consulted by every frontend/codegen site so the construction, bare-value, and `instanceof` sides cannot drift.
- **`new_expr.rs`**: `is_numeric_typed_array_constructor` delegates to the shared recognizer, so `new BigInt64Array(...)` / `new BigUint64Array(...)` construct through the same numeric-list model instead of aborting; the call site keeps the user-class shadow guard.
- **`references.rs`**: a typed-array name used as a bare *value* (an `instanceof` / `toBeInstanceOf` target, or a helper argument) resolves to a `Type::Class` reference — mirroring the `Date` bare-value model — instead of failing as an unresolved identifier.
- **`guards.rs`**: `x instanceof Uint8Array` folds to a boolean (`true` for a list-typed operand, `false` otherwise) and the eleven names join `instanceof_builtin_target`.

### Known limitation (documented in code)
The numeric-list representation cannot distinguish a typed array from a plain `number[]` at runtime for erased values, so `isTypedArray` / `instanceof` identity is best-effort where the static type is erased. Making identity exact would require a distinct runtime wrapper (the Buffer-style marker-record-with-data model) — deliberately out of scope for this minimum-viable pass, which targets unblocking the build.

## What now works
- Construction: `new Uint8Array(n)` (zero-filled), `new Uint8Array([1,2,3])`, and all eleven views incl. `BigInt64Array`/`BigUint64Array`.
- `.length`, integer index get/set (via the numeric-list model).
- `Uint8Array` etc. resolve as bare values (`toBeInstanceOf(Uint8Array)` targets, helper args).
- `x instanceof Uint8Array` folds to a boolean.
- es-toolkit's own `isTypedArray` (`ArrayBuffer.isView(x) && !(x instanceof DataView)`) lowers all the way to MIR.

## Build advance
`predicate/isTypedArray.ts` **and** `isTypedArray.spec.ts` now lower cleanly (no errors). The full es-toolkit build advances past **every** typed-array blocker; it now aborts on an **unrelated** blocker — the two-argument `new Error('msg', { cause })` / `new AggregateError([...], msg)` constructor in `object/clone.spec.ts` (`Error constructor lowering supports at most one message argument`), which is a separate Error-with-cause feature, not typed arrays.

## Verification
- New tests: stdlib recognizer; frontend constructor / bare-value / `instanceof` / `isTypedArray`-body lowering; codegen BigInt-view + element-literal emission.
- Full suites pass: `smelt-stdlib` 21, `smelt-frontend-ts` 779, `smelt-codegen-rust` 497.
- `cargo clippy` clean on all three crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)