### PR TITLE
feat(manifest): add [sources] exclude glob; unblock es-toolkit DOM specs

### DIFF
--- a/.github/compat/es-toolkit/Smelt.toml
+++ b/.github/compat/es-toolkit/Smelt.toml
@@ -7,6 +7,30 @@ description = "es-toolkit Smelt probe"
 roots = ["src"]
 test-prefix = ["array/**/*.spec.ts", "function/**/*.spec.ts", "math/**/*.spec.ts", "object/**/*.spec.ts", "predicate/**/*.spec.ts", "promise/**/*.spec.ts", "string/**/*.spec.ts", "util/**/*.spec.ts", "error/**/*.spec.ts"]
 entries = ["src/index.ts"]
+# Spec files excluded from the whole-crate build because they depend on host
+# globals Smelt's non-DOM profile deliberately does not model. Any one
+# unbuildable file aborts the entire crate build, so these DOM/host-only specs
+# would otherwise block every es-toolkit test from running. Each entry lists the
+# unmodeled global it needs; remove an entry once Smelt models that global.
+exclude = [
+  # `document` / `HTMLElement` (DOM)
+  "src/object/cloneDeep.dom.spec.ts",   # @vitest-environment happy-dom; document.createElement, HTMLElement
+  "src/compat/object/clone.spec.ts",    # document.createElement, document.body
+  "src/compat/object/cloneWith.spec.ts", # document.createElement, document.body
+  "src/compat/predicate/isElement.spec.ts", # document (isElement DOM checks)
+  # `Blob` / `File` (host file APIs)
+  "src/object/clone.spec.ts",           # new File(...), new Blob(...)
+  "src/object/cloneDeep.spec.ts",       # new File(...), new Blob(...)
+  "src/predicate/isBlob.spec.ts",       # new Blob(...), globalThis.File
+  "src/predicate/isFile.spec.ts",       # new File(...), Blob, globalThis.File
+]
+# Deliberately NOT excluded (host/ECMA globals, but ambiguous whether Smelt can
+# model them — left in per "when unsure, leave it in"):
+#   src/predicate/isFunction.spec.ts   -> `Proxy`
+#   src/predicate/isPlainObject.spec.ts -> `Intl`, `Proxy`, `Request`
+# After the excludes above, `smelt build` aborts earlier at
+# src/predicate/isEqualWith.spec.ts on a fixable `field access` lowering blocker
+# (not a host global), which is other work.
 
 [output]
 target = "./dist-smelt"

--- a/crates/smelt-transpiler/src/config.rs
+++ b/crates/smelt-transpiler/src/config.rs
@@ -80,6 +80,18 @@ impl Config {
         self.sources.test_globs.as_deref().unwrap_or(&[])
     }
 
+    /// Get root-relative glob patterns for source files to exclude from lowering.
+    ///
+    /// Files whose root-relative path matches any of these patterns are dropped
+    /// from both build discovery (`entries` plus test globs) and probe
+    /// discovery. This lets a manifest opt specific files out of the whole-crate
+    /// build without hiding them from the repository — useful for spec files
+    /// that depend on host globals Smelt's non-DOM profile does not model.
+    #[must_use]
+    pub fn source_excludes(&self) -> &[String] {
+        self.sources.exclude.as_deref().unwrap_or(&[])
+    }
+
     /// Get the output target directory path.
     #[must_use]
     pub fn output_target(&self) -> &PathBuf {
@@ -115,6 +127,12 @@ pub struct Source {
     /// Optional glob patterns used to discover test source files under roots.
     #[serde(rename = "test-globs", alias = "test-prefix")]
     test_globs: Option<Vec<String>>,
+    /// Optional root-relative glob patterns for source files to exclude.
+    ///
+    /// Matching files are skipped by both build and probe file discovery. The
+    /// glob syntax matches [`test_globs`](Self::test_globs): `*` spans one path
+    /// segment and `**` spans zero or more segments, always with `/` separators.
+    exclude: Option<Vec<String>>,
 }
 
 /// Output configuration from the [output] section.

--- a/crates/smelt-transpiler/src/lowering.rs
+++ b/crates/smelt-transpiler/src/lowering.rs
@@ -261,6 +261,9 @@ impl Drop for QuietPanics {
 
 /// Recursively collect every TypeScript/Python source file under the manifest
 /// source roots, skipping declaration files and vendored/output directories.
+///
+/// Files whose manifest-relative path matches a `[sources] exclude` glob are
+/// dropped so probe discovery honors the same exclusions as build discovery.
 pub(crate) fn discover_source_files(
     config: &crate::config::Config,
     manifest_dir: &Path,
@@ -273,6 +276,7 @@ pub(crate) fn discover_source_files(
         let absolute_root = resolve_manifest_path(manifest_dir, &root);
         collect_source_files(&absolute_root, &mut paths)?;
     }
+    retain_included_paths(&mut paths, config.source_excludes(), manifest_dir);
     paths.sort();
     paths.dedup();
     Ok(paths)
@@ -363,6 +367,11 @@ pub(crate) fn lower_manifest_entries(
 }
 
 /// Returns explicitly listed entries plus test files discovered by glob.
+///
+/// Any root source whose manifest-relative path matches a `[sources] exclude`
+/// glob is removed before dependency resolution. Because excluded specs are
+/// leaf test files that nothing imports, dropping them from the root set keeps
+/// them out of the whole-crate build entirely.
 fn manifest_root_paths(
     config: &crate::config::Config,
     manifest_dir: &Path,
@@ -373,9 +382,31 @@ fn manifest_root_paths(
         .map(|path| resolve_manifest_path(manifest_dir, path))
         .collect::<Vec<_>>();
     paths.extend(discover_test_paths(config, manifest_dir)?);
+    retain_included_paths(&mut paths, config.source_excludes(), manifest_dir);
     paths.sort();
     paths.dedup();
     Ok(paths)
+}
+
+/// Drops paths whose manifest-relative form matches any `exclude` glob.
+///
+/// Exclusion patterns are matched against each path relative to the manifest
+/// directory (for example `src/object/clone.spec.ts`), using the same narrow
+/// glob syntax as [`path_matches_glob`]. Paths outside `manifest_dir` and paths
+/// with no exclude patterns are always retained.
+fn retain_included_paths(paths: &mut Vec<PathBuf>, excludes: &[String], manifest_dir: &Path) {
+    if excludes.is_empty() {
+        return;
+    }
+    paths.retain(|path| !is_excluded_source(path, excludes, manifest_dir));
+}
+
+/// Returns whether `path` matches any `exclude` glob relative to `manifest_dir`.
+fn is_excluded_source(path: &Path, excludes: &[String], manifest_dir: &Path) -> bool {
+    let relative = path.strip_prefix(manifest_dir).unwrap_or(path);
+    excludes
+        .iter()
+        .any(|pattern| path_matches_glob(relative, pattern))
 }
 
 /// Discovers test files matching configured source-root-relative glob patterns.
@@ -770,4 +801,109 @@ fn manifest_module_names(sources: &[&ManifestSource]) -> Vec<String> {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for source-file glob matching and `[sources] exclude` filtering.
+
+    use super::{is_excluded_source, path_matches_glob, retain_included_paths};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn glob_double_star_spans_zero_or_more_segments() {
+        assert!(path_matches_glob(
+            Path::new("object/clone.spec.ts"),
+            "object/**/*.spec.ts"
+        ));
+        assert!(path_matches_glob(
+            Path::new("object/nested/deep/clone.spec.ts"),
+            "object/**/*.spec.ts"
+        ));
+        assert!(path_matches_glob(
+            Path::new("src/object/clone.spec.ts"),
+            "**/*.spec.ts"
+        ));
+    }
+
+    #[test]
+    fn glob_single_star_stays_within_one_segment() {
+        assert!(path_matches_glob(Path::new("clone.spec.ts"), "*.spec.ts"));
+        // `*` does not cross a `/`, so a nested path needs `**`.
+        assert!(!path_matches_glob(
+            Path::new("object/clone.spec.ts"),
+            "*.spec.ts"
+        ));
+    }
+
+    #[test]
+    fn glob_rejects_non_matching_extensions() {
+        assert!(!path_matches_glob(
+            Path::new("src/object/clone.ts"),
+            "src/object/*.spec.ts"
+        ));
+    }
+
+    #[test]
+    fn exclude_matches_manifest_relative_path() {
+        let manifest_dir = Path::new("/repo/es-toolkit");
+        let excludes = vec!["src/object/clone.spec.ts".to_owned()];
+        assert!(is_excluded_source(
+            Path::new("/repo/es-toolkit/src/object/clone.spec.ts"),
+            &excludes,
+            manifest_dir,
+        ));
+        assert!(!is_excluded_source(
+            Path::new("/repo/es-toolkit/src/object/clone.ts"),
+            &excludes,
+            manifest_dir,
+        ));
+    }
+
+    #[test]
+    fn exclude_supports_directory_wide_globs() {
+        let manifest_dir = Path::new("/repo/es-toolkit");
+        let excludes = vec!["src/**/*.spec.ts".to_owned()];
+        assert!(is_excluded_source(
+            Path::new("/repo/es-toolkit/src/array/chunk.spec.ts"),
+            &excludes,
+            manifest_dir,
+        ));
+        assert!(!is_excluded_source(
+            Path::new("/repo/es-toolkit/src/array/chunk.ts"),
+            &excludes,
+            manifest_dir,
+        ));
+    }
+
+    #[test]
+    fn retain_drops_only_excluded_paths() {
+        let manifest_dir = Path::new("/repo/es-toolkit");
+        let mut paths = vec![
+            PathBuf::from("/repo/es-toolkit/src/index.ts"),
+            PathBuf::from("/repo/es-toolkit/src/object/clone.spec.ts"),
+            PathBuf::from("/repo/es-toolkit/src/object/clone.ts"),
+        ];
+        let excludes = vec!["src/object/clone.spec.ts".to_owned()];
+        retain_included_paths(&mut paths, &excludes, manifest_dir);
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("/repo/es-toolkit/src/index.ts"),
+                PathBuf::from("/repo/es-toolkit/src/object/clone.ts"),
+            ]
+        );
+    }
+
+    #[test]
+    fn retain_with_no_excludes_keeps_everything() {
+        let manifest_dir = Path::new("/repo/es-toolkit");
+        let mut paths = vec![
+            PathBuf::from("/repo/es-toolkit/src/index.ts"),
+            PathBuf::from("/repo/es-toolkit/src/object/clone.spec.ts"),
+        ];
+        let original = paths.clone();
+        retain_included_paths(&mut paths, &[], manifest_dir);
+        assert_eq!(paths, original);
+    }
 }

--- a/smelt-schema.json
+++ b/smelt-schema.json
@@ -94,6 +94,16 @@
           "items": {
             "type": "string"
           }
+        },
+        "exclude": {
+          "description": "Optional root-relative glob patterns for source files to exclude.\n\nMatching files are skipped by both build and probe file discovery. The\nglob syntax matches [`test_globs`](Self::test_globs): `*` spans one path\nsegment and `**` spans zero or more segments, always with `/` separators.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [


### PR DESCRIPTION
## Summary

Adds an `exclude` glob list under `[sources]` in the Smelt manifest schema — a general, reusable feature for every library probe — and uses it to keep DOM/host-only es-toolkit spec files out of the whole-crate build.

es-toolkit builds as **one** generated Rust crate (`[sources] roots = ["src"]`), so **any single unbuildable file aborts every test**. Several `.spec.ts` files reference host globals Smelt's non-DOM profile deliberately does not model (`document`, `HTMLElement`, `Blob`, `File`). Those specs were blocking all es-toolkit tests from ever running.

## Mechanism

There was **no** existing exclude mechanism, so this PR adds one (option (b) from the task):

- `crates/smelt-transpiler/src/config.rs` — new optional `exclude: Vec<String>` field on `[sources]` + `Config::source_excludes()` accessor.
- `crates/smelt-transpiler/src/lowering.rs` — `retain_included_paths` / `is_excluded_source` filter applied in **both** `manifest_root_paths` (build) and `discover_source_files` (probe). Matching is against each path **relative to the manifest dir** (e.g. `src/object/clone.spec.ts`), reusing the existing narrow glob syntax (`*` = one segment, `**` = zero or more). Excluded specs are leaf test files nothing imports, so dropping them from the root set keeps them out of `dependency_closure` entirely.
- Unit tests added for glob matching and exclude filtering (7 tests, all green).
- `smelt-schema.json` regenerated for the new field.

## Excluded specs (in `.github/compat/es-toolkit/Smelt.toml`)

The tracked source of truth is `.github/compat/<name>/Smelt.toml` (CI copies it into the checked-out library via `scripts/probe_libraries.py`).

| Spec | Unmodeled host global |
| --- | --- |
| `src/object/cloneDeep.dom.spec.ts` | `document.createElement`, `HTMLElement` (`@vitest-environment happy-dom`) |
| `src/compat/object/clone.spec.ts` | `document.createElement`, `document.body` |
| `src/compat/object/cloneWith.spec.ts` | `document.createElement`, `document.body` |
| `src/compat/predicate/isElement.spec.ts` | `document` |
| `src/object/clone.spec.ts` | `new File(...)`, `new Blob(...)` |
| `src/object/cloneDeep.spec.ts` | `new File(...)`, `new Blob(...)` |
| `src/predicate/isBlob.spec.ts` | `new Blob(...)`, `globalThis.File` |
| `src/predicate/isFile.spec.ts` | `new File(...)`, `Blob`, `globalThis.File` |

### Deliberately left IN (not excluded)

Per "when unsure whether something is DOM vs fixable, leave it in and note it":
- `src/predicate/isFunction.spec.ts` — `Proxy`
- `src/predicate/isPlainObject.spec.ts` — `Intl`, `Proxy`, `Request`

These are host/ECMA globals (not DOM), and it's ambiguous whether Smelt could model them; excluding them wouldn't change the abort point anyway (see below).

Confirmed **false positives** that were NOT excluded (matches were in comments or string literals only): `src/compat/array/map.spec.ts`, `src/string/startCase.spec.ts`, `src/string/words.spec.ts`, `src/compat/string/camelCase.spec.ts`, `src/function/retry.spec.ts`.

## New abort point

With the DOM/File/Blob specs excluded, `smelt build` no longer aborts on any host global. The new first abort is a **fixable, non-DOM** blocker (other agents' work):

```
src/predicate/isEqualWith.spec.ts
  field access is only lowered for Record<string, T>, class, and interface values for now (receiver: String, field: a)
```

Subsequent aborts in build order (also non-DOM, for reference): `isFunction.spec.ts` (`Proxy`), `isPlainObject.spec.ts` (`Intl`), `isTypedArray.spec.ts` (typed arrays), then a MIR `await outside an async function` lowering gap.

## Verification (crate-scoped, light)

- `cargo check -p smelt-transpiler` — clean
- `cargo clippy -p smelt-transpiler --bins` — clean
- `cargo test -p smelt-transpiler --bins lowering::tests` — 7 passed
- `cargo test -p smelt-transpiler --test hir_cli_typescript_tests -- --test-threads=1` — 25 passed (the parallel-run failures are pre-existing resource-contention flakes; they pass single-threaded and individually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)