### PR TITLE
fix(ts): resolve host-class bases and imported-const switch labels

### DIFF
--- a/crates/smelt-frontend-ts/src/lowering/decls/functions.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/functions.rs
@@ -1909,22 +1909,29 @@ impl ModuleBuilder<'_> {
         };
         let name = name.as_str();
         let base = self.intern_type_name(name);
-        let allowed_builtin = matches!(
-            name,
-            "Date"
-                | "Error"
-                | "EvalError"
-                | "RangeError"
-                | "ReferenceError"
-                | "SyntaxError"
-                | "TypeError"
-                | "URIError"
-                | "AggregateError"
-                | "Map"
-                | "ReadonlyMap"
-                | "Set"
-                | "ReadonlySet"
-        );
+        // A modeled JavaScript host constructor (`Blob`, `File`, `ArrayBuffer`, the
+        // boxed primitive wrappers, …) is a legitimate base even though it is not a
+        // source-declared class: `smelt_stdlib::host_object` gives it a concrete
+        // constructed identity, so `class File extends Blob {}` resolves the same
+        // way the error/collection builtins below do. Keying on the shared registry
+        // keeps this a general rule rather than a per-name allowlist.
+        let allowed_builtin = smelt_stdlib::host_object_by_class(name).is_some()
+            || matches!(
+                name,
+                "Date"
+                    | "Error"
+                    | "EvalError"
+                    | "RangeError"
+                    | "ReferenceError"
+                    | "SyntaxError"
+                    | "TypeError"
+                    | "URIError"
+                    | "AggregateError"
+                    | "Map"
+                    | "ReadonlyMap"
+                    | "Set"
+                    | "ReadonlySet"
+            );
         if !allowed_builtin
             && !self.classes.contains_key(name)
             && !self.value_imports.contains(name)

--- a/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/class_module_tests.rs
@@ -880,3 +880,59 @@ class Branded {
     )?;
     Ok(())
 }
+
+/// A class extending a modeled JavaScript host constructor (`Blob`, `File`, the
+/// boxed primitive wrappers, …) resolves its base through the shared
+/// `smelt_stdlib::host_object` registry, exactly as extending a builtin error or
+/// collection type does. es-toolkit's `isBlob`/`isFile` specs declare
+/// `class File extends Blob {}` to fake the host `File` global, which previously
+/// failed with `base class \`Blob\` is not declared`.
+#[test]
+fn lowers_class_extending_host_object_base() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export class MyFile extends Blob {
+  name: string;
+  constructor(chunks: unknown[], filename: string) {
+    super(chunks);
+    this.name = filename;
+  }
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    // The lowered class records `Blob` as its resolved base symbol.
+    let my_file = module
+        .items
+        .iter()
+        .find_map(|item| match ctx.krate.items.get(item.0 as usize)? {
+            Item::Class(class) if ctx.krate.symbols.get(class.name) == Some("MyFile") => {
+                Some(class)
+            }
+            _ => None,
+        })
+        .ok_or_else(|| "missing MyFile class".to_owned())?;
+    let base = my_file
+        .base
+        .ok_or_else(|| "MyFile class has no resolved base".to_owned())?;
+    ensure_eq!(ctx.krate.symbols.get(base), Some("Blob"));
+    Ok(())
+}
+
+/// A class extending a genuinely unknown identifier still reports the honest
+/// blocker, so the host-object allowance does not silently accept every base.
+#[test]
+fn rejects_class_extending_undeclared_base() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let errors = lowering_errors(
+        ts!(r#"
+export class Widget extends NotARealBaseClass {}
+"#),
+        &mut ctx,
+    )?;
+    assert_unsupported_ts(&errors, "base class `NotARealBaseClass` is not declared")?;
+    Ok(())
+}

--- a/crates/smelt-transpiler/src/lowering.rs
+++ b/crates/smelt-transpiler/src/lowering.rs
@@ -147,15 +147,118 @@ pub(crate) fn lower_typescript_files(
 }
 
 /// Dispatches one source file to the matching frontend.
+///
+/// TypeScript targets are lowered together with their local relative-import
+/// dependencies (see [`lower_typescript_file_with_dependencies`]) so cross-file
+/// constants, classes, and interfaces resolve exactly as they do in a full
+/// manifest build. This keeps `dump-hir`/`dump-mir` from reporting isolation-only
+/// blockers — e.g. a `switch case <importedTag>:` label whose value lives in a
+/// sibling module — while still focusing the printed output on the target file.
 pub(crate) fn lower_single_file(file: &str) -> Result<LoweredCrate, Box<dyn std::error::Error>> {
     match SourceLang::from_path(file)? {
         SourceLang::TypeScript | SourceLang::TypeScriptDeclaration => {
-            lower_typescript_files(&[file.to_owned()])
+            lower_typescript_file_with_dependencies(file)
         }
         SourceLang::Python | SourceLang::PythonDeclaration => {
             crate::python::lower_files(&[file.to_owned()])
         }
     }
+}
+
+/// Lower a single TypeScript file after first lowering its local dependencies.
+///
+/// Single-file commands (`dump-hir`, `dump-mir`) historically lowered the target
+/// in isolation, so any value imported from a sibling module — a folded string
+/// tag used as a `switch` case label, an exported base class, an interface — was
+/// unresolvable and surfaced as a spurious lowering blocker. This resolves the
+/// target's relative-import closure (reusing the same manifest graph helpers a
+/// real build uses), lowers every dependency in dependency-first order into one
+/// shared [`smelt_frontend_ts::HirCtx`], and lowers the target last so its
+/// imports fold against the already-lowered modules.
+///
+/// Dependencies are lowered best-effort: a dependency that itself fails to lower
+/// (for example because of an unrelated unsupported feature) is skipped rather
+/// than aborting, since the target only needs the exported metadata a partially
+/// lowered dependency still records. Only the target file's own lowering errors
+/// are reported, and only the target module is returned so the printed HIR/MIR
+/// stays focused on the requested file while the shared crate still carries the
+/// dependency items the target references.
+fn lower_typescript_file_with_dependencies(
+    file: &str,
+) -> Result<LoweredCrate, Box<dyn std::error::Error>> {
+    let target_path = PathBuf::from(file);
+    let target_key = target_path.canonicalize().unwrap_or(target_path.clone());
+
+    // Build the dependency-first order of the target and its local imports. Any
+    // failure to scan/resolve dependencies degrades gracefully to lowering the
+    // target alone, preserving the previous isolated behavior for odd inputs.
+    let ordered_paths = ordered_dependency_paths(target_path.clone()).unwrap_or_default();
+
+    let mut ctx = smelt_frontend_ts::HirCtx::new();
+    let mut target_module: Option<(String, ModuleId)> = None;
+
+    for (idx, path) in ordered_paths.iter().enumerate() {
+        let Ok(source) = fs::read_to_string(path) else {
+            continue;
+        };
+        let path_string = path.display().to_string();
+        // A dependency file that is not TypeScript (a Python sibling reached
+        // through a mixed graph) is not lowered by this frontend path.
+        if !SourceLang::from_path(&path_string).is_ok_and(SourceLang::is_typescript) {
+            continue;
+        }
+        let file_id = FileId(u32::try_from(idx).unwrap_or(u32::MAX));
+        let is_target = path.canonicalize().unwrap_or_else(|_| path.clone()) == target_key
+            || path == &target_path;
+        let outcome =
+            smelt_frontend_ts::to_hir_with_path(&source, file_id, &path_string, &mut ctx);
+        match outcome {
+            Ok(module) => {
+                if is_target {
+                    target_module = Some((file.to_owned(), module));
+                }
+            }
+            Err(errors) => {
+                // Surface the target's own errors; a dependency's unrelated
+                // failure is swallowed so it cannot mask the target result.
+                if is_target {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("{}:\n{errors:#?}", target_path.display()),
+                    )
+                    .into());
+                }
+            }
+        }
+    }
+
+    // Fall back to lowering the target directly when the dependency walk never
+    // produced it (empty order, canonicalization mismatch, or a non-TypeScript
+    // classification of the target itself).
+    if let Some(module) = target_module {
+        Ok((ctx.krate, vec![module]))
+    } else {
+        lower_typescript_files(&[file.to_owned()])
+    }
+}
+
+/// Return the target file and its local dependency closure in dependency-first
+/// order (dependencies before importers, target last).
+///
+/// Reuses the manifest module-graph helpers so single-file lowering resolves the
+/// same relative imports a full build does. Returns `None` if the target cannot
+/// be read or its import graph cannot be ordered, letting the caller fall back to
+/// isolated lowering.
+fn ordered_dependency_paths(target: PathBuf) -> Option<Vec<PathBuf>> {
+    let root = read_manifest_source(target).ok()?;
+    let sources = dependency_closure(vec![root]).ok()?;
+    let ordered = order_manifest_sources(&sources).ok()?;
+    Some(
+        ordered
+            .into_iter()
+            .filter_map(|idx| sources.get(idx).map(|source| source.path.clone()))
+            .collect(),
+    )
 }
 
 /// One categorized frontend diagnostic from lowering a single file.

--- a/crates/smelt-transpiler/tests/hir_cli_typescript_tests.rs
+++ b/crates/smelt-transpiler/tests/hir_cli_typescript_tests.rs
@@ -1382,3 +1382,58 @@ console.log(counter.value);
 
     Ok(())
 }
+
+/// `dump-hir` on a single file now lowers that file's local relative-import
+/// dependencies first, so a `switch` whose case labels reference *imported*
+/// string constants (es-toolkit's `case argumentsTag:` pattern, where the tag
+/// values live in a sibling module) folds instead of failing with
+/// `switch case labels must be string, number, boolean, or null literals`.
+///
+/// This exercises the isolation-only regression that previously made `dump-hir`
+/// and `probe` report a blocker a full manifest build never hit.
+#[test]
+fn dump_hir_folds_imported_const_switch_labels_from_sibling_module() -> TestResult {
+    let project = TempProject::new()?;
+    let project_path = project.path();
+    fs::create_dir_all(project_path.join("src"))?;
+    fs::write(
+        project_path.join("src/tags.ts"),
+        r#"export const arrayTag = '[object Array]';
+export const objectTag = '[object Object]';
+"#,
+    )?;
+    fs::write(
+        project_path.join("src/classify.ts"),
+        r#"import { arrayTag, objectTag } from './tags';
+
+export function isContainerTag(tag: string): boolean {
+  switch (tag) {
+    case arrayTag:
+    case objectTag:
+      return true;
+    default:
+      return false;
+  }
+}
+"#,
+    )?;
+
+    let importer_arg = utf8_path(&project_path.join("src/classify.ts"))?;
+    // A successful dump-hir (a non-zero exit would make `smelt` return `Err`)
+    // proves the imported-const case labels folded rather than erroring.
+    let stdout = smelt(&["dump-hir", &importer_arg])?;
+    ensure(
+        stdout.contains("classify.ts"),
+        "missing importer module header in dump-hir output",
+    )?;
+    ensure(
+        stdout.contains("fn is_container_tag"),
+        "importer function item missing from dump-hir output",
+    )?;
+    ensure(
+        !stdout.contains("switch case labels must be"),
+        "imported const switch labels still reported as a blocker",
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes two independent, general es-toolkit lowering blockers. Both go through general rules — no per-file special cases.

### Blocker 1 — `switch case labels must be string, number, boolean, or null literals` (4 files)
Example: `third_party/es-toolkit/src/compat/object/clone.ts` — `isCloneableObject` switches on `getTag(x)` with `case argumentsTag:` / `case arrayTag:` etc. Those tag values are string constants **imported** from `_internal/tags.ts`. A full manifest build folds them, but `dump-hir`/`dump-mir`/`probe` lowered the file in isolation via `lower_single_file`, so the imported const's value was never available and the switch labels errored.

Fix: `lower_single_file` (TypeScript path) now lowers the target's local relative-import closure into one shared `HirCtx` **before** the target, reusing the existing manifest module-graph helpers (`read_manifest_source` → `dependency_closure` → `order_manifest_sources`). Imported consts, classes, and interfaces now resolve for single-file lowering exactly as they do in a real build. Dependencies lower best-effort (a dependency's unrelated failure is swallowed); only the target's own errors are reported and only its module is returned so `dump-hir` output stays focused.

Files fixed: `clone.ts`, `compat/object/cloneDeepWith.ts`, `object/cloneDeepWith.ts`, `predicate/isEqualWith.ts`.

### Blocker 2 — ``base class `X` is not declared`` (2 files)
Example: `third_party/es-toolkit/src/predicate/isBlob.spec.ts` — `class File extends Blob {}` fakes the host `File` global. `Blob` is a modeled JS **host constructor**, not a source-declared class, so `class_extends_clause` rejected it.

Fix: the `allowed_builtin` check now also accepts any base present in the shared `smelt_stdlib::host_object` registry (`Blob`, `File`, `ArrayBuffer`, boxed primitive wrappers, …), the same way it already accepts `Error`/`Map`/`Set`/`Date`. Keyed on the registry, so it stays a general rule. A genuinely undeclared base still reports the honest blocker.

Files fixed: `predicate/isBlob.spec.ts`, `predicate/isFile.spec.ts`.

## Files changed
- `crates/smelt-frontend-ts/src/lowering/decls/functions.rs` — host-object bases in `class_extends_clause`
- `crates/smelt-transpiler/src/lowering.rs` — dependency-resolving single-file lowering
- `crates/smelt-frontend-ts/src/tests/class_module_tests.rs` — 2 unit tests (host base resolves; undeclared base still rejected)
- `crates/smelt-transpiler/tests/hir_cli_typescript_tests.rs` — 1 integration test (imported-const switch labels fold via dump-hir)

## Verification
- Full recoverable `smelt check --message-format json` over es-toolkit: **0** switch-case and **0** base-class errors (previously 4 + 2). All 6 example files lower cleanly via `dump-hir`.
- `cargo test -p smelt-frontend-ts` — 776 passed
- `cargo test -p smelt-transpiler` (core / cross-language / typescript / probe / bin unit) — all passed
- `cargo check` + `cargo clippy` on both changed crates — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)