### PR TITLE
fix(ts): scope-aware builtin interceptors + bound string-method reads

### DIFF
--- a/crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs
@@ -999,6 +999,26 @@ impl ModuleBuilder<'_> {
         )
     }
 
+    /// Return whether a name-matched global builtin call is shadowed by a real
+    /// binding in scope, so the global interceptor must not fire.
+    ///
+    /// The builtin call interceptors (`isNaN(...)`, `parseInt(...)`, ...) are
+    /// dispatched by identifier name *before* the callee is resolved against the
+    /// module's bindings. That is only correct when the name still refers to the
+    /// JavaScript global. A value import, module item, or local binding of the
+    /// same name lexically shadows the global — for example es-toolkit's
+    /// `import { isNaN } from './isNaN'` makes `isNaN(true)` a call to the
+    /// imported function, not the numeric global predicate. In that case the
+    /// interceptor bails and the ordinary call path lowers the real binding
+    /// (mirroring how [`Self::imported_utility_object`] defers namespace member
+    /// calls). A file that genuinely calls the global has no such binding, so the
+    /// interceptor keeps firing unchanged.
+    pub(in crate::lowering) fn builtin_call_identifier_is_shadowed(&self, name: &str) -> bool {
+        self.locals.contains_key(name)
+            || self.items.contains_key(name)
+            || self.value_imports.contains(name)
+    }
+
     /// Lower a function-expression callback after expected parameter types are known.
     pub(in crate::lowering) fn function_callback_from_params(
         &mut self,

--- a/crates/smelt-frontend-ts/src/lowering/stdlib/numbers_math.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/numbers_math.rs
@@ -561,6 +561,14 @@ return_ty: string_ty,
                 (op, format!("Number.{}", member.property.name))
             }
             Expression::Identifier(identifier) if identifier.name == "isNaN" => {
+                // A value import, module item, or local binding of `isNaN`
+                // shadows the global predicate (es-toolkit's own
+                // `import { isNaN } from './isNaN'` accepts `any`). Defer to the
+                // ordinary call path so the shadowing binding is called instead
+                // of forcing the numeric-global predicate onto its argument.
+                if self.builtin_call_identifier_is_shadowed(identifier.name.as_str()) {
+                    return Ok(None);
+                }
                 (NumericPredicateOp::IsNaN, "isNaN".to_owned())
             }
             _ => return Ok(None),
@@ -764,6 +772,15 @@ return_ty: string_ty,
             return Ok(None);
         };
         if member.property.name != "toString" {
+            return Ok(None);
+        }
+        // `ns.toString(value)` on a utility *namespace* object (a `import * as _`
+        // star import or a registered object namespace) is the lodash/es-toolkit
+        // free-function `toString`, whose first argument is the value being
+        // stringified, not a `Number.prototype.toString` radix. Defer to the
+        // generic namespace member-call path instead of treating the value as a
+        // radix and rejecting a non-numeric one.
+        if self.imported_utility_object(&member.object) {
             return Ok(None);
         }
         let operand = self.expression(&member.object, body)?;

--- a/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
@@ -1313,6 +1313,16 @@ impl ModuleBuilder<'_> {
         let Expression::Identifier(callee) = &call.callee else {
             return Ok(None);
         };
+        // These names (`parseInt`, `String`, `Number`, `parseFloat`, `BigInt`,
+        // `Boolean`) are recognized as JavaScript globals by identifier name. A
+        // value import, module item, or local binding of the same name shadows
+        // the global — e.g. es-toolkit's `import { parseInt } from './parseInt'`
+        // accepts a value and an optional `undefined` radix. Defer to the
+        // ordinary call path so the shadowing binding is called instead of the
+        // global primitive-conversion op.
+        if self.builtin_call_identifier_is_shadowed(callee.name.as_str()) {
+            return Ok(None);
+        }
         if callee.name == "parseInt" {
             let (operand, radix) = self.parse_int_operand("parseInt", call, body)?;
             let ty = self.ctx.krate.types.intern(Type::Float);

--- a/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/annotations.rs
@@ -1857,6 +1857,23 @@ return_ty: function.return_ty,
             Type::String if self.allow_unknown_index_access => {
                 Ok(self.ctx.krate.types.intern(Type::Unknown))
             }
+            // Any remaining property read on a string value is a bound stdlib
+            // method reference taken as a value — `''.slice`, `str.split`, etc.
+            // (the concrete data properties `length`/`message`/`name`/`prototype`
+            // are handled above). A string in valid TypeScript exposes only
+            // `length` plus methods, so a property that is not one of the modeled
+            // data fields is a callable member accessed without calling it.
+            //
+            // A method *call* (`str.slice(...)`) never reaches here: the dedicated
+            // string call handlers in `dispatch_builtin_call` intercept those
+            // before member-type resolution runs. Only a genuine method *value*
+            // reaches this arm, and, like every other bound-method value on a
+            // builtin/erased receiver, it resolves to the erased dynamic boundary
+            // (`Unknown`) rather than hard-erroring. Codegen already tolerates the
+            // read: `string_field_text` emits an erased value for an unmodeled
+            // string field. This keeps field resolution general for strings
+            // instead of rejecting source that TypeScript accepts.
+            Type::String => Ok(self.ctx.krate.types.intern(Type::Unknown)),
             Type::Function(_) => {
                 if let Some(field) = self
                     .callable_fields

--- a/crates/smelt-frontend-ts/src/lowering/ty/assignability.rs
+++ b/crates/smelt-frontend-ts/src/lowering/ty/assignability.rs
@@ -668,6 +668,16 @@ impl ModuleBuilder<'_> {
         if member.property.name != "includes" {
             return Ok(None);
         }
+        // `ns.includes(collection, value, fromIndex?)` on a utility *namespace*
+        // object (a `import * as _` star import or a registered object namespace)
+        // is the lodash/es-toolkit free-function `includes`, whose second
+        // argument is the searched value, not a numeric start position. It is not
+        // `String.prototype.includes(needle, position?)`, so defer to the generic
+        // namespace member-call path instead of coercing the value argument into a
+        // position and rejecting a non-numeric one.
+        if self.imported_utility_object(&member.object) {
+            return Ok(None);
+        }
         // JavaScript `String.prototype.includes(needle, position?)` takes the
         // needle plus an optional numeric start position handled by the emitter.
         if !(1..=2).contains(&call.arguments.len()) {

--- a/crates/smelt-frontend-ts/src/tests/estk6_coverage_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/estk6_coverage_tests.rs
@@ -633,3 +633,147 @@ export function roundTrip(x: Record<string, number>): unknown {
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Builtin interceptor scoping.
+//
+// The name-matched global interceptors (`isNaN`, `parseInt`, `String`, ...) and
+// the string/number method interceptors (`.includes`, `.toString`) fire early,
+// before the callee/receiver is resolved against the module's bindings. They
+// must respect lexical scope: a value import, module item, or local binding of
+// the same name shadows the global, and a namespace/util object receiver marks a
+// free-function call rather than a string/number method. es-toolkit relies on
+// all of these (`import { isNaN } from './isNaN'`, `ns.includes(coll, value)`).
+// ---------------------------------------------------------------------------
+
+/// A bound string method taken as a *value* (`''.slice`, not `''.slice(...)`)
+/// resolves to the erased dynamic boundary instead of hard-erroring on field
+/// access, mirroring es-toolkit `pick('', 'slice')`.
+#[test]
+fn bound_string_method_reference_lowers_as_erased_value() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+export function pluck(): unknown {
+  const method = ''.slice;
+  return method;
+}
+"#),
+        &mut ctx,
+    )?;
+    // The value read lowers to a plain field access; it must not be rejected.
+    ensure!(crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::Field { .. }
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+/// A value import of `isNaN` shadows the numeric-global predicate, so the call
+/// lowers through the ordinary call path rather than as `NumericPredicate`.
+#[test]
+fn value_imported_is_nan_is_not_the_numeric_global() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+import { isNaN } from './isNaN';
+export function check(): unknown {
+  return isNaN(true);
+}
+"#),
+        &mut ctx,
+    )?;
+    // The shadowing binding is called; the numeric-global predicate op must not
+    // be synthesized for the shadowed name.
+    ensure!(!crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::NumericPredicate {
+            op: NumericPredicateOp::IsNaN,
+            ..
+        }
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+/// The bare-identifier `isNaN` global still lowers to the numeric predicate when
+/// it is *not* shadowed, so the shadow guard does not disable the global.
+#[test]
+fn unshadowed_is_nan_still_lowers_to_numeric_predicate() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+const value: number = 3;
+const flag = isNaN(value);
+"#),
+        &mut ctx,
+    )?;
+    ensure!(crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::NumericPredicate {
+            op: NumericPredicateOp::IsNaN,
+            ..
+        }
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+/// A value import of `parseInt` shadows the global, so `parseInt(str, undefined)`
+/// lowers through the ordinary call path rather than the global parse op.
+#[test]
+fn value_imported_parse_int_is_not_the_global() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+import { parseInt } from './parseInt';
+export function pi(): unknown {
+  return parseInt('10', undefined);
+}
+"#),
+        &mut ctx,
+    )?;
+    // Neither the radix parse op nor the bare `ToInt` cast may be synthesized for
+    // the shadowed name.
+    ensure!(!crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::ParseIntRadix { .. }
+    )));
+    ensure!(!crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::PrimitiveCast {
+            op: PrimitiveCastOp::ToInt,
+            ..
+        }
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+/// A namespace-import `includes`/`toString` is the free-function form, so its
+/// second argument is a value, not a numeric string position or radix. It must
+/// not be rejected by the string/number method interceptors.
+#[test]
+fn namespace_includes_and_to_string_are_free_functions() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+import * as tk from './lib';
+export function useNs(value: unknown): unknown {
+  const a = tk.includes(value, '__p');
+  const b = tk.toString(value);
+  return [a, b];
+}
+"#),
+        &mut ctx,
+    )?;
+    // The string-includes op (which would demand a numeric position) must not
+    // fire on the namespace free-function call.
+    ensure!(!crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::StringContains { .. }
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes a cluster of small, general es-toolkit lowering blockers. All changes lower through **general rules** — no per-file special cases (per repo `CLAUDE.md`).

### Blocker 1 — bound string-method reference (`''.slice` as a value)
`class_field_type` (`ty/annotations.rs`) raised *"field access is only lowered for Record<string, T>, class, and interface values ... (receiver: String, field: slice)"* for a String method taken as a **value** (e.g. es-toolkit `pick('', 'slice')` → `{ slice: ''.slice }`). A JS string exposes only `length` plus methods, so any unmodeled `Type::String` property read is a bound-method/dynamic value and now resolves to the erased boundary (`Unknown`), like every other bound-method value on a builtin/erased receiver. Method **calls** are unaffected — dedicated string call handlers intercept `str.slice(...)` earlier. Codegen already tolerates the read (`string_field_text` fallthrough emits an erased value).

### Blocker 2 — over-strict numeric-argument checks
Root causes were name-matched interceptors firing on the **wrong binding**, not genuinely-strict numeric checks:

- **`isNaN` / `parseInt`** are re-exported by es-toolkit and imported as **value imports** that lexically shadow the JS globals. The interceptors (`number_predicate_call`, `primitive_cast_call`) matched by identifier name *before* binding resolution, so `isNaN(true)` / `parseInt('10', undefined)` were forced through the numeric globals. New helper `builtin_call_identifier_is_shadowed` (checks `locals`/`items`/`value_imports`) makes them bail so the ordinary call path lowers the real binding. An unshadowed `isNaN(x)` still lowers to the numeric op (covered by a negative test).
- **`toString` / `includes`** fired on **namespace free-function** calls (`ns.toString(value)`, `ns.includes(coll, value)` from `import * as ns`), treating the value argument as a `Number.prototype.toString` radix / `String.prototype.includes` position. They now defer to the generic namespace member-call path via the existing `imported_utility_object` guard (same precedent as `.concat`).

## Files changed
- `crates/smelt-frontend-ts/src/lowering/ty/annotations.rs` — general String bound-method-value arm in `class_field_type`
- `crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs` — new `builtin_call_identifier_is_shadowed` helper
- `crates/smelt-frontend-ts/src/lowering/stdlib/numbers_math.rs` — shadow guard on bare `isNaN`; namespace guard on `toString`
- `crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs` — shadow guard on `primitive_cast_call` (`parseInt`/`String`/`Number`/...)
- `crates/smelt-frontend-ts/src/lowering/ty/assignability.rs` — namespace guard on `string_contains_call` (`.includes`)
- `crates/smelt-frontend-ts/src/tests/estk6_coverage_tests.rs` — 5 new unit tests

## Per-blocker status (via `smelt dump-hir` on es-toolkit)
| file | before | after |
|---|---|---|
| `compat/object/pick.spec.ts` | field-access String error | **fully lowers** |
| `compat/predicate/isNaN.spec.ts` | isNaN requires number | **fully lowers** |
| `compat/string/template.spec.ts` | includes position must be numeric | **fully lowers** |
| `compat/math/parseInt.spec.ts` | numeric radix | **advances** (new unrelated blocker: `.map(Object)`) |
| `compat/object/pickBy.spec.ts` | toString radix | **advances** (new unrelated blocker: `args[1] += ''`) |

## Verification
- `cargo test -p smelt-frontend-ts` — 779 pass (incl. 5 new)
- `cargo test -p smelt-codegen-rust` — pass
- `cargo clippy -p smelt-frontend-ts` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)