### PR TITLE
feat(stdlib): model Blob/File with real content, size, and File fields

### DIFF
--- a/.github/compat/es-toolkit/Smelt.toml
+++ b/.github/compat/es-toolkit/Smelt.toml
@@ -8,29 +8,40 @@ roots = ["src"]
 test-prefix = ["array/**/*.spec.ts", "function/**/*.spec.ts", "math/**/*.spec.ts", "object/**/*.spec.ts", "predicate/**/*.spec.ts", "promise/**/*.spec.ts", "string/**/*.spec.ts", "util/**/*.spec.ts", "error/**/*.spec.ts"]
 entries = ["src/index.ts"]
 # Spec files excluded from the whole-crate build because they depend on host
-# globals Smelt's non-DOM profile deliberately does not model. Any one
-# unbuildable file aborts the entire crate build, so these DOM/host-only specs
-# would otherwise block every es-toolkit test from running. Each entry lists the
-# unmodeled global it needs; remove an entry once Smelt models that global.
+# globals Smelt's non-DOM profile deliberately does not model, or hit a known
+# lowering blocker. Any one unbuildable file aborts the entire crate build, so
+# these specs would otherwise block every es-toolkit test from running. Each
+# entry lists what it needs; remove an entry once Smelt models it.
 exclude = [
   # `document` / `HTMLElement` (DOM)
   "src/object/cloneDeep.dom.spec.ts",   # @vitest-environment happy-dom; document.createElement, HTMLElement
   "src/compat/object/clone.spec.ts",    # document.createElement, document.body
   "src/compat/object/cloneWith.spec.ts", # document.createElement, document.body
   "src/compat/predicate/isElement.spec.ts", # document (isElement DOM checks)
-  # `Blob` / `File` (host file APIs)
-  "src/object/clone.spec.ts",           # new File(...), new Blob(...)
-  "src/object/cloneDeep.spec.ts",       # new File(...), new Blob(...)
-  "src/predicate/isBlob.spec.ts",       # new Blob(...), globalThis.File
-  "src/predicate/isFile.spec.ts",       # new File(...), Blob, globalThis.File
+  # Blocked on the Error-options constructor, not on a host global: `Blob`/
+  # `File` are modeled now, but this spec also spells
+  # `new AggregateError(errors, message, { cause })` / `new Error(msg, { cause })`,
+  # which the Error constructor lowering does not accept yet ("supports at most
+  # one message argument"). Re-include once Error `cause` options land.
+  "src/object/clone.spec.ts",
 ]
+# `Blob` / `File` are modeled as marker records with real `type`/`size`/
+# `content` (and `name`/`lastModified` for File), so the former Blob/File
+# excludes are back in the build:
+#   src/object/cloneDeep.spec.ts, src/predicate/isBlob.spec.ts,
+#   src/predicate/isFile.spec.ts
+# Note: isBlob/isFile specs reassign `globalThis.File`/`globalThis.Blob`
+# (monkey-patching, a Smelt non-goal); they build, but the environment-absence
+# test cases will fail at runtime because presence guards fold at compile time.
 # Deliberately NOT excluded (host/ECMA globals, but ambiguous whether Smelt can
 # model them — left in per "when unsure, leave it in"):
 #   src/predicate/isFunction.spec.ts   -> `Proxy`
 #   src/predicate/isPlainObject.spec.ts -> `Intl`, `Proxy`, `Request`
-# After the excludes above, `smelt build` aborts earlier at
-# src/predicate/isEqualWith.spec.ts on a fixable `field access` lowering blocker
-# (not a host global), which is other work.
+# After the excludes above, `smelt build` still aborts earlier at
+# src/predicate/isEqualWith.spec.ts ("const item expression shape is not
+# supported for inlining yet"), which is other work; with that file also
+# excluded the next blockers are isFunction.spec.ts (`Proxy`) and
+# isPlainObject.spec.ts (`Intl`).
 
 [output]
 target = "./dist-smelt"

--- a/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
@@ -1200,6 +1200,35 @@ impl FunctionEmitter<'_> {
             Rvalue::UrlField { field, url } => self.url_field_text(*field, url),
             Rvalue::FileReadText { path } => self.file_read_text(path),
             Rvalue::FileWriteText { path, text } => self.file_write_text(path, text),
+            Rvalue::BlobFromParts {
+                parts,
+                blob_type,
+                name,
+                last_modified,
+            } => {
+                let parts_text = self.operand_text(parts)?;
+                let type_text = self.operand_text(blob_type)?;
+                let name_text = match name {
+                    Some(name_operand) => {
+                        format!("Some(({}).clone())", self.operand_text(name_operand)?)
+                    }
+                    None => "None".to_owned(),
+                };
+                let last_modified_text = match last_modified {
+                    Some(last_modified_operand) => {
+                        format!(
+                            "Some(({}) as f64)",
+                            self.operand_text(last_modified_operand)?
+                        )
+                    }
+                    None => "None".to_owned(),
+                };
+                Ok(format!(
+                    "{blob_record_from_parts}(({parts_text}).clone(), ({type_text}).clone(), {name_text}, {last_modified_text})",
+                    blob_record_from_parts =
+                        smelt_stdlib::runtime_symbols::host::BLOB_RECORD_FROM_PARTS,
+                ))
+            }
             Rvalue::Await(operand) => {
                 if self.mir.types.get(self.operand_ty(operand)?) == Some(&Type::None) {
                     return self.default_value(dest_ty);

--- a/crates/smelt-codegen-rust/src/lib.rs
+++ b/crates/smelt-codegen-rust/src/lib.rs
@@ -390,6 +390,7 @@ fn emit_source_with_free_function_router(
     let needs_erased_function = needs_erased_function_runtime(mir);
     let needs_date_now = stdlib::needs_date_now_runtime(mir);
     let needs_date_timezone_offset = stdlib::needs_date_timezone_offset_runtime(mir);
+    let needs_blob_record = stdlib::needs_blob_record_runtime(mir);
     let needs_shared_captures = mir
         .closures
         .iter()
@@ -992,6 +993,47 @@ fn emit_source_with_free_function_router(
             writer.line("}");
         }
         writer.blank_line();
+        if needs_blob_record {
+            writer.line("/// Build the modeled host `Blob`/`File` record for `new Blob(...)` / `new File(...)`.");
+            writer.line("///");
+            writer.line("/// Concatenates BlobPart contents (strings verbatim; nested Blob/File records");
+            writer.line("/// contribute their stored `content`; other parts stringify like JavaScript)");
+            writer.line("/// and stores the UTF-8 byte length as `size`. Passing a file name stamps the");
+            writer.line("/// `__smelt_file` marker on top of `__smelt_blob`, so `file instanceof Blob`");
+            writer.line("/// observes the host subtype relationship; `lastModified` defaults to `0.0`");
+            writer.line("/// for determinism instead of the wall clock.");
+            writer.line(format!(
+                "fn {}(parts: SmeltUnknown, blob_type: String, file_name: Option<String>, last_modified: Option<f64>) -> SmeltUnknown {{",
+                smelt_stdlib::runtime_symbols::host::BLOB_RECORD_FROM_PARTS,
+            ));
+            writer.line("    let mut content = String::new();");
+            writer.line("    if let SmeltUnknown::Array(items) = parts {");
+            writer.line("        for item in items.iter() {");
+            writer.line("            match item {");
+            writer.line("                SmeltUnknown::String(text) => content.push_str(text),");
+            writer.line("                SmeltUnknown::Object(map) if map.contains_key(\"__smelt_blob\") => {");
+            writer.line("                    if let Some(SmeltUnknown::String(text)) = map.get(\"content\") { content.push_str(&text); }");
+            writer.line("                }");
+            writer.line("                other => content.push_str(&other.to_string()),");
+            writer.line("            }");
+            writer.line("        }");
+            writer.line("    }");
+            writer.line("    let record = ::std::collections::HashMap::from([");
+            writer.line("        (\"__smelt_blob\".to_owned(), SmeltUnknown::Bool(true)),");
+            writer.line("        (\"type\".to_owned(), SmeltUnknown::String(blob_type)),");
+            writer.line("        (\"size\".to_owned(), SmeltUnknown::Number(content.len() as f64)),");
+            writer.line("        (\"content\".to_owned(), SmeltUnknown::String(content)),");
+            writer.line("    ]);");
+            writer.line("    let record = SmeltObject::new(record);");
+            writer.line("    if let Some(name) = file_name {");
+            writer.line("        record.insert(\"__smelt_file\".to_owned(), SmeltUnknown::Bool(true));");
+            writer.line("        record.insert(\"name\".to_owned(), SmeltUnknown::String(name));");
+            writer.line("        record.insert(\"lastModified\".to_owned(), SmeltUnknown::Number(last_modified.unwrap_or(0.0)));");
+            writer.line("    }");
+            writer.line("    SmeltUnknown::Object(record)");
+            writer.line("}");
+            writer.blank_line();
+        }
         writer.line("fn smelt_get_object_field(map: &SmeltObject, field: &str) -> SmeltUnknown {");
         writer.line("    // A missing property reads as JS `undefined`, distinct from an");
         writer.line("    // explicit `null` value (`obj.missing === undefined`, `!== null`).");

--- a/crates/smelt-codegen-rust/src/stdlib.rs
+++ b/crates/smelt-codegen-rust/src/stdlib.rs
@@ -149,6 +149,15 @@ pub(crate) fn needs_date_timezone_offset_runtime(mir: &Mir) -> bool {
     })
 }
 
+/// Returns true when generated Rust constructs a modeled host `Blob`/`File`
+/// record and therefore needs the `smelt_blob_record_from_parts` runtime helper.
+#[must_use]
+pub(crate) fn needs_blob_record_runtime(mir: &Mir) -> bool {
+    any_rvalue_needs(mir, |rvalue| {
+        matches!(rvalue, Rvalue::BlobFromParts { .. })
+    })
+}
+
 /// Returns true when a MIR rvalue uses Url APIs.
 fn rvalue_needs_url(rvalue: &Rvalue) -> bool {
     matches!(rvalue, Rvalue::UrlField { .. })

--- a/crates/smelt-codegen-rust/src/tests/part_2_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_2_tests.rs
@@ -257,6 +257,43 @@ const no = isBlob(1);
 }
 
 #[test]
+fn emits_blob_record_helper_for_file_constructor() {
+    let source = source_for(
+        r#"
+const file = new File(["content"], "file.txt", { type: "text/plain" });
+const isFile = file instanceof File;
+const isBlob = file instanceof Blob;
+"#,
+    );
+
+    // Construction routes through the shared runtime helper (which stamps
+    // `__smelt_file` on top of `__smelt_blob`), and both instanceof checks
+    // resolve through their marker keys.
+    assert!(
+        source.contains("fn smelt_blob_record_from_parts("),
+        "{source}"
+    );
+    assert!(source.contains("smelt_blob_record_from_parts(("), "{source}");
+    assert!(
+        source.contains("value.contains_key(\"__smelt_file\")"),
+        "{source}"
+    );
+    assert!(
+        source.contains("value.contains_key(\"__smelt_blob\")"),
+        "{source}"
+    );
+}
+
+#[test]
+fn omits_blob_record_helper_without_blob_construction() {
+    let source = source_for("const value: number = 1;");
+    assert!(
+        !source.contains("smelt_blob_record_from_parts"),
+        "the Blob/File record helper must stay gated behind actual Blob/File construction: {source}"
+    );
+}
+
+#[test]
 fn emits_runtime_boxed_number_identity_for_unknown_instanceof_guard() {
     let source = source_for(
         r"

--- a/crates/smelt-frontend-ts/src/lowering/guards.rs
+++ b/crates/smelt-frontend-ts/src/lowering/guards.rs
@@ -169,6 +169,11 @@ impl ModuleBuilder<'_> {
                     // resolves through that marker in `instance_of_text`.
                     | "Buffer"
                     | "Blob"
+                    // `File` records stamp `__smelt_file` on top of
+                    // `__smelt_blob` (see `file_constructor_expression`), so
+                    // both `value instanceof File` and `value instanceof Blob`
+                    // resolve through their markers in `instance_of_text`.
+                    | "File"
                     | "Number"
                     // Boxed primitive wrappers. A real primitive (`true`, `"a"`)
                     // is never `instanceof` its wrapper; only the boxed object
@@ -215,7 +220,7 @@ impl ModuleBuilder<'_> {
     /// satisfy would reintroduce the erased-vs-runtime disagreement the globals
     /// plan warns against, so unmodeled host globals are deliberately excluded.
     pub(super) fn is_known_defined_global_constructor(name: &str) -> bool {
-        matches!(name, "Blob" | "ArrayBuffer" | "Buffer")
+        matches!(name, "Blob" | "File" | "ArrayBuffer" | "Buffer")
             || Self::marker_only_builtin_marker(name).is_some()
     }
 

--- a/crates/smelt-frontend-ts/src/lowering/new_expr.rs
+++ b/crates/smelt-frontend-ts/src/lowering/new_expr.rs
@@ -152,6 +152,9 @@ impl ModuleBuilder<'_> {
         if callee.name == "Blob" && !self.classes.contains_key("Blob") {
             return self.blob_constructor_expression(new_expr, body);
         }
+        if callee.name == "File" && !self.classes.contains_key("File") {
+            return self.file_constructor_expression(new_expr, body);
+        }
         if callee.name == "Number" && !self.classes.contains_key("Number") {
             return self.boxed_primitive_constructor_expression(
                 new_expr,
@@ -837,13 +840,13 @@ impl ModuleBuilder<'_> {
     /// The mapping lives in the shared `smelt_stdlib::host_object` registry so the
     /// construct side, the `instanceof` side, and the runtime host-marker registry
     /// cannot drift. "Marker-only" here means host objects with no retained
-    /// structural fields (`WeakMap`/`WeakSet`/`DataView`/`SharedArrayBuffer`/
-    /// `File`); host objects with retained fields (`ArrayBuffer`, `Blob`, boxed
+    /// structural fields (`WeakMap`/`WeakSet`/`DataView`/`SharedArrayBuffer`);
+    /// host objects with retained fields (`ArrayBuffer`, `Blob`, `File`, boxed
     /// primitives, `DOMException`) have their own dedicated constructors and are
     /// excluded here even though they share the registry.
     pub(crate) fn marker_only_builtin_marker(name: &str) -> Option<&'static str> {
         match name {
-            "WeakMap" | "WeakSet" | "DataView" | "SharedArrayBuffer" | "File" => {
+            "WeakMap" | "WeakSet" | "DataView" | "SharedArrayBuffer" => {
                 smelt_stdlib::host_object_marker(name)
             }
             _ => None,
@@ -1129,54 +1132,108 @@ impl ModuleBuilder<'_> {
 
     /// Lower `new Blob(parts?, options?)` to a concrete marker-bearing record.
     ///
-    /// JavaScript `Blob` is a host binary-data object. es-toolkit only
-    /// constructs it and inspects it via `value instanceof Blob` (the `isBlob`
-    /// predicate over an erased `unknown`, plus the `cloneDeepWith` clone path).
-    /// Rather than erase it to a shapeless `SmeltUnknown` (which would lose its
-    /// identity), model it as a record carrying a dedicated `__smelt_blob`
-    /// marker plus its observable `type` string, mirroring the `ArrayBuffer`
-    /// model so a later dynamic `instanceof Blob` resolves through the marker
-    /// (see `instance_of_text`). The constructor arguments are still lowered so
-    /// their effects/types are validated, but only `type` is retained.
+    /// JavaScript `Blob` is a host binary-data object: constructed, inspected
+    /// via `value instanceof Blob` (the `isBlob` predicate over an erased
+    /// `unknown`), and read through `.type`/`.size` (the `clone`/`cloneDeepWith`
+    /// paths). Rather than erase it to a shapeless `SmeltUnknown` (which would
+    /// lose its identity), model it as a record carrying a dedicated
+    /// `__smelt_blob` marker plus its observable `type`, `size`, and `content`,
+    /// built by the `smelt_blob_record_from_parts` runtime helper (see
+    /// `ExprKind::BlobFromParts`) so a later dynamic `instanceof Blob` resolves
+    /// through the marker (see `instance_of_text`) and field reads observe real
+    /// values.
     pub(super) fn blob_constructor_expression(
         &mut self,
         new_expr: &oxc::ast::ast::NewExpression<'_>,
         body: &mut Body,
     ) -> Result<smelt_hir::ExprId, SmeltError> {
-        let string_ty = self.ctx.krate.types.intern(Type::String);
-        let bool_ty = self.ctx.krate.types.intern(Type::Bool);
         let unknown_ty = self.ctx.krate.types.intern(Type::Unknown);
-        let dict_ty = self.ctx.krate.types.intern(Type::Dict(string_ty, unknown_ty));
         let span = self.span(new_expr.span.start, new_expr.span.end);
-        // Lower the constructor arguments for their side effects and type checks
-        // even though only the MIME `type` ends up on the modeled record.
-        for argument in &new_expr.arguments {
-            let _ = self.argument(argument, body)?;
-        }
-        let blob_type = self.blob_options_type_string(new_expr.arguments.get(1), body, span);
-        let marker_key = body.push_expr(Expr {
-            kind: ExprKind::Literal(Literal::String("__smelt_blob".to_owned())),
-            ty: string_ty,
+        let parts = self.blob_parts_expression(new_expr.arguments.first(), body, span)?;
+        let (blob_type, _) =
+            self.blob_options_expressions(new_expr.arguments.get(1), "Blob", body, span)?;
+        Ok(body.push_expr(Expr {
+            kind: ExprKind::BlobFromParts {
+                parts,
+                blob_type,
+                name: None,
+                last_modified: None,
+            },
+            ty: unknown_ty,
             span,
-        });
-        let marker_value = body.push_expr(Expr {
-            kind: ExprKind::Literal(Literal::Bool(true)),
-            ty: bool_ty,
+        }))
+    }
+
+    /// Lower `new File(parts, name, options?)` to a concrete marker-bearing record.
+    ///
+    /// JavaScript `File` extends `Blob`, so the modeled record carries the
+    /// `__smelt_file` marker *on top of* `__smelt_blob` (stamped by the
+    /// `smelt_blob_record_from_parts` runtime helper): `file instanceof Blob`
+    /// and `file instanceof File` both resolve through their markers, matching
+    /// the host subtype relationship that `isBlob`/`isFile` observe. The record
+    /// retains `name`, `type`, `lastModified`, `size`, and `content`, so the
+    /// `clone`/`cloneDeepWith` paths that rebuild a `File` from those fields
+    /// round-trip real values.
+    pub(super) fn file_constructor_expression(
+        &mut self,
+        new_expr: &oxc::ast::ast::NewExpression<'_>,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let string_ty = self.ctx.krate.types.intern(Type::String);
+        let unknown_ty = self.ctx.krate.types.intern(Type::Unknown);
+        let span = self.span(new_expr.span.start, new_expr.span.end);
+        let parts = self.blob_parts_expression(new_expr.arguments.first(), body, span)?;
+        let name = match new_expr.arguments.get(1) {
+            Some(name_arg) => {
+                let name = self.argument(name_arg, body)?;
+                self.blob_string_field_expression(name, name_arg.span(), "File", "name", body)?
+            }
+            None => body.push_expr(Expr {
+                kind: ExprKind::Literal(Literal::String(String::new())),
+                ty: string_ty,
+                span,
+            }),
+        };
+        let (blob_type, last_modified) =
+            self.blob_options_expressions(new_expr.arguments.get(2), "File", body, span)?;
+        Ok(body.push_expr(Expr {
+            kind: ExprKind::BlobFromParts {
+                parts,
+                blob_type,
+                name: Some(name),
+                last_modified,
+            },
+            ty: unknown_ty,
             span,
-        });
-        let type_key = body.push_expr(Expr {
-            kind: ExprKind::Literal(Literal::String("type".to_owned())),
-            ty: string_ty,
-            span,
-        });
-        let object = body.push_expr(Expr {
-            kind: ExprKind::DictLit(vec![(marker_key, marker_value), (type_key, blob_type)]),
-            ty: dict_ty,
-            span,
-        });
+        }))
+    }
+
+    /// Lower a `Blob`/`File` constructor `BlobPart` array to an erased value.
+    ///
+    /// Parts are heterogeneous at runtime (strings and other Blob/File records),
+    /// so the lowered array is erased to `SmeltUnknown` and walked by the
+    /// `smelt_blob_record_from_parts` runtime helper. A missing argument
+    /// (`new Blob()`) lowers to an empty erased list.
+    fn blob_parts_expression(
+        &mut self,
+        parts_argument: Option<&Argument<'_>>,
+        body: &mut Body,
+        span: Span,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let unknown_ty = self.ctx.krate.types.intern(Type::Unknown);
+        let parts = if let Some(argument) = parts_argument {
+            self.argument(argument, body)?
+        } else {
+            let list_ty = self.ctx.krate.types.intern(Type::List(unknown_ty));
+            body.push_expr(Expr {
+                kind: ExprKind::ListLit(Vec::new()),
+                ty: list_ty,
+                span,
+            })
+        };
         Ok(body.push_expr(Expr {
             kind: ExprKind::UnknownCast {
-                value: object,
+                value: parts,
                 target: unknown_ty,
             },
             ty: unknown_ty,
@@ -1184,43 +1241,122 @@ impl ModuleBuilder<'_> {
         }))
     }
 
-    /// Resolve a `Blob` constructor `options.type` string literal when present.
+    /// Resolve the `type` (and `File`-only `lastModified`) expressions from a
+    /// `Blob`/`File` constructor options argument.
     ///
-    /// Only a directly-spelled `{ type: "..." }` literal is carried onto the
-    /// modeled record; any other options shape falls back to the empty MIME
-    /// string that a real `Blob` reports when no type is supplied.
-    pub(super) fn blob_options_type_string(
+    /// An object-literal options argument keeps the spelled `type`/`lastModified`
+    /// *value expressions* — arbitrary expressions such as `valueToClone.type`,
+    /// not just string literals — and lowers every other property for its
+    /// effects. A missing or non-literal options argument falls back to the
+    /// empty MIME string a real `Blob` reports when no type is supplied.
+    fn blob_options_expressions(
         &mut self,
         options_argument: Option<&Argument<'_>>,
+        class_name: &str,
         body: &mut Body,
         span: Span,
-    ) -> smelt_hir::ExprId {
+    ) -> Result<(smelt_hir::ExprId, Option<smelt_hir::ExprId>), SmeltError> {
         let string_ty = self.ctx.krate.types.intern(Type::String);
-        let blob_type = options_argument.and_then(|argument| {
-            let Argument::ObjectExpression(object) = argument else {
-                return None;
-            };
-            object.properties.iter().find_map(|property| {
-                let ObjectPropertyKind::ObjectProperty(property) = property else {
-                    return None;
-                };
-                let PropertyKey::StaticIdentifier(key) = &property.key else {
-                    return None;
-                };
-                if key.name != "type" {
-                    return None;
+        let float_ty = self.ctx.krate.types.intern(Type::Float);
+        let mut blob_type = None;
+        let mut last_modified = None;
+        match options_argument {
+            Some(Argument::ObjectExpression(object)) => {
+                for property in &object.properties {
+                    let ObjectPropertyKind::ObjectProperty(property) = property else {
+                        continue;
+                    };
+                    let PropertyKey::StaticIdentifier(key) = &property.key else {
+                        let _ = self.expression(&property.value, body)?;
+                        continue;
+                    };
+                    let value = self.expression(&property.value, body)?;
+                    let value_span = property.value.span();
+                    match key.name.as_str() {
+                        "type" => {
+                            blob_type = Some(self.blob_string_field_expression(
+                                value,
+                                value_span,
+                                class_name,
+                                "options.type",
+                                body,
+                            )?);
+                        }
+                        "lastModified" => {
+                            let value_ty = Self::expr_ty(body, value);
+                            let coerced = if matches!(
+                                self.ctx.krate.types.get(value_ty),
+                                Some(Type::Int | Type::Float)
+                            ) {
+                                value
+                            } else if self.type_contains_unknown(value_ty) {
+                                body.push_expr(Expr {
+                                    kind: ExprKind::TypeAssert { value },
+                                    ty: float_ty,
+                                    span: self.span(value_span.start, value_span.end),
+                                })
+                            } else {
+                                return Err(SmeltError::unsupported(
+                                    self.span(value_span.start, value_span.end),
+                                    format!(
+                                        "{class_name} constructor options.lastModified must be a number"
+                                    ),
+                                ));
+                            };
+                            last_modified = Some(coerced);
+                        }
+                        // Unmodeled options (`endings`, ...) are evaluated for
+                        // their effects and dropped from the record.
+                        _ => {}
+                    }
                 }
-                match &property.value {
-                    Expression::StringLiteral(literal) => Some(literal.value.to_string()),
-                    _ => None,
-                }
+            }
+            // A non-literal options value (a variable, a call) is evaluated for
+            // its effects; its fields are not recoverable statically, so the
+            // record falls back to the constructor defaults.
+            Some(argument) => {
+                let _ = self.argument(argument, body)?;
+            }
+            None => {}
+        }
+        let blob_type = blob_type.unwrap_or_else(|| {
+            body.push_expr(Expr {
+                kind: ExprKind::Literal(Literal::String(String::new())),
+                ty: string_ty,
+                span,
             })
         });
-        body.push_expr(Expr {
-            kind: ExprKind::Literal(Literal::String(blob_type.unwrap_or_default())),
-            ty: string_ty,
-            span,
-        })
+        Ok((blob_type, last_modified))
+    }
+
+    /// Coerce a lowered `Blob`/`File` constructor field to a string expression,
+    /// mirroring the `DOMException` message idiom: strings pass through,
+    /// string-compatible or erased values get a runtime `TypeAssert`, anything
+    /// else is a lowering error naming the offending field.
+    fn blob_string_field_expression(
+        &mut self,
+        value: smelt_hir::ExprId,
+        value_span: oxc::span::Span,
+        class_name: &str,
+        field_name: &str,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let string_ty = self.ctx.krate.types.intern(Type::String);
+        let value_ty = Self::expr_ty(body, value);
+        if self.ctx.krate.types.get(value_ty) == Some(&Type::String) {
+            return Ok(value);
+        }
+        if self.is_string_compatible_type(value_ty) || self.type_contains_unknown(value_ty) {
+            return Ok(body.push_expr(Expr {
+                kind: ExprKind::TypeAssert { value },
+                ty: string_ty,
+                span: self.span(value_span.start, value_span.end),
+            }));
+        }
+        Err(SmeltError::unsupported(
+            self.span(value_span.start, value_span.end),
+            format!("{class_name} constructor {field_name} must be a string"),
+        ))
     }
 
     /// Lower a boxed primitive wrapper (`new Number(v)`, `new Boolean(v)`) to a

--- a/crates/smelt-frontend-ts/src/tests/category_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/category_tests.rs
@@ -42,10 +42,11 @@ fn new_unresolved_builtin_class_is_missing_stdlib() -> Result<(), String> {
 }
 
 /// `new WeakMap()` / `new WeakSet()` / `new DataView()` / `new SharedArrayBuffer()`
-/// / `new File()` lower to concrete marker-bearing records so `instanceof` keeps a
-/// distinct identity for each host type, rather than erasing to a shapeless
+/// lower to concrete marker-bearing records so `instanceof` keeps a distinct
+/// identity for each host type, rather than erasing to a shapeless
 /// `SmeltUnknown::Object` (which the `isWeakMap`/`isWeakSet`/`isTypedArray`/`clone`
-/// predicates inspect).
+/// predicates inspect). (`File` retains structural fields now and has its own
+/// `BlobFromParts` construction; see `new_file_lowers_to_blob_from_parts_with_name`.)
 #[test]
 fn new_marker_only_host_builtins_lower_to_concrete_marker_records() -> Result<(), String> {
     for (source, marker) in [
@@ -53,7 +54,6 @@ fn new_marker_only_host_builtins_lower_to_concrete_marker_records() -> Result<()
         ("const w = new WeakSet();", "__smelt_weakset"),
         ("const d = new DataView(new ArrayBuffer(8));", "__smelt_dataview"),
         ("const s = new SharedArrayBuffer(8);", "__smelt_sharedarraybuffer"),
-        (r#"const f = new File(["x"], "n.txt");"#, "__smelt_file"),
     ] {
         let mut ctx = HirCtx::new();
         let module_id = lower_ok(source, &mut ctx)?;
@@ -527,9 +527,11 @@ fn object_constructor_passes_object_argument_through() -> Result<(), String> {
     Ok(())
 }
 
-/// `new Blob(parts, options)` lowers to a concrete record carrying the
-/// dedicated `__smelt_blob` marker (and observable `type`), giving it a distinct
-/// identity for `instanceof Blob` instead of erasing it to a shapeless value.
+/// `new Blob(parts, options)` lowers to a `BlobFromParts` construction (the
+/// `smelt_blob_record_from_parts` runtime helper builds the marker record with
+/// real `type`/`size`/`content`), retaining the spelled options `type` string,
+/// so `instanceof Blob` keeps a distinct identity and field reads observe real
+/// values instead of a shapeless erased object.
 #[test]
 fn new_blob_lowers_to_concrete_marker_record() -> Result<(), String> {
     let mut ctx = HirCtx::new();
@@ -542,16 +544,16 @@ fn new_blob_lowers_to_concrete_marker_record() -> Result<(), String> {
     ensure!(
         body.exprs.iter().any(|expr| matches!(
             (&expr.kind, ctx.krate.types.get(expr.ty)),
-            (ExprKind::DictLit(entries), Some(Type::Dict(_, _))) if entries.len() == 2
+            (
+                ExprKind::BlobFromParts {
+                    name: None,
+                    last_modified: None,
+                    ..
+                },
+                Some(Type::Unknown)
+            )
         )),
-        "expected `new Blob(...)` to lower to a concrete record (DictLit + Dict type)",
-    );
-    ensure!(
-        body.exprs.iter().any(|expr| matches!(
-            &expr.kind,
-            ExprKind::Literal(Literal::String(text)) if text == "__smelt_blob"
-        )),
-        "expected the Blob record to carry the `__smelt_blob` marker key",
+        "expected `new Blob(...)` to lower to a BlobFromParts construction",
     );
     ensure!(
         body.exprs.iter().any(|expr| matches!(
@@ -589,6 +591,101 @@ export function isBlob(x: unknown): x is Blob {
                 ExprKind::InstanceOf { class, .. } if ctx.krate.symbols.get(class) == Some("Blob")
             )),
         "expected `x instanceof Blob` to lower to a Blob InstanceOf predicate",
+    );
+    Ok(())
+}
+
+/// The `isFile` predicate shape (`typeof File === 'undefined'` presence guard
+/// plus `x instanceof File`) lowers like the `isBlob` shape: the presence guard
+/// folds to a constant and the `instanceof` resolves through the modeled
+/// `__smelt_file` marker instead of aborting on an unmodeled class.
+#[test]
+fn is_file_predicate_shape_lowers() -> Result<(), String> {
+    let source = ts!(r#"
+export function isFile(x: unknown): x is File {
+  if (typeof File === 'undefined') {
+    return false;
+  }
+  return x instanceof File;
+}
+"#);
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(source, &mut ctx)?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate
+            .bodies
+            .iter()
+            .flat_map(|body| body.exprs.iter())
+            .any(|expr| matches!(
+                expr.kind,
+                ExprKind::InstanceOf { class, .. } if ctx.krate.symbols.get(class) == Some("File")
+            )),
+        "expected `x instanceof File` to lower to a File InstanceOf predicate",
+    );
+    Ok(())
+}
+
+/// `new File(parts, name, options)` lowers to a `BlobFromParts` construction
+/// that retains the spelled `name` and `lastModified` expressions, so the
+/// modeled record observes real `.name`/`.type`/`.size`/`.lastModified` reads
+/// (the `clone`/`cloneDeepWith` File round-trip).
+#[test]
+fn new_file_lowers_to_blob_from_parts_with_name() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"const f = new File(['content'], 'file.txt', { type: 'text/plain', lastModified: 3 });"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+    ensure!(
+        body.exprs.iter().any(|expr| matches!(
+            (&expr.kind, ctx.krate.types.get(expr.ty)),
+            (
+                ExprKind::BlobFromParts {
+                    name: Some(_),
+                    last_modified: Some(_),
+                    ..
+                },
+                Some(Type::Unknown)
+            )
+        )),
+        "expected `new File(...)` to lower to BlobFromParts retaining name and lastModified",
+    );
+    Ok(())
+}
+
+/// A `Blob` constructor options `type` spelled as a non-literal expression
+/// (`{ type: source.type }`, the `cloneDeepWith` Blob clone arm) is retained on
+/// the modeled record instead of collapsing to the empty MIME default.
+#[test]
+fn new_blob_retains_dynamic_options_type() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function cloneBlob(source: Blob): Blob {
+  return new Blob([source], { type: source.type });
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    let retained_dynamic_type = ctx.krate.bodies.iter().any(|body| {
+        body.exprs.iter().any(|expr| {
+            matches!(
+                &expr.kind,
+                ExprKind::BlobFromParts { blob_type, name: None, .. }
+                    if !matches!(
+                        body.exprs.get(blob_type.0 as usize).map(|blob_type_expr| &blob_type_expr.kind),
+                        Some(ExprKind::Literal(Literal::String(text))) if text.is_empty()
+                    )
+            )
+        })
+    });
+    ensure!(
+        retained_dynamic_type,
+        "expected `new Blob([source], {{ type: source.type }})` to retain the dynamic type expression",
     );
     Ok(())
 }

--- a/crates/smelt-hir/src/expr/kinds.rs
+++ b/crates/smelt-hir/src/expr/kinds.rs
@@ -589,6 +589,22 @@ pub enum ExprKind {
         path: ExprId,
         text: ExprId,
     },
+    /// Construct a modeled host `Blob` or `File` record from constructor
+    /// arguments (`new Blob(parts?, options?)` / `new File(parts, name, options?)`).
+    ///
+    /// `parts` is the erased `BlobPart` array (strings and other `Blob`/`File`
+    /// records); `blob_type` is the resolved MIME `type` string. `name` and
+    /// `last_modified` are present only for `File`, whose record additionally
+    /// carries the `__smelt_file` marker on top of `__smelt_blob` so
+    /// `file instanceof Blob` observes the host subtype relationship. The
+    /// runtime helper concatenates part contents and stores the UTF-8 byte
+    /// `size`, so `.size`/`.type`/`.name` reads observe real values.
+    BlobFromParts {
+        parts: ExprId,
+        blob_type: ExprId,
+        name: Option<ExprId>,
+        last_modified: Option<ExprId>,
+    },
     BinOp {
         op: BinOp,
         lhs: ExprId,

--- a/crates/smelt-hir/src/format/call.rs
+++ b/crates/smelt-hir/src/format/call.rs
@@ -777,6 +777,20 @@ pub(super) fn expr_text(krate: &Crate, expr: &Expr) -> String {
         ExprKind::FileWriteText { path, text } => {
             format!("file_write_text {}, {}", expr_ref(*path), expr_ref(*text))
         }
+        ExprKind::BlobFromParts {
+            parts,
+            blob_type,
+            name,
+            last_modified,
+        } => {
+            let name_text = name.map_or("none".to_owned(), expr_ref);
+            let last_modified_text = last_modified.map_or("none".to_owned(), expr_ref);
+            format!(
+                "blob_from_parts {}, {}, {name_text}, {last_modified_text}",
+                expr_ref(*parts),
+                expr_ref(*blob_type),
+            )
+        }
         ExprKind::BinOp { op, lhs, rhs } => {
             format!("{op:?} {}, {}", expr_ref(*lhs), expr_ref(*rhs))
         }

--- a/crates/smelt-mir/src/format.rs
+++ b/crates/smelt-mir/src/format.rs
@@ -1205,6 +1205,24 @@ fn rvalue_text(value: &Rvalue) -> String {
                 operand_text(text)
             )
         }
+        Rvalue::BlobFromParts {
+            parts,
+            blob_type,
+            name,
+            last_modified,
+        } => {
+            let name_text = name
+                .as_ref()
+                .map_or_else(|| "none".to_owned(), operand_text);
+            let last_modified_text = last_modified
+                .as_ref()
+                .map_or_else(|| "none".to_owned(), operand_text);
+            format!(
+                "blob_from_parts {}, {}, {name_text}, {last_modified_text}",
+                operand_text(parts),
+                operand_text(blob_type),
+            )
+        }
         Rvalue::Await(operand) => format!("await {}", operand_text(operand)),
         Rvalue::AsyncOp { op, args } => {
             let op_text = match op {

--- a/crates/smelt-mir/src/lower/expr.rs
+++ b/crates/smelt-mir/src/lower/expr.rs
@@ -1802,6 +1802,29 @@ impl LoweringCtx<'_> {
                     },
                 )?
             }
+            ExprKind::BlobFromParts {
+                parts,
+                blob_type,
+                name,
+                last_modified,
+            } => {
+                let parts_operand = self.lower_expr(*parts)?;
+                let blob_type_operand = self.lower_expr(*blob_type)?;
+                let name_operand = name.map(|name_expr| self.lower_expr(name_expr)).transpose()?;
+                let last_modified_operand = last_modified
+                    .map(|last_modified_expr| self.lower_expr(last_modified_expr))
+                    .transpose()?;
+                self.assign_temp(
+                    expr.ty,
+                    expr.span,
+                    Rvalue::BlobFromParts {
+                        parts: parts_operand,
+                        blob_type: blob_type_operand,
+                        name: name_operand,
+                        last_modified: last_modified_operand,
+                    },
+                )?
+            }
             ExprKind::Method {
                 receiver,
                 method,

--- a/crates/smelt-mir/src/lower/place.rs
+++ b/crates/smelt-mir/src/lower/place.rs
@@ -232,6 +232,7 @@ impl LoweringCtx<'_> {
             | ExprKind::UrlField { .. }
             | ExprKind::FileReadText { .. }
             | ExprKind::FileWriteText { .. }
+            | ExprKind::BlobFromParts { .. }
             | ExprKind::BinOp { .. }
             | ExprKind::UnaryOp { .. }
             | ExprKind::Conditional { .. }

--- a/crates/smelt-mir/src/opt/mod.rs
+++ b/crates/smelt-mir/src/opt/mod.rs
@@ -727,6 +727,21 @@ fn rewrite_rvalue(
             rewrite_operand_except(path, aliases, dest)
                 | rewrite_operand_except(text, aliases, dest)
         }
+        Rvalue::BlobFromParts {
+            parts,
+            blob_type,
+            name,
+            last_modified,
+        } => {
+            rewrite_operand_except(parts, aliases, dest)
+                | rewrite_operand_except(blob_type, aliases, dest)
+                | name
+                    .as_mut()
+                    .is_some_and(|name_operand| rewrite_operand_except(name_operand, aliases, dest))
+                | last_modified.as_mut().is_some_and(|last_modified_operand| {
+                    rewrite_operand_except(last_modified_operand, aliases, dest)
+                })
+        }
         Rvalue::NumericExtrema { args, .. } => args.iter_mut().fold(false, |changed, arg| {
             rewrite_operand_except(arg, aliases, dest) | changed
         }),

--- a/crates/smelt-mir/src/types.rs
+++ b/crates/smelt-mir/src/types.rs
@@ -1521,6 +1521,18 @@ pub enum Rvalue {
         /// Text content to write.
         text: Operand,
     },
+    /// Construct a modeled host `Blob`/`File` marker record from constructor parts.
+    BlobFromParts {
+        /// Erased `BlobPart` array (strings and other `Blob`/`File` records).
+        parts: Operand,
+        /// Resolved MIME `type` string.
+        blob_type: Operand,
+        /// `File` name; present only for `new File(...)`, which also stamps
+        /// the `__smelt_file` marker on top of `__smelt_blob`.
+        name: Option<Operand>,
+        /// `File` options `lastModified` milliseconds, when spelled.
+        last_modified: Option<Operand>,
+    },
     /// Await a future and produce its output.
     Await(Operand),
     /// Run a runtime-backed async operation.

--- a/crates/smelt-mir/src/validate/operands.rs
+++ b/crates/smelt-mir/src/validate/operands.rs
@@ -624,6 +624,21 @@ impl Rvalue {
                 visit(path);
                 visit(text);
             }
+            Self::BlobFromParts {
+                parts,
+                blob_type,
+                name,
+                last_modified,
+            } => {
+                visit(parts);
+                visit(blob_type);
+                if let Some(name_operand) = name {
+                    visit(name_operand);
+                }
+                if let Some(last_modified_operand) = last_modified {
+                    visit(last_modified_operand);
+                }
+            }
             Self::NumericExtrema { args, .. } => {
                 for arg in args {
                     visit(arg);
@@ -1303,6 +1318,21 @@ impl Rvalue {
             Self::FileWriteText { path, text } => {
                 visit(path);
                 visit(text);
+            }
+            Self::BlobFromParts {
+                parts,
+                blob_type,
+                name,
+                last_modified,
+            } => {
+                visit(parts);
+                visit(blob_type);
+                if let Some(name_operand) = name {
+                    visit(name_operand);
+                }
+                if let Some(last_modified_operand) = last_modified {
+                    visit(last_modified_operand);
+                }
             }
             Self::NumericExtrema { args, .. } => {
                 for arg in args.iter_mut() {

--- a/crates/smelt-stdlib/src/runtime_symbols.rs
+++ b/crates/smelt-stdlib/src/runtime_symbols.rs
@@ -78,3 +78,17 @@ pub mod json {
     /// `JSON.parse` and other JSON-ingest boundaries.
     pub const UNKNOWN_FROM_JSON_VALUE: &str = "smelt_unknown_from_json_value";
 }
+
+/// Host-object construction helpers.
+///
+/// These build the marker records that model JavaScript host builtins (see
+/// `host_object.rs` for the marker registry itself).
+pub mod host {
+    /// Builds the modeled `Blob`/`File` record from its `BlobPart` contents.
+    ///
+    /// Backs `new Blob(parts?, options?)` and `new File(parts, name, options?)`
+    /// (`Rvalue::BlobFromParts`). Concatenates part contents, stores the UTF-8
+    /// byte `size`, and stamps `__smelt_file` on top of `__smelt_blob` when a
+    /// file name is supplied.
+    pub const BLOB_RECORD_FROM_PARTS: &str = "smelt_blob_record_from_parts";
+}


### PR DESCRIPTION
## Summary

Tier 1 of #126: promote `Blob`/`File` from identity-only marker records to a real structural model, so es-toolkit's `clone`/`cloneDeepWith` sources and specs observe correct `.type`/`.size`/`.name`/`.lastModified` values and `File extends Blob` subtyping.

- New `ExprKind::BlobFromParts` → `Rvalue::BlobFromParts` → `smelt_blob_record_from_parts` runtime helper (gated like other `needs_*` prelude helpers, named in `runtime_symbols::host`). Parts concatenate at runtime (strings verbatim, nested Blob/File records contribute their stored `content`, others stringify like JS); `size` is the UTF-8 byte length.
- `File` leaves the marker-only builtin set: dedicated constructor retaining `name`/`type`/`lastModified`, records stamp `__smelt_file` **on top of** `__smelt_blob`, so `file instanceof Blob` / `isBlob(file)` are finally true.
- Constructor options keep arbitrary spelled expressions (`{ type: source.type }`, the cloneDeepWith round-trip) instead of collapsing non-literal types to `""`; DOMException-style string/number coercion asserts.
- es-toolkit fixture: re-include `cloneDeep.spec.ts`, `isBlob.spec.ts`, `isFile.spec.ts` (verified: whole-crate build reaches the same pre-existing abort at `isEqualWith.spec.ts`, so no new blockers). `clone.spec.ts` stays excluded on the unrelated Error-`cause` constructor blocker, re-documented in the fixture.

Blob/File records stay behind the documented host-object dynamic boundary (`SmeltUnknown::Object` marker records inspected via runtime narrowing); no new erasure of statically-shaped values.

## Verification

- `cargo test --workspace` green (excluding `smelt-gui`, which cannot link in the dev container — missing X11 system libs).
- `cargo check` / `cargo clippy` clean on touched crates.
- New regression tests: frontend `BlobFromParts` lowering (File fields, dynamic options type, `isFile` predicate shape), codegen helper emission + gating; updated the two tests that asserted the old marker-only model.
- Local probe (`scripts/probe_libraries.py` with this branch's binary, pinned es-toolkit ref): zero Blob/File blockers remain across the 1219-file scan; remaining host-global blockers are only `Proxy`×3, `Intl`×1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_