### PR TITLE
feat(hir): structural const-item inlining via exhaustive child-expr mapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ blocker-logs/*.md
 !blocker-logs/library-probes.md
 # smelt-unknown-report.md documents the SmeltUnknown metric methodology + baseline
 !blocker-logs/smelt-unknown-report.md
+# estk-const-item-inlining.md documents the const-item-inlining blocker fix
+!blocker-logs/estk-const-item-inlining.md
 
 # Generated docs site output
 _site/

--- a/blocker-logs/estk-const-item-inlining.md
+++ b/blocker-logs/estk-const-item-inlining.md
@@ -1,0 +1,147 @@
+# es-toolkit blocker: `const item expression shape is not supported for inlining yet`
+
+Investigation and fix report for the TypeScript-frontend lowering blocker that
+aborted the whole-crate es-toolkit build (pinned ref `e008a2818cd8`) at
+`src/predicate/isEqualWith.spec.ts` and affected 29 spec files.
+
+## Failure family
+
+Importing (or referencing same-module) `const` items whose initializer is a
+*computed* expression failed to inline into the referencing body:
+
+```
+src/compat/_internal/arrayViews.ts   export const arrayViews = [...typedArrays, 'DataView'];
+src/compat/_internal/empties.ts      export const empties = [[], {}].concat(falsey.slice(1));
+src/compat/_internal/whitespace.ts   export const whitespace = [...].filter(chr => /\s/.exec(chr)).join('');
+src/compat/_internal/args.ts         export const args = toArgs([1, 2, 3]);
+```
+
+Any spec importing one of these consts died with
+`const item expression shape is not supported for inlining yet`.
+
+## Root cause
+
+`ModuleBuilder::clone_const_body_expr`
+(`crates/smelt-frontend-ts/src/lowering/expr/references.rs`) copied a const
+item's initializer expression tree into the referencing body through a
+hand-maintained **whitelist** of ~20 `ExprKind` variants (literals, calls,
+fields, container literals, conditionals, bin/unary ops). Every other
+expression kind — `ListConcat` (array spread / `.concat`), `ListSlice`
+(`.slice`), `ListCallback` (`.filter`), `StringJoin` (`.join`), `Method`,
+`Index`, regex kinds, and roughly 140 more — fell into the `_ =>` arm and
+raised the diagnostic, even though the const body had already lowered those
+kinds successfully.
+
+A secondary defect surfaced once inlining succeeded: array-spread literals
+with plain elements (`[...typedArrays, 'DataView']`) blanket-typed their items
+as `Unknown` (`array_spread_item_type` returned `Unknown` whenever any
+non-spread element existed). The inlined spread operand kept its concrete
+`List<String>` type, the surrounding concat chain was `List<Unknown>`, and the
+Rust emitter silently produced an empty `SmeltList::default()` for the
+mismatched concat — generated tests then failed at runtime with wrong values.
+
+## General rules implemented (no per-library special cases)
+
+1. **Exhaustive structural child remapping** — new
+   `ExprKind::try_map_child_exprs` in `crates/smelt-hir/src/expr/map.rs`
+   rebuilds any expression kind with each direct child `ExprId` passed through
+   a mapping function. The match is exhaustive (no `_` arm), so a future
+   `ExprKind` variant forces the mapper to be updated.
+   `clone_const_body_expr` now recurses through this mapper, so **every**
+   expression shape a const initializer can lower to also inlines. The only
+   rejected shapes are the ones that genuinely reference the source body's
+   local arenas — `ExprKind::Local` and `ExprKind::Block` — which cannot move
+   across bodies by expression cloning alone (they do not occur in
+   module-level const initializers es-toolkit uses).
+
+2. **Spread-literal item type unification** —
+   `array_expression_with_spread`
+   (`crates/smelt-frontend-ts/src/lowering/expr/operators.rs`) now lowers all
+   elements first (in source order, preserving evaluation order), then unifies
+   the item type from every piece: spread operands contribute their unwrapped
+   `List`/`Set` item type (or `String` for string spreads), plain elements
+   contribute their expression type. A single agreed candidate wins; mixed or
+   erased candidates fall back to `Unknown` exactly as before. This keeps
+   `[...typedArrays, 'DataView']` a concrete `List<String>` — a net
+   *reduction* in `SmeltUnknown` usage, per the SmeltUnknown boundary rules.
+
+## Shapes fixed vs deferred
+
+Fixed (verified end-to-end via fixture `smelt build` + generated `cargo test`):
+
+- array spread in array literal: `[...xs, 'y']` (`ListConcat`)
+- method chains: `[a, b].concat(other.slice(1))` (`ListConcat` + `ListSlice`)
+- callback chains: `[...].filter(cb).join('')` (`ListCallback` + `StringJoin`
+  + cloned `Closure` reference)
+- every other `ExprKind` with only crate-global references now clones
+  structurally (calls, indexing, regex, string/list/dict/set operations, ...)
+
+Deferred (unchanged behavior, now with a precise diagnostic
+`const item expression references body-local state that cannot be inlined`):
+
+- const initializers whose HIR references body-local state (`Local`, `Block`).
+
+Out-of-scope defects observed while verifying (pre-existing, reproduce without
+any const imports):
+
+- `filter(chr => /\s/.exec(chr))` generates
+  `Option<SmeltMatch>.map_or(false, |value| value)` — regex-exec truthiness in
+  predicate callbacks does not compile (`expected bool, found SmeltMatch`).
+  This will surface when es-toolkit builds reach `whitespace`-consuming specs
+  at codegen level; HIR lowering is fine.
+- `importedConst.join(',')` takes the namespace-import static-join path in
+  `string_join_call` because the receiver identifier is in `value_imports`,
+  and mis-treats the separator as the array argument.
+
+## Verification
+
+- `cargo check --workspace` clean.
+- `cargo clippy` on touched crates (`smelt-hir`, `smelt-frontend-ts`,
+  `smelt-codegen-rust`) clean. (`--all-targets` reports pre-existing pedantic
+  lints in test modules untouched by this change.)
+- `cargo test --workspace --exclude smelt-gui` green.
+- Regression tests added:
+  - `smelt-frontend-ts::tests::part01_tests::imported_const_with_array_spread_initializer_inlines`
+  - `smelt-frontend-ts::tests::part01_tests::imported_const_with_method_chain_initializer_inlines`
+  - `smelt-frontend-ts::tests::part01_tests::imported_const_with_callback_chain_initializer_inlines`
+  - `smelt-codegen-rust::tests::part_7_tests::inlined_spread_const_emits_concrete_string_list_concat`
+  - `smelt-codegen-rust::tests::part_7_tests::inlined_method_chain_const_emits_concat_and_slice`
+- Fixture project (spread + concat/slice + filter/join consts imported across
+  modules): `smelt build` succeeds and the generated crate's `cargo test`
+  passes 3/3.
+
+### es-toolkit re-check (all 29 previously-affected files, single-file dump-hir)
+
+The `const item expression shape is not supported for inlining yet` family is
+gone from **all 29 files**. 16 now lower cleanly:
+
+find, flatMap, findLast, pullAt, reduceRight, reduce (compat/array); mean
+(compat/math); at, get, result (compat/object); trim, trimEnd, trimStart
+(compat/string); toFinite, toInteger (compat/util).
+
+13 keep *unrelated pre-existing* diagnostics:
+
+- `array callback callback item parameter count is not supported` (10):
+  every, includes, sample, some (compat/array); sum, sumBy (compat/math);
+  keys, keysIn (compat/object); isArguments, isEmpty (compat/predicate);
+  constant (compat/util)
+- `dynamic computed access on the global object requires the runtime global
+  object (not yet modeled)` (2): compat/predicate/isEqual,
+  predicate/isEqualWith — from `globalThis[type]`
+- `callback item references must resolve to callable values` (1):
+  compat/util/toNumber
+
+### Whole-crate build abort point
+
+- Before: `src/predicate/isEqualWith.spec.ts` —
+  `const item expression shape is not supported for inlining yet`.
+- After: still `src/predicate/isEqualWith.spec.ts`, but the abort is now the
+  *next* family in the same file: `dynamic computed access on the global
+  object requires the runtime global object (not yet modeled)`
+  (`globalThis[type]` inside the arrayViews loop). The const-item family no
+  longer aborts anything.
+- With the two `globalThis` specs (`predicate/isEqualWith`,
+  `compat/predicate/isEqual`) additionally excluded in a scratch copy, the
+  build reaches `src/predicate/isFunction.spec.ts`
+  (`unresolved identifier \`Proxy\``) — matching the "next blockers" already
+  documented in `.github/compat/es-toolkit/Smelt.toml`.

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -6386,3 +6386,62 @@ export function run(values: number[]): string {
         "expected the reduce return-type rejection, got: {errors:?}"
     );
 }
+
+/// A module const whose initializer is an array spread (es-toolkit's
+/// `arrayViews = [...typedArrays, 'DataView']` shape) inlines into a function
+/// body as a concrete `SmeltList<String>` concat chain. The homogeneous
+/// literal must keep its `String` item type — the previous blanket
+/// `List<Unknown>` item type made the concat operands disagree and the
+/// emitter silently produced an empty `SmeltList::default()` value.
+#[test]
+fn inlined_spread_const_emits_concrete_string_list_concat() {
+    let source = source_for(
+        r#"
+const typedNames = ["Float32Array", "Int8Array", "Uint8Array"];
+const viewNames = [...typedNames, "DataView"];
+export function describeViews(): string {
+  const names = viewNames;
+  return names.join(",");
+}
+"#,
+    );
+    assert!(source.contains("fn describe_views()"), "{source}");
+    assert!(
+        source.contains("\"DataView\".to_owned()"),
+        "expected the spread tail literal to survive codegen: {source}"
+    );
+    assert!(
+        source.contains("let names: SmeltList<String>"),
+        "expected the inlined spread const to stay a concrete string list: {source}"
+    );
+    assert!(
+        !source.contains("SmeltList::default()"),
+        "expected no silently-defaulted list value in the concat chain: {source}"
+    );
+}
+
+/// A module const whose initializer is a concat/slice method chain
+/// (es-toolkit's `empties = [[], {}].concat(falsey.slice(1))` shape) inlines
+/// into a function body and emits the full chain instead of erroring as an
+/// unsupported const item expression shape.
+#[test]
+fn inlined_method_chain_const_emits_concat_and_slice() {
+    let source = source_for(
+        r#"
+const smallNumbers = [0, 1].concat([2, 3, 4].slice(1));
+export function numberCount(): number {
+  const values = smallNumbers;
+  return values.length;
+}
+"#,
+    );
+    assert!(source.contains("fn number_count()"), "{source}");
+    assert!(
+        source.contains(".chain("),
+        "expected the inlined concat chain to emit list concatenation: {source}"
+    );
+    assert!(
+        source.contains(".skip("),
+        "expected the inlined slice argument to emit a skip-based slice: {source}"
+    );
+}

--- a/crates/smelt-frontend-ts/src/lowering/expr/operators.rs
+++ b/crates/smelt-frontend-ts/src/lowering/expr/operators.rs
@@ -16,6 +16,18 @@ use crate::lowering::{
 use crate::RestParam;
 use oxc::span::GetSpan;
 
+/// One lowered element of a spread-containing array literal.
+///
+/// `array_expression_with_spread` lowers all elements before assembling the
+/// `ListLit`/`ListConcat` chain so the literal's item type can be unified from
+/// the lowered piece types.
+enum SpreadPiece {
+    /// A `...operand` spread with its lowered operand and source span.
+    Spread(smelt_hir::ExprId, oxc::span::Span),
+    /// A plain element expression.
+    Item(smelt_hir::ExprId),
+}
+
 impl ModuleBuilder<'_> {
     /// Lower static `Array.from({ length }, mapper)` calls into indexed list construction.
     pub(in crate::lowering) fn array_from_call(
@@ -2332,38 +2344,19 @@ impl ModuleBuilder<'_> {
             let list_ty = self.ctx.krate.types.intern(Type::List(item_ty));
             return self.list_expr_from_spread_value(spread_value, list_ty, spread.span, body);
         }
-        let item_ty = self.array_spread_item_type(array, type_hint);
-        let list_ty = self.ctx.krate.types.intern(Type::List(item_ty));
-        let mut packed = None;
-        let mut current_items = Vec::new();
+        // Two-phase lowering: first lower every element/spread operand in
+        // source order (preserving evaluation order and side effects), then
+        // unify their item types, and finally assemble the `ListLit`/
+        // `ListConcat` chain with the unified list type. Lowering before type
+        // assembly lets homogeneous literals such as `[...typedArrays,
+        // 'DataView']` keep their concrete item type instead of erasing to
+        // `List<Unknown>` and mismatching against the typed spread operand.
+        let mut pieces = Vec::new();
         for element in &array.elements {
             match element {
                 ArrayExpressionElement::SpreadElement(spread) => {
-                    if !current_items.is_empty() {
-                        let right = body.push_expr(Expr {
-                            kind: ExprKind::ListLit(std::mem::take(&mut current_items)),
-                            ty: list_ty,
-                            span: self.span(array.span.start, array.span.end),
-                        });
-                        packed = Some(packed.map_or(right, |left| {
-                            body.push_expr(Expr {
-                                kind: ExprKind::ListConcat { left, right },
-                                ty: list_ty,
-                                span: self.span(array.span.start, array.span.end),
-                            })
-                        }));
-                    }
-                    let spread_value =
-                        self.expression_with_hint(&spread.argument, body, Some(list_ty))?;
-                    let right =
-                        self.list_expr_from_spread_value(spread_value, list_ty, spread.span, body)?;
-                    packed = Some(packed.map_or(right, |left| {
-                        body.push_expr(Expr {
-                            kind: ExprKind::ListConcat { left, right },
-                            ty: list_ty,
-                            span: self.span(array.span.start, array.span.end),
-                        })
-                    }));
+                    let spread_value = self.expression(&spread.argument, body)?;
+                    pieces.push(SpreadPiece::Spread(spread_value, spread.span));
                 }
                 ArrayExpressionElement::Elision(_) => {
                     return Err(SmeltError::unsupported(
@@ -2371,7 +2364,49 @@ impl ModuleBuilder<'_> {
                         "array elisions are not lowered",
                     ));
                 }
-                _ => current_items.push(self.array_element(element, body)?),
+                _ => pieces.push(SpreadPiece::Item(self.array_element(element, body)?)),
+            }
+        }
+        let piece_exprs: Vec<(smelt_hir::ExprId, bool)> = pieces
+            .iter()
+            .map(|piece| match piece {
+                SpreadPiece::Spread(value, _) => (*value, true),
+                SpreadPiece::Item(value) => (*value, false),
+            })
+            .collect();
+        let item_ty = self.array_spread_item_type(&piece_exprs, body, type_hint);
+        let list_ty = self.ctx.krate.types.intern(Type::List(item_ty));
+        let mut packed = None;
+        let mut current_items = Vec::new();
+        let mut append = |target: &mut Body, right: smelt_hir::ExprId| {
+            packed = Some(packed.map_or(right, |left| {
+                target.push_expr(Expr {
+                    kind: ExprKind::ListConcat { left, right },
+                    ty: list_ty,
+                    span: self.span(array.span.start, array.span.end),
+                })
+            }));
+        };
+        for piece in &pieces {
+            match piece {
+                SpreadPiece::Spread(spread_value, spread_span) => {
+                    if !current_items.is_empty() {
+                        let right = body.push_expr(Expr {
+                            kind: ExprKind::ListLit(std::mem::take(&mut current_items)),
+                            ty: list_ty,
+                            span: self.span(array.span.start, array.span.end),
+                        });
+                        append(body, right);
+                    }
+                    let right = self.list_expr_from_spread_value(
+                        *spread_value,
+                        list_ty,
+                        *spread_span,
+                        body,
+                    )?;
+                    append(body, right);
+                }
+                SpreadPiece::Item(item) => current_items.push(*item),
             }
         }
         if !current_items.is_empty() {
@@ -2380,13 +2415,7 @@ impl ModuleBuilder<'_> {
                 ty: list_ty,
                 span: self.span(array.span.start, array.span.end),
             });
-            packed = Some(packed.map_or(right, |left| {
-                body.push_expr(Expr {
-                    kind: ExprKind::ListConcat { left, right },
-                    ty: list_ty,
-                    span: self.span(array.span.start, array.span.end),
-                })
-            }));
+            append(body, right);
         }
         packed.ok_or_else(|| {
             SmeltError::unsupported(
@@ -2396,10 +2425,20 @@ impl ModuleBuilder<'_> {
         })
     }
 
-    /// Infer the list item type for an array spread literal.
+    /// Infer the list item type for an array spread literal from its lowered
+    /// pieces.
+    ///
+    /// A `List` item type from the contextual hint wins. Otherwise every
+    /// lowered piece contributes one candidate item type — a spread operand
+    /// contributes its unwrapped `List`/`Set` item type (or `String` for
+    /// string spreads), a plain element contributes its own expression type —
+    /// and the literal keeps the single unified candidate when they all
+    /// agree. Mixed or erased candidates fall back to `Unknown`, matching the
+    /// previous blanket behavior for genuinely heterogeneous literals.
     pub(in crate::lowering) fn array_spread_item_type(
         &mut self,
-        array: &oxc::ast::ast::ArrayExpression<'_>,
+        pieces: &[(smelt_hir::ExprId, bool)],
+        body: &Body,
         type_hint: Option<smelt_hir::TypeId>,
     ) -> smelt_hir::TypeId {
         if let Some(hint) = type_hint
@@ -2407,15 +2446,26 @@ impl ModuleBuilder<'_> {
         {
             return *item_ty;
         }
-        for element in &array.elements {
-            match element {
-                ArrayExpressionElement::SpreadElement(_) | ArrayExpressionElement::Elision(_) => {}
-                _ => {
-                    return self.ctx.krate.types.intern(Type::Unknown);
+        let unknown = self.ctx.krate.types.intern(Type::Unknown);
+        let mut unified: Option<smelt_hir::TypeId> = None;
+        for &(value, is_spread) in pieces {
+            let candidate = if is_spread {
+                let value_ty = self.type_param_constraint_or_self(Self::expr_ty(body, value));
+                match self.ctx.krate.types.get(value_ty) {
+                    Some(Type::List(item_ty) | Type::Set(item_ty)) => *item_ty,
+                    Some(Type::String) => self.ctx.krate.types.intern(Type::String),
+                    _ => unknown,
                 }
+            } else {
+                Self::expr_ty(body, value)
+            };
+            match unified {
+                None => unified = Some(candidate),
+                Some(existing) if existing == candidate => {}
+                Some(_) => return unknown,
             }
         }
-        self.ctx.krate.types.intern(Type::Unknown)
+        unified.unwrap_or(unknown)
     }
 
     /// Convert an iterable spread operand into the list value required by list concatenation.

--- a/crates/smelt-frontend-ts/src/lowering/expr/references.rs
+++ b/crates/smelt-frontend-ts/src/lowering/expr/references.rs
@@ -1279,6 +1279,14 @@ return_ty: function.return_ty,
     }
 
     /// Clone one expression from a const body, remapping nested expression IDs.
+    ///
+    /// Cloning is fully structural: every expression kind is rebuilt through
+    /// [`ExprKind::try_map_child_exprs`], which remaps direct child expression
+    /// IDs into the target body while preserving crate-global references
+    /// (items, types, symbols, closure bodies). The only shapes rejected here
+    /// are the ones that genuinely point into the source body's local arenas —
+    /// `Local` variables and statement `Block`s — because those cannot move to
+    /// another body by expression cloning alone.
     pub(in crate::lowering) fn clone_const_body_expr(
         source_body: &Body,
         expr_id: smelt_hir::ExprId,
@@ -1297,107 +1305,15 @@ return_ty: function.return_ty,
                     "const expression is missing",
                 )
             })?;
-        let kind = match expr.kind {
-            ExprKind::Literal(value) => ExprKind::Literal(value),
-            ExprKind::Item(item) => ExprKind::Item(item),
-            ExprKind::Closure(closure) => ExprKind::Closure(closure),
-            ExprKind::Call { callee, args } => ExprKind::Call {
-                callee: Self::clone_const_body_expr(source_body, callee, target_body)?,
-                args: args
-                    .into_iter()
-                    .map(|arg| Self::clone_const_body_expr(source_body, arg, target_body))
-                    .collect::<Result<Vec<_>, _>>()?,
-            },
-            ExprKind::Field { receiver, field } => ExprKind::Field {
-                receiver: Self::clone_const_body_expr(source_body, receiver, target_body)?,
-                field,
-            },
-            ExprKind::OptionalField { receiver, field } => ExprKind::OptionalField {
-                receiver: Self::clone_const_body_expr(source_body, receiver, target_body)?,
-                field,
-            },
-            ExprKind::TypeAssert { value } => ExprKind::TypeAssert {
-                value: Self::clone_const_body_expr(source_body, value, target_body)?,
-            },
-            ExprKind::UnknownCast { value, target } => ExprKind::UnknownCast {
-                value: Self::clone_const_body_expr(source_body, value, target_body)?,
-                target,
-            },
-            ExprKind::AsyncOp { op, args } => ExprKind::AsyncOp {
-                op,
-                args: args
-                    .into_iter()
-                    .map(|arg| Self::clone_const_body_expr(source_body, arg, target_body))
-                    .collect::<Result<Vec<_>, _>>()?,
-            },
-            ExprKind::DateFromValue { value } => ExprKind::DateFromValue {
-                value: Self::clone_const_body_expr(source_body, value, target_body)?,
-            },
-            ExprKind::DictLit(entries) => ExprKind::DictLit(
-                entries
-                    .into_iter()
-                    .map(|(key, value)| {
-                        Ok((
-                            Self::clone_const_body_expr(source_body, key, target_body)?,
-                            Self::clone_const_body_expr(source_body, value, target_body)?,
-                        ))
-                    })
-                    .collect::<Result<Vec<_>, SmeltError>>()?,
-            ),
-            ExprKind::DictProjection { op, dict } => ExprKind::DictProjection {
-                op,
-                dict: Self::clone_const_body_expr(source_body, dict, target_body)?,
-            },
-            ExprKind::ListLit(items) => ExprKind::ListLit(
-                items
-                    .into_iter()
-                    .map(|item| Self::clone_const_body_expr(source_body, item, target_body))
-                    .collect::<Result<Vec<_>, _>>()?,
-            ),
-            ExprKind::SetLit(items) => ExprKind::SetLit(
-                items
-                    .into_iter()
-                    .map(|item| Self::clone_const_body_expr(source_body, item, target_body))
-                    .collect::<Result<Vec<_>, _>>()?,
-            ),
-            ExprKind::TupleLit(items) => ExprKind::TupleLit(
-                items
-                    .into_iter()
-                    .map(|item| Self::clone_const_body_expr(source_body, item, target_body))
-                    .collect::<Result<Vec<_>, _>>()?,
-            ),
-            ExprKind::New { class, args } => ExprKind::New {
-                class,
-                args: args
-                    .into_iter()
-                    .map(|arg| Self::clone_const_body_expr(source_body, arg, target_body))
-                    .collect::<Result<Vec<_>, _>>()?,
-            },
-            ExprKind::Conditional {
-                cond,
-                then_expr,
-                else_expr,
-            } => ExprKind::Conditional {
-                cond: Self::clone_const_body_expr(source_body, cond, target_body)?,
-                then_expr: Self::clone_const_body_expr(source_body, then_expr, target_body)?,
-                else_expr: Self::clone_const_body_expr(source_body, else_expr, target_body)?,
-            },
-            ExprKind::BinOp { op, lhs, rhs } => ExprKind::BinOp {
-                op,
-                lhs: Self::clone_const_body_expr(source_body, lhs, target_body)?,
-                rhs: Self::clone_const_body_expr(source_body, rhs, target_body)?,
-            },
-            ExprKind::UnaryOp { op, operand } => ExprKind::UnaryOp {
-                op,
-                operand: Self::clone_const_body_expr(source_body, operand, target_body)?,
-            },
-            _ => {
-                return Err(SmeltError::unsupported(
-                    expr.span,
-                    "const item expression shape is not supported for inlining yet",
-                ));
-            }
-        };
+        if matches!(expr.kind, ExprKind::Local(_) | ExprKind::Block(_)) {
+            return Err(SmeltError::unsupported(
+                expr.span,
+                "const item expression references body-local state that cannot be inlined",
+            ));
+        }
+        let kind = expr.kind.try_map_child_exprs(&mut |child| {
+            Self::clone_const_body_expr(source_body, child, target_body)
+        })?;
         Ok(target_body.push_expr(Expr {
             kind,
             ty: expr.ty,

--- a/crates/smelt-frontend-ts/src/tests/part01_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part01_tests.rs
@@ -652,6 +652,135 @@ export function firstSeparator(): string {
     Ok(())
 }
 
+/// An imported const whose initializer uses an array spread (es-toolkit's
+/// `arrayViews = [...typedArrays, 'DataView']` shape) inlines its computed
+/// `ListConcat` expression into the importing function body instead of
+/// erroring as an unsupported const item expression shape.
+#[test]
+fn imported_const_with_array_spread_initializer_inlines() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_path_ok(
+        ts!(r#"
+export const typedNames = ["Float32Array", "Int8Array", "Uint8Array"];
+export const viewNames = [...typedNames, "DataView"];
+"#),
+        "src/constants.ts",
+        &mut ctx,
+    )?;
+    let module_id = lower_path_ok(
+        ts!(r#"
+import { viewNames } from "./constants";
+
+export function viewCount(): number {
+  const names = viewNames;
+  return names.length;
+}
+"#),
+        "src/views.ts",
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = function_item(&ctx, module, 0)?;
+    let body = function_body(&ctx, function)?;
+    ensure!(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(&expr.kind, ExprKind::ListConcat { .. })),
+        "expected the imported spread const to inline its ListConcat expression"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+/// An imported const whose initializer is a method-call chain (es-toolkit's
+/// `empties = [[], {}].concat(falsey.slice(1))` shape) inlines the computed
+/// `ListConcat`/`ListSlice` expressions into the importing function body.
+#[test]
+fn imported_const_with_method_chain_initializer_inlines() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_path_ok(
+        ts!(r#"
+export const smallNumbers = [0, 1].concat([2, 3, 4].slice(1));
+"#),
+        "src/constants.ts",
+        &mut ctx,
+    )?;
+    let module_id = lower_path_ok(
+        ts!(r#"
+import { smallNumbers } from "./constants";
+
+export function numberCount(): number {
+  const values = smallNumbers;
+  return values.length;
+}
+"#),
+        "src/numbers.ts",
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = function_item(&ctx, module, 0)?;
+    let body = function_body(&ctx, function)?;
+    ensure!(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(&expr.kind, ExprKind::ListConcat { .. })),
+        "expected the imported concat const to inline its ListConcat expression"
+    );
+    ensure!(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(&expr.kind, ExprKind::ListSlice { .. })),
+        "expected the imported concat const to inline its ListSlice argument"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+/// An imported const whose initializer is a callback chain (es-toolkit's
+/// `whitespace = [...].filter(chr => /\s/.exec(chr)).join('')` shape) inlines
+/// the computed `ListCallback`/`StringJoin` expressions, cloning the closure
+/// callback reference into the importing function body.
+#[test]
+fn imported_const_with_callback_chain_initializer_inlines() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_path_ok(
+        ts!(r#"
+export const whitespace = [" ", "\t", "a"].filter(chr => /\s/.exec(chr)).join("");
+"#),
+        "src/constants.ts",
+        &mut ctx,
+    )?;
+    let module_id = lower_path_ok(
+        ts!(r#"
+import { whitespace } from "./constants";
+
+export function padded(value: string): string {
+  const pad = whitespace;
+  return pad + value;
+}
+"#),
+        "src/pad.ts",
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = function_item(&ctx, module, 0)?;
+    let body = function_body(&ctx, function)?;
+    ensure!(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(&expr.kind, ExprKind::StringJoin { .. })),
+        "expected the imported callback-chain const to inline its StringJoin expression"
+    );
+    ensure!(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(&expr.kind, ExprKind::ListCallback { .. })),
+        "expected the imported callback-chain const to inline its ListCallback expression"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
 /// A member expression whose root is genuinely undefined still fails rather
 /// than lowering incorrectly.
 ///

--- a/crates/smelt-hir/src/expr/map.rs
+++ b/crates/smelt-hir/src/expr/map.rs
@@ -1,0 +1,711 @@
+//! Structural child-expression remapping for HIR expression kinds.
+//!
+//! [`ExprKind::try_map_child_exprs`] rebuilds an expression kind with every
+//! direct child [`ExprId`] passed through a caller-supplied mapping function.
+//! It exists so passes that copy expressions between bodies (for example
+//! const-item inlining in the frontends) do not need to enumerate every
+//! expression variant themselves: the match below is exhaustive, so adding a
+//! new [`ExprKind`] variant forces this mapper to be updated alongside it.
+//!
+//! The mapper is intentionally shallow. It only rewrites the [`ExprId`]s
+//! stored directly inside one `ExprKind` value; callers drive recursion by
+//! re-invoking the mapper from inside their mapping function. Identifiers
+//! that point into crate-global arenas ([`crate::ids::BodyId`],
+//! [`crate::ids::ItemId`], [`crate::ids::TypeId`], [`crate::ids::Symbol`])
+//! are preserved untouched, as are body-local references
+//! ([`crate::ids::LocalId`] in [`ExprKind::Local`] and
+//! [`crate::ids::BlockId`] in [`ExprKind::Block`]) — callers that move
+//! expressions across bodies must decide separately whether those are valid
+//! in the destination body.
+
+use super::kinds::{ExprKind, ListSpliceItem};
+use crate::ids::ExprId;
+
+/// Map every element of a child-expression list through `f`.
+fn map_vec<E>(
+    items: Vec<ExprId>,
+    f: &mut impl FnMut(ExprId) -> Result<ExprId, E>,
+) -> Result<Vec<ExprId>, E> {
+    items.into_iter().map(f).collect()
+}
+
+/// Map an optional child expression through `f`, preserving `None`.
+fn map_opt<E>(
+    item: Option<ExprId>,
+    f: &mut impl FnMut(ExprId) -> Result<ExprId, E>,
+) -> Result<Option<ExprId>, E> {
+    item.map(f).transpose()
+}
+
+impl ExprKind {
+    /// Rebuild this expression kind with each direct child [`ExprId`] mapped
+    /// through `f`, leaving all other payload (operators, symbols, types,
+    /// bodies, blocks, locals) unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error produced by `f`; no partial mapping is
+    /// observable because the kind is rebuilt by value.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "exhaustive match over every ExprKind variant is intentionally one function"
+    )]
+    pub fn try_map_child_exprs<E>(
+        self,
+        f: &mut impl FnMut(ExprId) -> Result<ExprId, E>,
+    ) -> Result<Self, E> {
+        Ok(match self {
+            // Leaf kinds without direct child expression IDs. `Closure` and
+            // `Lambda` reference crate-global bodies; `Local` and `Block`
+            // reference body-local arenas that this shallow mapper preserves.
+            kind @ (Self::Literal(_)
+            | Self::Local(_)
+            | Self::Item(_)
+            | Self::Closure(_)
+            | Self::NumericRandom
+            | Self::DateNow
+            | Self::DateResetNow
+            | Self::DateTimezoneOffset
+            | Self::DateResetTimezoneOffset
+            | Self::Block(_)
+            | Self::Lambda { .. }) => kind,
+            Self::Call { callee, args } => Self::Call {
+                callee: f(callee)?,
+                args: map_vec(args, f)?,
+            },
+            Self::ClosureCall { callee, args } => Self::ClosureCall {
+                callee: f(callee)?,
+                args: map_vec(args, f)?,
+            },
+            Self::ClosureCallSpread { callee, args } => Self::ClosureCallSpread {
+                callee: f(callee)?,
+                args: f(args)?,
+            },
+            Self::Method {
+                receiver,
+                method,
+                args,
+            } => Self::Method {
+                receiver: f(receiver)?,
+                method,
+                args: map_vec(args, f)?,
+            },
+            Self::Field { receiver, field } => Self::Field {
+                receiver: f(receiver)?,
+                field,
+            },
+            Self::OptionalField { receiver, field } => Self::OptionalField {
+                receiver: f(receiver)?,
+                field,
+            },
+            Self::Index { receiver, index } => Self::Index {
+                receiver: f(receiver)?,
+                index: f(index)?,
+            },
+            Self::OptionalIndex { receiver, index } => Self::OptionalIndex {
+                receiver: f(receiver)?,
+                index: f(index)?,
+            },
+            Self::OptionalMethod {
+                receiver,
+                method,
+                args,
+            } => Self::OptionalMethod {
+                receiver: f(receiver)?,
+                method,
+                args: map_vec(args, f)?,
+            },
+            Self::OptionalCoalesce { optional, fallback } => Self::OptionalCoalesce {
+                optional: f(optional)?,
+                fallback: f(fallback)?,
+            },
+            Self::TypeAssert { value } => Self::TypeAssert { value: f(value)? },
+            Self::Len { operand } => Self::Len {
+                operand: f(operand)?,
+            },
+            Self::NumericAbs { operand } => Self::NumericAbs {
+                operand: f(operand)?,
+            },
+            Self::NumericRound { op, operand } => Self::NumericRound {
+                op,
+                operand: f(operand)?,
+            },
+            Self::NumericExtrema { op, args } => Self::NumericExtrema {
+                op,
+                args: map_vec(args, f)?,
+            },
+            Self::NumericHypot { args } => Self::NumericHypot {
+                args: map_vec(args, f)?,
+            },
+            Self::NumericPredicate { op, operand } => Self::NumericPredicate {
+                op,
+                operand: f(operand)?,
+            },
+            Self::NumericUnaryFunc { op, operand } => Self::NumericUnaryFunc {
+                op,
+                operand: f(operand)?,
+            },
+            Self::NumericPow { base, exponent } => Self::NumericPow {
+                base: f(base)?,
+                exponent: f(exponent)?,
+            },
+            Self::NumericAtan2 { y, x } => Self::NumericAtan2 { y: f(y)?, x: f(x)? },
+            Self::NumericRandomInt { start, end } => Self::NumericRandomInt {
+                start: f(start)?,
+                end: f(end)?,
+            },
+            Self::NumericToStringRadix { operand, radix } => Self::NumericToStringRadix {
+                operand: f(operand)?,
+                radix: f(radix)?,
+            },
+            Self::NumericToFixed { operand, digits } => Self::NumericToFixed {
+                operand: f(operand)?,
+                digits: f(digits)?,
+            },
+            Self::ParseIntRadix { operand, radix } => Self::ParseIntRadix {
+                operand: f(operand)?,
+                radix: f(radix)?,
+            },
+            Self::PrimitiveCast { op, operand } => Self::PrimitiveCast {
+                op,
+                operand: f(operand)?,
+            },
+            Self::StringCase { op, operand } => Self::StringCase {
+                op,
+                operand: f(operand)?,
+            },
+            Self::StringNormalize { form, operand } => Self::StringNormalize {
+                form,
+                operand: f(operand)?,
+            },
+            Self::StringTrim { side, operand } => Self::StringTrim {
+                side,
+                operand: f(operand)?,
+            },
+            Self::StringAffix {
+                op,
+                haystack,
+                needle,
+            } => Self::StringAffix {
+                op,
+                haystack: f(haystack)?,
+                needle: f(needle)?,
+            },
+            Self::StringSearch {
+                op,
+                haystack,
+                needle,
+                from_index,
+            } => Self::StringSearch {
+                op,
+                haystack: f(haystack)?,
+                needle: f(needle)?,
+                from_index: map_opt(from_index, f)?,
+            },
+            Self::StringReplace {
+                op,
+                haystack,
+                pattern,
+                replacement,
+            } => Self::StringReplace {
+                op,
+                haystack: f(haystack)?,
+                pattern: f(pattern)?,
+                replacement: f(replacement)?,
+            },
+            Self::StringRemoveAffix {
+                op,
+                haystack,
+                affix,
+            } => Self::StringRemoveAffix {
+                op,
+                haystack: f(haystack)?,
+                affix: f(affix)?,
+            },
+            Self::StringRepeat { operand, count } => Self::StringRepeat {
+                operand: f(operand)?,
+                count: f(count)?,
+            },
+            Self::StringPad {
+                op,
+                operand,
+                target_len,
+                pad,
+            } => Self::StringPad {
+                op,
+                operand: f(operand)?,
+                target_len: f(target_len)?,
+                pad: f(pad)?,
+            },
+            Self::StringPredicate { op, operand } => Self::StringPredicate {
+                op,
+                operand: f(operand)?,
+            },
+            Self::RegexIsMatch {
+                op,
+                pattern,
+                haystack,
+            } => Self::RegexIsMatch {
+                op,
+                pattern: f(pattern)?,
+                haystack: f(haystack)?,
+            },
+            Self::RegexReplace {
+                op,
+                pattern,
+                haystack,
+                replacement,
+            } => Self::RegexReplace {
+                op,
+                pattern: f(pattern)?,
+                haystack: f(haystack)?,
+                replacement: f(replacement)?,
+            },
+            Self::RegexReplaceCallback {
+                op,
+                pattern,
+                haystack,
+                callback,
+            } => Self::RegexReplaceCallback {
+                op,
+                pattern: f(pattern)?,
+                haystack: f(haystack)?,
+                callback: f(callback)?,
+            },
+            Self::RegexReplaceFirstMatchUppercase { pattern, haystack } => {
+                Self::RegexReplaceFirstMatchUppercase {
+                    pattern: f(pattern)?,
+                    haystack: f(haystack)?,
+                }
+            }
+            Self::RegexSplit { pattern, haystack } => Self::RegexSplit {
+                pattern: f(pattern)?,
+                haystack: f(haystack)?,
+            },
+            Self::RegexFind { pattern, haystack } => Self::RegexFind {
+                pattern: f(pattern)?,
+                haystack: f(haystack)?,
+            },
+            Self::RegexExec { regex, haystack } => Self::RegexExec {
+                regex: f(regex)?,
+                haystack: f(haystack)?,
+            },
+            Self::RegexMatchAll { regex, haystack } => Self::RegexMatchAll {
+                regex: f(regex)?,
+                haystack: f(haystack)?,
+            },
+            Self::StringCharAt { operand, index } => Self::StringCharAt {
+                operand: f(operand)?,
+                index: f(index)?,
+            },
+            Self::StringCharCodeAt { operand, index } => Self::StringCharCodeAt {
+                operand: f(operand)?,
+                index: f(index)?,
+            },
+            Self::StringContains {
+                haystack,
+                needle,
+                from_index,
+            } => Self::StringContains {
+                haystack: f(haystack)?,
+                needle: f(needle)?,
+                from_index: map_opt(from_index, f)?,
+            },
+            Self::StringSlice {
+                operand,
+                start,
+                end,
+            } => Self::StringSlice {
+                operand: f(operand)?,
+                start: map_opt(start, f)?,
+                end: map_opt(end, f)?,
+            },
+            Self::ListContains { list, item } => Self::ListContains {
+                list: f(list)?,
+                item: f(item)?,
+            },
+            Self::SetContains { set, item } => Self::SetContains {
+                set: f(set)?,
+                item: f(item)?,
+            },
+            Self::SetDisjoint { left, right } => Self::SetDisjoint {
+                left: f(left)?,
+                right: f(right)?,
+            },
+            Self::SetRelation { op, left, right } => Self::SetRelation {
+                op,
+                left: f(left)?,
+                right: f(right)?,
+            },
+            Self::SetAdd { set, item } => Self::SetAdd {
+                set: f(set)?,
+                item: f(item)?,
+            },
+            Self::SetRemove { op, set, item } => Self::SetRemove {
+                op,
+                set: f(set)?,
+                item: f(item)?,
+            },
+            Self::SetClear { set } => Self::SetClear { set: f(set)? },
+            Self::SetCopy { set } => Self::SetCopy { set: f(set)? },
+            Self::SetBinary { op, left, right } => Self::SetBinary {
+                op,
+                left: f(left)?,
+                right: f(right)?,
+            },
+            Self::SetProjection { op, set } => Self::SetProjection { op, set: f(set)? },
+            Self::ListConcat { left, right } => Self::ListConcat {
+                left: f(left)?,
+                right: f(right)?,
+            },
+            Self::ListSearch {
+                op,
+                list,
+                item,
+                from_index,
+            } => Self::ListSearch {
+                op,
+                list: f(list)?,
+                item: f(item)?,
+                from_index: map_opt(from_index, f)?,
+            },
+            Self::ListCallback { op, list, callback } => Self::ListCallback {
+                op,
+                list: f(list)?,
+                callback: f(callback)?,
+            },
+            Self::ListFromLength { length } => Self::ListFromLength { length: f(length)? },
+            Self::ListRepeat { value, count } => Self::ListRepeat {
+                value: f(value)?,
+                count: f(count)?,
+            },
+            Self::ListFromLengthMap { length, callback } => Self::ListFromLengthMap {
+                length: f(length)?,
+                callback: f(callback)?,
+            },
+            Self::ListReduce {
+                list,
+                initial,
+                callback,
+            } => Self::ListReduce {
+                list: f(list)?,
+                initial: map_opt(initial, f)?,
+                callback: f(callback)?,
+            },
+            Self::ListSlice { list, start, end } => Self::ListSlice {
+                list: f(list)?,
+                start: map_opt(start, f)?,
+                end: map_opt(end, f)?,
+            },
+            Self::ListSplice {
+                list,
+                start,
+                delete_count,
+                items,
+                mutate,
+            } => Self::ListSplice {
+                list: f(list)?,
+                start: f(start)?,
+                delete_count: map_opt(delete_count, f)?,
+                items: items
+                    .into_iter()
+                    .map(|item| {
+                        Ok(ListSpliceItem {
+                            value: f(item.value)?,
+                            spread: item.spread,
+                        })
+                    })
+                    .collect::<Result<Vec<_>, E>>()?,
+                mutate,
+            },
+            Self::ListFill {
+                list,
+                value,
+                start,
+                end,
+            } => Self::ListFill {
+                list: f(list)?,
+                value: f(value)?,
+                start: map_opt(start, f)?,
+                end: map_opt(end, f)?,
+            },
+            Self::ListCopyWithin {
+                list,
+                target,
+                start,
+                end,
+            } => Self::ListCopyWithin {
+                list: f(list)?,
+                target: f(target)?,
+                start: f(start)?,
+                end: map_opt(end, f)?,
+            },
+            Self::ListWith { list, index, value } => Self::ListWith {
+                list: f(list)?,
+                index: f(index)?,
+                value: f(value)?,
+            },
+            Self::ListFlat { list, depth } => Self::ListFlat {
+                list: f(list)?,
+                depth: map_opt(depth, f)?,
+            },
+            Self::ListProjection { op, list } => Self::ListProjection { op, list: f(list)? },
+            Self::ListPush { list, item } => Self::ListPush {
+                list: f(list)?,
+                item: f(item)?,
+            },
+            Self::ListExtend { list, other } => Self::ListExtend {
+                list: f(list)?,
+                other: f(other)?,
+            },
+            Self::ListInsert { list, index, item } => Self::ListInsert {
+                list: f(list)?,
+                index: f(index)?,
+                item: f(item)?,
+            },
+            Self::ListUnshift { list, items } => Self::ListUnshift {
+                list: f(list)?,
+                items: map_vec(items, f)?,
+            },
+            Self::ListReverse { list } => Self::ListReverse { list: f(list)? },
+            Self::ListClear { list } => Self::ListClear { list: f(list)? },
+            Self::ListCopy { list } => Self::ListCopy { list: f(list)? },
+            Self::ListCount { list, item } => Self::ListCount {
+                list: f(list)?,
+                item: f(item)?,
+            },
+            Self::ListSum { list } => Self::ListSum { list: f(list)? },
+            Self::ListBoolFold { op, list } => Self::ListBoolFold { op, list: f(list)? },
+            Self::ListSorted { list, key, reverse } => Self::ListSorted {
+                list: f(list)?,
+                key: map_opt(key, f)?,
+                reverse,
+            },
+            Self::ListReversed { list } => Self::ListReversed { list: f(list)? },
+            Self::ListEnumerate { list } => Self::ListEnumerate { list: f(list)? },
+            Self::ListZip { left, right } => Self::ListZip {
+                left: f(left)?,
+                right: f(right)?,
+            },
+            Self::ListRange { start, end, step } => Self::ListRange {
+                start: f(start)?,
+                end: f(end)?,
+                step: f(step)?,
+            },
+            Self::ListRandomChoice { list } => Self::ListRandomChoice { list: f(list)? },
+            Self::ListIndex { list, item } => Self::ListIndex {
+                list: f(list)?,
+                item: f(item)?,
+            },
+            Self::ListRemove { list, item } => Self::ListRemove {
+                list: f(list)?,
+                item: f(item)?,
+            },
+            Self::ListSort {
+                list,
+                comparator,
+                key,
+                reverse,
+            } => Self::ListSort {
+                list: f(list)?,
+                comparator: map_opt(comparator, f)?,
+                key: map_opt(key, f)?,
+                reverse,
+            },
+            Self::ListPop { list } => Self::ListPop { list: f(list)? },
+            Self::ListShift { list } => Self::ListShift { list: f(list)? },
+            Self::ListNext { list } => Self::ListNext { list: f(list)? },
+            Self::IteratorDone { result } => Self::IteratorDone { result: f(result)? },
+            Self::IteratorValue { result } => Self::IteratorValue { result: f(result)? },
+            Self::TupleContains { tuple, item } => Self::TupleContains {
+                tuple: f(tuple)?,
+                item: f(item)?,
+            },
+            Self::DictContainsKey { dict, key } => Self::DictContainsKey {
+                dict: f(dict)?,
+                key: f(key)?,
+            },
+            Self::DictSet { dict, key, value } => Self::DictSet {
+                dict: f(dict)?,
+                key: f(key)?,
+                value: f(value)?,
+            },
+            Self::DictRemoveKey { dict, key } => Self::DictRemoveKey {
+                dict: f(dict)?,
+                key: f(key)?,
+            },
+            Self::DictGet { dict, key, default } => Self::DictGet {
+                dict: f(dict)?,
+                key: f(key)?,
+                default: map_opt(default, f)?,
+            },
+            Self::DictSetDefault { dict, key, default } => Self::DictSetDefault {
+                dict: f(dict)?,
+                key: f(key)?,
+                default: f(default)?,
+            },
+            Self::DictClear { dict } => Self::DictClear { dict: f(dict)? },
+            Self::DictPop { dict, key, default } => Self::DictPop {
+                dict: f(dict)?,
+                key: f(key)?,
+                default: map_opt(default, f)?,
+            },
+            Self::DictUpdate { dict, other } => Self::DictUpdate {
+                dict: f(dict)?,
+                other: f(other)?,
+            },
+            Self::DictAssign { target, sources } => Self::DictAssign {
+                target: f(target)?,
+                sources: map_vec(sources, f)?,
+            },
+            Self::CallableObjectAssign { callable, props } => Self::CallableObjectAssign {
+                callable: f(callable)?,
+                props: props
+                    .into_iter()
+                    .map(|(name, value)| Ok((name, f(value)?)))
+                    .collect::<Result<Vec<_>, E>>()?,
+            },
+            Self::DictCopy { dict } => Self::DictCopy { dict: f(dict)? },
+            Self::DictProjection { op, dict } => Self::DictProjection { op, dict: f(dict)? },
+            Self::StringSplit {
+                haystack,
+                separator,
+                limit,
+            } => Self::StringSplit {
+                haystack: f(haystack)?,
+                separator: f(separator)?,
+                limit: map_opt(limit, f)?,
+            },
+            Self::StringChars { haystack } => Self::StringChars {
+                haystack: f(haystack)?,
+            },
+            Self::StringJoin { items, separator } => Self::StringJoin {
+                items: f(items)?,
+                separator: f(separator)?,
+            },
+            Self::JsonStringify { value } => Self::JsonStringify { value: f(value)? },
+            Self::JsonParse { text } => Self::JsonParse { text: f(text)? },
+            Self::HttpGetText { url } => Self::HttpGetText { url: f(url)? },
+            Self::DateSetNow { timestamp } => Self::DateSetNow {
+                timestamp: f(timestamp)?,
+            },
+            Self::DateSetTimezoneOffset { offset } => Self::DateSetTimezoneOffset {
+                offset: f(offset)?,
+            },
+            Self::DateTimezoneContext { timezone } => Self::DateTimezoneContext {
+                timezone: f(timezone)?,
+            },
+            Self::DateToIsoString { timestamp_ms } => Self::DateToIsoString {
+                timestamp_ms: f(timestamp_ms)?,
+            },
+            Self::DateToString { timestamp_ms } => Self::DateToString {
+                timestamp_ms: f(timestamp_ms)?,
+            },
+            Self::DateFromParts { parts } => Self::DateFromParts {
+                parts: map_vec(parts, f)?,
+            },
+            Self::DateFromValue { value } => Self::DateFromValue { value: f(value)? },
+            Self::DateGetPart { part, timestamp_ms } => Self::DateGetPart {
+                part,
+                timestamp_ms: f(timestamp_ms)?,
+            },
+            Self::DateSetPart {
+                part,
+                timestamp_ms,
+                values,
+            } => Self::DateSetPart {
+                part,
+                timestamp_ms: f(timestamp_ms)?,
+                values: map_vec(values, f)?,
+            },
+            Self::UrlField { field, url } => Self::UrlField { field, url: f(url)? },
+            Self::FileReadText { path } => Self::FileReadText { path: f(path)? },
+            Self::FileWriteText { path, text } => Self::FileWriteText {
+                path: f(path)?,
+                text: f(text)?,
+            },
+            Self::BlobFromParts {
+                parts,
+                blob_type,
+                name,
+                last_modified,
+            } => Self::BlobFromParts {
+                parts: f(parts)?,
+                blob_type: f(blob_type)?,
+                name: map_opt(name, f)?,
+                last_modified: map_opt(last_modified, f)?,
+            },
+            Self::BinOp { op, lhs, rhs } => Self::BinOp {
+                op,
+                lhs: f(lhs)?,
+                rhs: f(rhs)?,
+            },
+            Self::UnaryOp { op, operand } => Self::UnaryOp {
+                op,
+                operand: f(operand)?,
+            },
+            Self::Conditional {
+                cond,
+                then_expr,
+                else_expr,
+            } => Self::Conditional {
+                cond: f(cond)?,
+                then_expr: f(then_expr)?,
+                else_expr: f(else_expr)?,
+            },
+            Self::FunctionTableLookup { key, cases } => Self::FunctionTableLookup {
+                key: f(key)?,
+                cases: cases
+                    .into_iter()
+                    .map(|(name, value)| Ok((name, f(value)?)))
+                    .collect::<Result<Vec<_>, E>>()?,
+            },
+            Self::InstanceOf { value, class } => Self::InstanceOf {
+                value: f(value)?,
+                class,
+            },
+            Self::UnknownIs { value, kind } => Self::UnknownIs {
+                value: f(value)?,
+                kind,
+            },
+            Self::TypeofValue { value } => Self::TypeofValue { value: f(value)? },
+            Self::PrototypeSentinel { value } => Self::PrototypeSentinel { value: f(value)? },
+            Self::UnknownCast { value, target } => Self::UnknownCast {
+                value: f(value)?,
+                target,
+            },
+            Self::ListLit(items) => Self::ListLit(map_vec(items, f)?),
+            Self::SetLit(items) => Self::SetLit(map_vec(items, f)?),
+            Self::ListToSet { list } => Self::ListToSet { list: f(list)? },
+            Self::ListPairsToDict { list } => Self::ListPairsToDict { list: f(list)? },
+            Self::DictLit(entries) => Self::DictLit(
+                entries
+                    .into_iter()
+                    .map(|(key, value)| Ok((f(key)?, f(value)?)))
+                    .collect::<Result<Vec<_>, E>>()?,
+            ),
+            Self::TupleLit(items) => Self::TupleLit(map_vec(items, f)?),
+            Self::TupleToList { tuple } => Self::TupleToList { tuple: f(tuple)? },
+            Self::ListToTuple { list } => Self::ListToTuple { list: f(list)? },
+            Self::TupleToSet { tuple } => Self::TupleToSet { tuple: f(tuple)? },
+            Self::TupleIndex { tuple, index } => Self::TupleIndex {
+                tuple: f(tuple)?,
+                index,
+            },
+            Self::TupleSlice { tuple, start, end } => Self::TupleSlice {
+                tuple: f(tuple)?,
+                start,
+                end,
+            },
+            Self::New { class, args } => Self::New {
+                class,
+                args: map_vec(args, f)?,
+            },
+            Self::Await(value) => Self::Await(f(value)?),
+            Self::AsyncOp { op, args } => Self::AsyncOp {
+                op,
+                args: map_vec(args, f)?,
+            },
+        })
+    }
+}

--- a/crates/smelt-hir/src/expr/mod.rs
+++ b/crates/smelt-hir/src/expr/mod.rs
@@ -6,6 +6,8 @@ mod core;
 /// Split expression kind variants.
 mod kinds;
 mod literals;
+/// Structural child-expression remapping over `ExprKind`.
+mod map;
 mod ops;
 mod types;
 


### PR DESCRIPTION
## Summary

Eliminates the `const item expression shape is not supported for inlining yet` blocker family (29 es-toolkit files; the whole-crate build abort at `isEqualWith.spec.ts`).

- Replaces the hand-maintained ~20-variant whitelist in `clone_const_body_expr` with a new exhaustive `ExprKind::try_map_child_exprs` structural remapper (`crates/smelt-hir/src/expr/map.rs`, no wildcard arm — new `ExprKind` variants force a compile-time decision). Only genuinely body-local shapes (`Local`, `Block`) remain rejected, with a precise diagnostic.
- Secondary fix surfaced by verification: array-spread literals now unify their item type from lowered pieces instead of blanket `List<Unknown>` — previously the mismatch made codegen silently emit an empty `SmeltList::default()`. Net `SmeltUnknown` usage decreases.

## Verification

- `cargo check --workspace`, clippy on touched crates, `cargo test --workspace --exclude smelt-gui` all green; 5 new regression tests.
- Fixture with all three es-toolkit const shapes passes `smelt build` + generated `cargo test` end to end.
- Family gone from all 29 affected files; 16 lower fully clean. Whole-crate abort advances to the next pre-existing family (`globalThis[type]` computed access, then `Proxy`).
- Details in `blocker-logs/estk-const-item-inlining.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_