### PR TITLE
feat(frontend-ts): adapt named-callback arity at array-callback call sites

### DIFF
--- a/blocker-logs/estk-callback-arity.md
+++ b/blocker-logs/estk-callback-arity.md
@@ -1,0 +1,107 @@
+# es-toolkit blocker family: `array callback callback item parameter count is not supported`
+
+## Failure family
+
+Largest es-toolkit lowering blocker family (30 spec files at pinned ref
+`e008a2818cd8`): passing a *named* function as an array callback aborted
+lowering whenever the function's declared parameter count did not fit the
+receiver's supplied `(value, index, array)` triple.
+
+Two concrete shapes:
+
+1. **Zero-parameter named callbacks** (the dominant shape): lodash-style stubs
+   passed to `map`/`filter`/`forEach` — `values.map(stubTrue)`,
+   `falsey.map(stubArray)`, `values.map(noop)`, `expected = values.map(stubZero)`.
+   Every one of the 30 affected files uses this shape.
+2. **Over-arity named callbacks**: a function declaring *more* parameters than
+   the receiver supplies, with an optional tail —
+   `[[2,1,3],[3,2,1]].map(orderBy)` where compat `orderBy` declares
+   `(collection, criteria?, orders?, guard?)` (4 > 3).
+
+## Root cause
+
+`ModuleBuilder::callback_argument` (crates/smelt-frontend-ts/src/lowering/callbacks/dispatch.rs)
+rejected any item callback with `params.is_empty() || params.len() > expected_param_tys.len()`.
+The compact predicate path (`named_callback_reference` in
+crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs) had the equivalent
+`function_params_len < expected_param_tys.len().min(1)` guard, and the local
+callback branch rejected `callback.params.is_empty()` too.
+
+On the codegen side, `list_callback_iteration_parts`
+(crates/smelt-codegen-rust/src/emitter/list_query.rs) *required* an item
+parameter, and four `function_ty.params.is_empty()` guards short-circuited to a
+silently wrong `Default::default()` placeholder, so the frontend restriction was
+also masking a codegen gap.
+
+## General rule implemented
+
+JavaScript adapts callback arity at the call site; the lowering now mirrors
+that as one general rule (no per-function special cases):
+
+- **Fewer declared parameters than supplied (including zero)**: the callback
+  ignores the extra arguments. The item wrapper closure
+  (`item_function_closure_expression`) is built at the item's own arity and the
+  list-callback emitter now passes exactly the arguments the closure declares —
+  down to a zero-argument `(smelt_callback)()` call. The compact predicate path
+  builds the zero-argument `Call` naturally once the guard is removed. The same
+  rule applies to zero-parameter local callback bindings.
+- **More declared parameters than supplied**: the unsupplied tail is
+  `undefined` in JavaScript (and must be optional for the source to typecheck).
+  A new `item_function_closure_expression_with_max_params` wraps the item
+  capped at the receiver's supplied arity; the wrapper calls the item with the
+  supplied prefix and the existing call-lowering pads the optional tail with
+  its default (`None`), which is exactly the JS `undefined` tail
+  (`with_tail(a, b, c, None::<f64>)` in generated Rust). Truncated wrappers are
+  not tagged with `function_item` so they never alias the full-arity per-item
+  wrapper cache used for `===` reference identity.
+
+Codegen: the four `Default::default()` placeholder guards in
+`list_query.rs` were removed and `list_callback_iteration_parts` now treats the
+item parameter as optional, emitting real iteration for zero-parameter
+callbacks.
+
+No `SmeltUnknown` was introduced or expanded.
+
+## Arity shapes fixed vs deferred
+
+Fixed:
+- zero-parameter named item callbacks in every array-callback position
+  (`map`, `flatMap`, `forEach`, `filter`, `find*`, `some`, `every`);
+- zero-parameter local callback bindings (`const stub = () => 42; xs.map(stub)`);
+- named item callbacks declaring more parameters than supplied with an
+  optional tail (`xs.map(orderBy)`), padded with defaults per parameter type.
+
+Deferred:
+- *local* callback literals declaring more parameters than the receiver
+  supplies still error (`local callback parameter count is not supported`):
+  the compact callback IR would need `undefined` bindings for the dropped
+  parameter names. Not observed in the es-toolkit corpus.
+- over-arity padding uses each parameter type's default value; for a
+  non-optional concrete tail parameter (invalid TS at such a call site,
+  rejected by `tsc` upstream) this would diverge from `undefined`.
+
+## Verification
+
+- Fixture project (source + spec + Smelt.toml modeled on the es-toolkit
+  probe) covering all fixed shapes: `smelt build` succeeds and the generated
+  crate's `cargo test` passes 7/7 end to end, including
+  `values.map(sumWithTail)` proving the `None` tail padding at runtime.
+- Compiler regression tests added:
+  `crates/smelt-frontend-ts/src/tests/part07_tests.rs` (4 tests) and
+  `crates/smelt-codegen-rust/src/tests/part_7_tests.rs` (3 tests).
+- `cargo check --workspace` clean; `cargo clippy -p smelt-frontend-ts
+  -p smelt-codegen-rust` clean; `cargo test --workspace --exclude smelt-gui`
+  green.
+- Per-file `smelt dump-hir` re-scan of all 30 affected es-toolkit files: the
+  family diagnostic is gone from **all 30**. 27 files now lower with no
+  diagnostics at all; 3 files surface pre-existing unrelated diagnostics:
+  - `src/compat/predicate/isMatch.spec.ts`,
+    `src/compat/predicate/matches.spec.ts`:
+    `const item expression shape is not supported for inlining yet`
+  - `src/compat/predicate/matchesProperty.spec.ts`:
+    `function parameters must have explicit type annotations or default initializers`
+- Whole-project `smelt build` abort point: unchanged before/after at
+  `src/predicate/isEqualWith.spec.ts`
+  (`const item expression shape is not supported for inlining yet`, a separate
+  family owned by other work), as expected — this change's metric is the
+  per-file scan above.

--- a/crates/smelt-codegen-rust/src/emitter/list_query.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_query.rs
@@ -144,9 +144,6 @@ impl FunctionEmitter<'_> {
         else {
             return Ok("Default::default()".to_owned());
         };
-        if function_ty.params.is_empty() {
-            return Ok("Default::default()".to_owned());
-        }
         if self.mir.types.get(function_ty.return_ty) != Some(&Type::Bool) {
             return Err(EmitError::new(
                 "array predicate callback must return boolean",
@@ -245,9 +242,6 @@ impl FunctionEmitter<'_> {
         else {
             return Ok("Default::default()".to_owned());
         };
-        if function_ty.params.is_empty() {
-            return Ok("Default::default()".to_owned());
-        }
         let closure_text = match self.closure_operand_text_for_declared_type(callback) {
             Ok(closure_text) => closure_text,
             Err(_) => self.operand_text(callback)?,
@@ -287,9 +281,6 @@ impl FunctionEmitter<'_> {
         else {
             return Ok("Default::default()".to_owned());
         };
-        if function_ty.params.is_empty() {
-            return Ok("Default::default()".to_owned());
-        }
         let closure_text = match self.closure_operand_text_for_declared_type(callback) {
             Ok(closure_text) => closure_text,
             Err(_) => self.operand_text(callback)?,
@@ -320,9 +311,6 @@ impl FunctionEmitter<'_> {
         else {
             return Ok("Default::default()".to_owned());
         };
-        if function_ty.params.is_empty() {
-            return Ok("Default::default()".to_owned());
-        }
         let closure_text = match self.closure_operand_text_for_declared_type(callback) {
             Ok(closure_text) => closure_text,
             Err(_) => self.operand_text(callback)?,
@@ -371,16 +359,17 @@ impl FunctionEmitter<'_> {
         _callback: &Operand,
         function_ty: &FunctionType,
     ) -> Result<ListCallbackIterationParts, EmitError> {
-        let Some(item_param_ty) = function_ty.params.first().copied() else {
-            return Err(EmitError::new("array callback must have an item parameter"));
-        };
         let owned_list_text = self.operand_text(list)?;
         let borrowed_list_text = match list {
             Operand::Copy(place) | Operand::Move(place) => self.place_text(place)?,
             Operand::Const(_) => owned_list_text.clone(),
         };
-        let item_text = self.value_at_type_text("item.clone()", element_ty, item_param_ty)?;
-        let mut call_args = vec![item_text];
+        // A zero-parameter callback (`values.map(stubTrue)`) ignores every
+        // supplied argument, so it is called with no arguments at all.
+        let mut call_args = Vec::new();
+        if let Some(item_param_ty) = function_ty.params.first().copied() {
+            call_args.push(self.value_at_type_text("item.clone()", element_ty, item_param_ty)?);
+        }
         if let Some(index_param_ty) = function_ty.params.get(1).copied() {
             let index_source_ty = if self.mir.types.get(index_param_ty) == Some(&Type::Int) {
                 self.type_id(Type::Int)?

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -6445,3 +6445,61 @@ export function numberCount(): number {
         "expected the inlined slice argument to emit a skip-based slice: {source}"
     );
 }
+
+/// A zero-parameter named callback (`values.map(stubTrue)`) is called with no
+/// arguments at all — JavaScript ignores the supplied `(value, index, array)`
+/// triple when the callback declares no parameters.
+#[test]
+fn zero_parameter_named_map_callback_calls_with_no_arguments() {
+    let source = source_for(
+        r#"
+function stubTrue(): boolean {
+  return true;
+}
+export function run(values: number[]): boolean[] {
+  return values.map(stubTrue);
+}
+"#,
+    );
+    assert!(source.contains("(smelt_callback)()"), "{source}");
+    assert!(source.contains("fn run("), "{source}");
+}
+
+/// A zero-parameter named predicate emits a real filter over the receiver
+/// instead of the former `Default::default()` placeholder.
+#[test]
+fn zero_parameter_named_filter_callback_emits_real_iteration() {
+    let source = source_for(
+        r#"
+function stubFalse(): boolean {
+  return false;
+}
+export function run(values: number[]): number[] {
+  return values.filter(stubFalse);
+}
+"#,
+    );
+    assert!(source.contains("stub_false()"), "{source}");
+    assert!(source.contains(".iter().enumerate().filter_map("), "{source}");
+}
+
+/// A named callback declaring more parameters than the receiver supplies is
+/// wrapped at the supplied arity; the item call pads the unsupplied optional
+/// tail with its default (`None`), matching the JavaScript `undefined` tail.
+#[test]
+fn over_arity_named_map_callback_pads_optional_tail_with_none() {
+    let source = source_for(
+        r#"
+function withTail(value: number, index?: number, list?: number[], guard?: number): number {
+  return value + (guard ?? 0);
+}
+export function run(values: number[]): number[] {
+  return values.map(withTail);
+}
+"#,
+    );
+    assert!(
+        source.contains("with_tail(closure_arg_0.clone(), closure_arg_1.clone(), closure_arg_2.clone(), None::<f64>)"),
+        "{source}"
+    );
+}

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs
@@ -563,12 +563,10 @@ impl ModuleBuilder<'_> {
             let function_params_len = function.params.len();
             let function_return_ty = function.return_ty;
             let function_ty = self.item_expr_type(item, span)?;
-            if function_params_len < expected_param_tys.len().min(1) {
-                return Err(SmeltError::unsupported(
-                    span,
-                    "array callback function reference has too few parameters",
-                ));
-            }
+            // JavaScript ignores callback arguments beyond the declared
+            // parameters, so a reference declaring fewer parameters than the
+            // receiver supplies — down to zero (`values.filter(stubTrue)`) —
+            // is called with just its declared prefix.
             let args = expected_param_tys
                 .iter()
                 .copied()
@@ -596,12 +594,9 @@ impl ModuleBuilder<'_> {
         if let Some(local) = self.locals.get(name).copied() {
             let local_ty = Self::local_ty(body, local);
             if let Some(Type::Function(function)) = self.ctx.krate.types.get(local_ty).cloned() {
-                if function.params.len() < expected_param_tys.len().min(1) {
-                    return Err(SmeltError::unsupported(
-                        self.span(start, end),
-                        "array callback function reference has too few parameters",
-                    ));
-                }
+                // Same arity rule as item references above: fewer declared
+                // parameters (including zero) ignore the extra supplied
+                // arguments.
                 let args = expected_param_tys
                     .iter()
                     .copied()

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/dispatch.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/dispatch.rs
@@ -47,15 +47,18 @@ impl ModuleBuilder<'_> {
                         ),
                     ));
                 };
-                if function.params.is_empty() || function.params.len() > expected_param_tys.len() {
-                    return Err(SmeltError::unsupported(
-                        span,
-                        format!("{context} callback item parameter count is not supported"),
-                    ));
-                }
+                // JavaScript adapts callback arity at the call site: an item
+                // declaring fewer parameters than the receiver supplies (down
+                // to zero, e.g. `values.map(stubTrue)`) ignores the extra
+                // arguments, and one declaring more (e.g. `xs.map(orderBy)`
+                // with a four-parameter `orderBy`) receives `undefined` for the
+                // unsupplied optional tail. Wrap the item capped at the
+                // receiver's supplied arity so the generated closure matches
+                // what the callback caller actually passes.
                 let return_ty = function.return_ty;
-                let expr = self.item_function_closure_expression(
+                let expr = self.item_function_closure_expression_with_max_params(
                     item,
+                    expected_param_tys.len(),
                     identifier.span.start,
                     identifier.span.end,
                     body,
@@ -163,7 +166,12 @@ impl ModuleBuilder<'_> {
                     ),
                 ));
             };
-            if callback.params.is_empty() || callback.params.len() > expected_param_tys.len() {
+            // A local callback declaring fewer parameters than the receiver
+            // supplies (including zero) is valid JavaScript — the extra
+            // arguments are simply ignored — so only reject the shape the
+            // compact callback IR cannot express: a body that references more
+            // parameters than the receiver will ever pass.
+            if callback.params.len() > expected_param_tys.len() {
                 return Err(SmeltError::unsupported(
                     self.span(identifier.span.start, identifier.span.end),
                     format!("{context} local callback parameter count is not supported"),

--- a/crates/smelt-frontend-ts/src/lowering/expr/references.rs
+++ b/crates/smelt-frontend-ts/src/lowering/expr/references.rs
@@ -888,6 +888,29 @@ impl ModuleBuilder<'_> {
         end: u32,
         outer_body: &mut Body,
     ) -> Result<smelt_hir::ExprId, SmeltError> {
+        self.item_function_closure_expression_with_max_params(item, usize::MAX, start, end, outer_body)
+    }
+
+    /// Wrap a function item in a closure value capped at a caller-supplied arity.
+    ///
+    /// JavaScript callback call sites adapt arity at runtime: a caller that
+    /// supplies `max_params` arguments simply leaves any further declared
+    /// parameters `undefined`. When the item declares more parameters than the
+    /// call site supplies (`xs.map(orderBy)` supplies 3, `orderBy` declares 4),
+    /// the wrapper closure therefore only declares the supplied arity and calls
+    /// the item with those arguments; the item call pads the remaining
+    /// (optional, per the source type checker) parameters with their defaults
+    /// downstream, matching the JavaScript `undefined` tail. Items declaring
+    /// `max_params` or fewer parameters (including zero) are wrapped at their
+    /// own arity, since callback callers only pass what the closure declares.
+    pub(in crate::lowering) fn item_function_closure_expression_with_max_params(
+        &mut self,
+        item: smelt_hir::ItemId,
+        max_params: usize,
+        start: u32,
+        end: u32,
+        outer_body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
         let Item::Function(function) = self.item_ref(item).clone() else {
             return Err(SmeltError::unsupported(
                 self.span(start, end),
@@ -895,10 +918,12 @@ impl ModuleBuilder<'_> {
             ));
         };
         let span = self.span(start, end);
+        let wrapped_params_len = function.params.len().min(max_params);
+        let truncated = wrapped_params_len < function.params.len();
         let mut closure_body = Body::new(None, span);
         let mut closure_params = Vec::new();
         let mut call_args = Vec::new();
-        for param in &function.params {
+        for param in function.params.iter().take(wrapped_params_len) {
             let local = closure_body.push_local(LocalDecl {
                 name: Some(param.name),
                 ty: param.ty,
@@ -933,11 +958,27 @@ impl ModuleBuilder<'_> {
         });
         closure_body.push_stmt(Stmt::Return(Some(call)));
         let body_id = self.ctx.krate.push_body(closure_body);
+        // A truncated wrapper drops the item's trailing parameters (and any rest
+        // parameter that falls beyond the cap), so its declared surface is the
+        // capped prefix with every remaining parameter required.
+        let rest = function.rest.filter(|index| *index < wrapped_params_len);
+        let required_params = if truncated {
+            function
+                .required_params
+                .map(|required| required.min(wrapped_params_len))
+        } else {
+            function.required_params
+        };
         let closure_ty = self.ctx.krate.types.intern(Type::Function(FunctionType {
-            params: function.params.iter().map(|param| param.ty).collect(),
-            rest: function.rest,
-            required_params: function.required_params,
-                    mutable_params: Vec::new(),
+            params: function
+                .params
+                .iter()
+                .take(wrapped_params_len)
+                .map(|param| param.ty)
+                .collect(),
+            rest,
+            required_params,
+            mutable_params: Vec::new(),
             return_ty: function.return_ty,
             is_async: function.is_async,
             may_throw: false,
@@ -945,15 +986,18 @@ impl ModuleBuilder<'_> {
         Ok(outer_body.push_expr(Expr {
             kind: ExprKind::Closure(smelt_hir::ClosureExpr {
                 params: closure_params,
-                rest: function.rest,
-                required_params: function.required_params,
+                rest,
+                required_params,
                 return_ty: function.return_ty,
                 captures: Vec::new(),
                 body: body_id,
                 // Tag this wrapper with its source function item so codegen caches
                 // one runtime wrapper per item, giving every `func1`-as-value
                 // reference the same JavaScript reference identity under `===`.
-                function_item: Some(item),
+                // Truncated wrappers stay untagged: the per-item wrapper cache is
+                // keyed by item alone, and a capped-arity wrapper must not alias
+                // the full-arity wrapper emitted for ordinary value positions.
+                function_item: if truncated { None } else { Some(item) },
                 span,
             }),
             ty: closure_ty,

--- a/crates/smelt-frontend-ts/src/tests/part07_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part07_tests.rs
@@ -308,3 +308,84 @@ export function dyn(key: string): unknown {
     ensure!(!errors.is_empty());
     Ok(())
 }
+
+#[test]
+fn lowers_zero_parameter_named_function_array_callback() -> Result<(), String> {
+    // JavaScript callbacks adapt arity at the call site: a named function
+    // declaring no parameters (`values.map(stubTrue)`, the lodash-style stub
+    // shape) simply ignores the supplied `(value, index, array)` arguments.
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+function stubTrue(): boolean {
+  return true;
+}
+export function run(values: number[]): boolean[] {
+  return values.map(stubTrue);
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_zero_parameter_named_function_array_predicate() -> Result<(), String> {
+    // The predicate path (`filter`/`some`/`every`) accepts the same
+    // zero-parameter named callback shape as `map`.
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+function stubFalse(): boolean {
+  return false;
+}
+export function run(values: number[]): number[] {
+  return values.filter(stubFalse);
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_zero_parameter_local_arrow_array_callback() -> Result<(), String> {
+    // A zero-parameter *local* callback binding follows the same JavaScript
+    // arity rule as named items: extra supplied arguments are ignored.
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+export function run(values: string[]): number[] {
+  const localStub = () => 42;
+  return values.map(localStub);
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_named_array_callback_with_optional_parameter_tail() -> Result<(), String> {
+    // A named callback declaring *more* parameters than the receiver supplies
+    // (`xs.map(orderBy)` with a four-parameter `orderBy`) receives `undefined`
+    // for the unsupplied optional tail, so the wrapper truncates to the
+    // receiver's supplied arity instead of rejecting the reference.
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+function withTail(value: number, index?: number, list?: number[], guard?: number): number {
+  return value + (guard ?? 0);
+}
+export function run(values: number[]): number[] {
+  return values.map(withTail);
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Eliminates the `array callback callback item parameter count is not supported` blocker family (30 es-toolkit files, the largest family).

- Implements JavaScript callback-arity semantics as a general rule: named callbacks with fewer declared parameters (down to zero) ignore extra supplied arguments; more declared parameters receive `undefined` for the optional tail. New `item_function_closure_expression_with_max_params` caps the item wrapper at the receiver's supplied `(value, index, array)` arity; truncated wrappers stay out of the per-item `===`-identity wrapper cache.
- Codegen now emits real iteration with zero-argument calls instead of masking empty-param callbacks with `Default::default()` placeholders.
- No new `SmeltUnknown`. Deferred (absent from the corpus): local callback literals declaring more params than supplied.

## Verification

- `cargo check --workspace`, clippy on touched crates, `cargo test --workspace --exclude smelt-gui` green; 7 new regression tests (4 frontend, 3 codegen).
- Fixture covering every fixed shape: `smelt build` + generated `cargo test` 7/7.
- Family gone from all 30 files; 27 lower with zero diagnostics (remaining 3 hit unrelated pre-existing families).
- Details in `blocker-logs/estk-callback-arity.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_