### PR TITLE
feat(frontend-ts): honor ts-error suppressions in overload resolution; live toHaveProperty on erased actuals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ blocker-logs/*.md
 !blocker-logs/smelt-unknown-report.md
 # estk-const-item-inlining.md documents the const-item-inlining blocker fix
 !blocker-logs/estk-const-item-inlining.md
+# estk-overload-resolution.md documents the overload-resolution blocker fix
+!blocker-logs/estk-overload-resolution.md
 
 # Generated docs site output
 _site/

--- a/blocker-logs/estk-overload-resolution.md
+++ b/blocker-logs/estk-overload-resolution.md
@@ -1,0 +1,154 @@
+# es-toolkit: function-overload resolution + `toHaveProperty` blockers
+
+Investigation of the `no overload of \`X\` matches this call` family (11
+es-toolkit compat spec files) and the
+`expect(...).toHaveProperty(...) requires an object or map actual value` gap
+(2 files), against es-toolkit pinned at `e008a2818cd8`.
+
+## Root cause of the `args: []` family
+
+Every one of the 11 overload failures — including the plausible-looking ones
+(`clamp` with 1 arg, `inRange(0)`, `fill(array)`, `isMatchWith(a, b)`) — sits
+directly under a `// @ts-expect-error` or `// @ts-ignore` pragma in the spec
+source. The lodash-compat suites deliberately call the helpers with too few or
+mistyped arguments to probe runtime coercion behavior:
+
+```ts
+// @ts-expect-error
+expect(split()).toEqual(['']);          // args: []
+// @ts-expect-error - testing runtime behavior when only one argument is provided
+expect(clamp(5)).toBe(5);               // args: [Float] vs [2,3]-ary overloads
+```
+
+The `args: []` reports were not an argument-collection bug: the calls really
+have zero arguments. `tsc` accepts these files only because the author
+suppressed the checker on that line; Smelt's overload resolver had no notion of
+that suppression (it only recognized `@ts-expect-error` comments carrying the
+literal code `ts2353`) and aborted the whole file — and any one unbuildable
+spec aborts the entire crate build.
+
+## Fix 1: suppressed calls fall back to the implementation signature
+
+`crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs` gains
+`has_ts_error_suppression_before(start)`: a line-precise scan that reports a
+`@ts-expect-error` / `@ts-ignore` pragma on the contiguous comment lines
+directly above the line containing `start` (matching `tsc`'s
+next-line-suppression semantics; the pragma cannot leak past the statement it
+annotates — regression-tested).
+
+`selected_overload_signature`
+(`crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs`) now returns
+`Ok(None)` instead of erroring when no overload matches **and** the call site
+is suppressed. The caller already handles `None` generally: the call lowers
+against the *implementation* signature (the same path used when a sibling in
+the library calls the implementation directly), and the Rust emitter pads
+missing trailing parameters with each parameter's default (`undefined` for
+erased slots, `None` for `Optional<T>`). No per-function logic anywhere.
+
+Semantics note: a missing argument pads faithfully (as JS `undefined`) whenever
+the implementation parameter is erased (`any`/`unknown`) or optional — which
+covers `split()`, `replace()`, `range()`, `rangeRight()`, `fromPairs()`,
+`flatMapDeep(1)`, `invokeMap(1)`, `inRange(0)`, `fill(...)`, `isMatchWith(...)`.
+A missing argument for a *required concrete* slot (es-toolkit compat `clamp`'s
+`bound1: number`) pads with the type default (`0.0`), which can deviate from JS
+`undefined` semantics at runtime; representing `undefined` in a concrete `f64`
+ABI slot would need call-site-driven parameter widening — deferred.
+
+## Fix 2: `None`-collapse tie-break in overload selection (cloneWith)
+
+`cloneWith(args, noop)` mis-selected its first overload: Smelt interns
+TypeScript `void`, `undefined`, and `null` as one `None` type, so matching the
+`noop` callback bound `R := None` and passed the
+`R extends object | string | number | boolean | null` constraint that `tsc`
+fails for `void` (and `object` lowers to `Unknown`, which accepts everything).
+The call's static type collapsed to `None` and the runtime value was erased to
+`()`.
+
+Overload selection now scores candidates by how free their inferences are of
+`None` collapse (`overload_substitution_none_collapse_score`), applied after
+the literal and specificity scores and before declaration order. A candidate
+that absorbs the callback's undefined return through an explicit
+`R | undefined` slot (leaving `R` unbound — `infer_overload_type` deliberately
+binds nothing for `Optional(_) ⊇ None`) mirrors the checker's real selection
+and wins. `cloneWith(args, noop)` now selects the `R | T` overload and keeps
+the argument value. General typing rule; no per-function logic. The full
+frontend suite (796 tests) passes unchanged apart from the new tests.
+
+## Fix 3: `toHaveProperty` over erased class-shaped actuals
+
+`clone(args)` / `cloneWith(args, noop)` produce actuals typed by the ambient
+`IArguments` interface — a `Type::Class` with no local declaration, which is
+represented as a live `SmeltUnknown` at runtime (frontend predicate
+`class_type_erases_to_unknown`, codegen predicate `is_erased_class_type`).
+
+- `crates/smelt-frontend-ts/src/lowering/testing/matchers.rs`
+  (`dict_contains_key_expr`): accepts an actual whose class-shaped type erases
+  to `SmeltUnknown`, alongside the existing `Unknown`/`Union`/`TypeParam`
+  arms; the rejection message now includes the offending actual type.
+- `crates/smelt-codegen-rust/src/emitter/map.rs`
+  (`dict_contains_key_uses_erased_object`): such class types emit the same
+  live-object inspection as `unknown` actuals instead of folding the check to
+  a constant `false`.
+
+Statically primitive actuals are still rejected (regression-tested).
+
+## Verification
+
+- `cargo check --workspace`, `cargo clippy -p smelt-frontend-ts -p
+  smelt-codegen-rust` (pedantic set), `cargo test --workspace --exclude
+  smelt-gui`: green.
+- New regression tests: `part04_tests.rs`
+  (`lowers_suppressed_zero_argument_overload_call_against_implementation`,
+  `lowers_ts_ignore_suppressed_under_applied_overload_call`,
+  `rejects_unsuppressed_overload_call_with_missing_arguments`,
+  `suppression_pragma_does_not_leak_past_intervening_code`,
+  `prefers_undefined_absorbing_overload_for_void_callback`) and
+  `part06_tests.rs` (`lowers_to_have_property_over_erased_class_actual`,
+  `rejects_to_have_property_over_primitive_actual`).
+- Minimal fixture projects (suppressed zero-arg / under-applied / mistyped
+  overload calls; `toHaveProperty` over `IArguments` actuals through generic
+  `clone`/`cloneWith`): `smelt build` succeeds and all generated-crate
+  `cargo test` cases pass, including runtime values (`joinText()` → `'-'`,
+  `scale(5)` → `5`).
+- No new `SmeltUnknown` conversions were introduced: the fallback lowers
+  through concrete implementation types, and the matcher/codegen changes reuse
+  the value's existing erased representation (ambient interop is already a
+  documented dynamic boundary).
+
+### dump-hir on the 13 files (before → after)
+
+| file | before | after |
+| --- | --- | --- |
+| compat/array/fill.spec.ts | no overload of `fill` | `array callback callback item parameter count` (pre-existing, separate family) |
+| compat/array/flatMapDeep.spec.ts | no overload of `flatMapDeep` | clean |
+| compat/array/invokeMap.spec.ts | no overload of `invokeMap` | clean |
+| compat/math/clamp.spec.ts | no overload of `clamp` | clean |
+| compat/math/inRange.spec.ts | no overload of `inRange` | `array callback callback item parameter count` (pre-existing, separate family) |
+| compat/math/range.spec.ts | no overload of `range` | clean |
+| compat/math/rangeRight.spec.ts | no overload of `rangeRight` | clean |
+| compat/object/fromPairs.spec.ts | no overload of `fromPairs` | clean |
+| compat/predicate/isMatchWith.spec.ts | no overload of `isMatchWith` | `array callback callback item parameter count` (pre-existing, separate family) |
+| compat/string/replace.spec.ts | no overload of `replace` | clean |
+| compat/string/split.spec.ts | no overload of `split` | clean |
+| compat/object/clone.spec.ts | toHaveProperty requires object/map | `unresolved identifier \`document\`` (DOM, already excluded in the fixture Smelt.toml) |
+| compat/object/cloneWith.spec.ts | toHaveProperty requires object/map | `unresolved identifier \`document\`` (DOM, already excluded in the fixture Smelt.toml) |
+
+### Whole-crate `smelt build` abort point
+
+Unchanged before vs after: `src/predicate/isEqualWith.spec.ts`
+(`const item expression shape is not supported for inlining yet`) — the
+pre-existing blocker already documented in the fixture `Smelt.toml`; the
+compat specs fixed here are not on the crate's current entry/test graph, so
+the whole-build abort point is governed by that separate family.
+
+## Deferred
+
+- Runtime `undefined` semantics for suppressed calls that omit a *required
+  concrete-typed* parameter (compat `clamp(5)`): needs undefined-capable ABI
+  slots or call-site-driven widening.
+- The `array callback callback item parameter count` family now surfaced in
+  fill/inRange/isMatchWith (was masked by the earlier abort) — separate
+  investigation.
+- The `arguments`-object model carries only `length`; `toHaveProperty('0')`
+  over a real `toArgs([1,2,3])` value lowers and runs but reports the indexed
+  key as absent at runtime.

--- a/crates/smelt-codegen-rust/src/emitter/map.rs
+++ b/crates/smelt-codegen-rust/src/emitter/map.rs
@@ -63,10 +63,16 @@ impl FunctionEmitter<'_> {
 
     /// Return whether a dictionary containment check must inspect an erased
     /// JavaScript object value at runtime.
+    ///
+    /// Class-shaped types without a local declaration (ambient interfaces such
+    /// as `IArguments`) are represented as `SmeltUnknown` at runtime — see
+    /// [`Self::is_erased_class_type`] — so their containment checks go through
+    /// the same live-object inspection as `unknown` values.
     fn dict_contains_key_uses_erased_object(&self, ty: TypeId) -> bool {
         match self.mir.types.get(ty) {
             Some(Type::Unknown | Type::Union(_)) => true,
             Some(Type::TypeParam { name }) => !self.current_function_has_type_param(*name),
+            Some(Type::Class { .. }) => self.is_erased_class_type(ty),
             _ => false,
         }
     }

--- a/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
@@ -1991,7 +1991,11 @@ impl<'builder> ModuleBuilder<'builder> {
             let arg = self.argument(argument, body)?;
             lowered_arg_tys.push(Self::expr_ty(body, arg));
         }
-        let mut selected: Option<(usize, usize, usize, OverloadSignature, HashMap<_, _>)> = None;
+        let mut selected: Option<(
+            (usize, usize, usize, usize),
+            OverloadSignature,
+            HashMap<_, _>,
+        )> = None;
         for (order, signature) in signatures.iter().enumerate() {
             let mut substitutions = HashMap::new();
             let constraint_scope = Self::overload_type_param_constraint_scope(signature);
@@ -2009,21 +2013,27 @@ impl<'builder> ModuleBuilder<'builder> {
                     self.overload_signature_specificity_score(signature, lowered_arg_tys.len());
                 let literal_score =
                     usize::MAX - self.overload_source_arg_mismatch_count(signature, arguments);
+                let none_collapse_score =
+                    self.overload_substitution_none_collapse_score(&substitutions);
                 let candidate = (
-                    score,
-                    literal_score,
-                    usize::MAX - order,
+                    (
+                        literal_score,
+                        score,
+                        none_collapse_score,
+                        usize::MAX - order,
+                    ),
                     signature.clone(),
                     substitutions,
                 );
-                if selected.as_ref().is_none_or(|current| {
-                    (candidate.1, candidate.0, candidate.2) > (current.1, current.0, current.2)
-                }) {
+                if selected
+                    .as_ref()
+                    .is_none_or(|current| candidate.0 > current.0)
+                {
                     selected = Some(candidate);
                 }
             }
         }
-        if let Some((_, _, _, signature, substitutions)) = selected {
+        if let Some((_, signature, substitutions)) = selected {
             return Ok(Some(
                 self.instantiate_overload_signature(signature, &substitutions),
             ));
@@ -2031,11 +2041,21 @@ impl<'builder> ModuleBuilder<'builder> {
         if self.has_ts_expect_error_before(span.start, "ts2353") {
             return Ok(None);
         }
+        // The author explicitly suppressed TypeScript's own rejection of this
+        // call (`@ts-expect-error` / `@ts-ignore` on the preceding line), so no
+        // declared overload *can* describe it — the call is a deliberate
+        // runtime-behavior probe (lodash-compat specs call `range()`,
+        // `clamp(5)`, `fill(1, 'a')`, ... this way). Fall back to the
+        // implementation signature exactly like a sibling implementation call:
+        // the caller lowers the supplied arguments against the implementation
+        // parameter types and missing trailing parameters take their padded
+        // defaults (`undefined` for erased/optional slots).
+        if self.has_ts_error_suppression_before(span.start) {
+            return Ok(None);
+        }
         if self.allow_unknown_index_access {
             let mut loose_selected: Option<(
-                usize,
-                usize,
-                usize,
+                (usize, usize, usize, usize),
                 OverloadSignature,
                 HashMap<_, _>,
             )> = None;
@@ -2061,20 +2081,26 @@ impl<'builder> ModuleBuilder<'builder> {
                     self.overload_signature_specificity_score(signature, lowered_arg_tys.len());
                 let literal_score =
                     usize::MAX - self.overload_source_arg_mismatch_count(signature, arguments);
+                let none_collapse_score =
+                    self.overload_substitution_none_collapse_score(&substitutions);
                 let candidate = (
-                    score,
-                    literal_score,
-                    usize::MAX - order,
+                    (
+                        literal_score,
+                        score,
+                        none_collapse_score,
+                        usize::MAX - order,
+                    ),
                     signature.clone(),
                     substitutions,
                 );
-                if loose_selected.as_ref().is_none_or(|current| {
-                    (candidate.1, candidate.0, candidate.2) > (current.1, current.0, current.2)
-                }) {
+                if loose_selected
+                    .as_ref()
+                    .is_none_or(|current| candidate.0 > current.0)
+                {
                     loose_selected = Some(candidate);
                 }
             }
-            if let Some((_, _, _, signature, substitutions)) = loose_selected {
+            if let Some((_, signature, substitutions)) = loose_selected {
                 return Ok(Some(
                     self.instantiate_overload_signature(signature, &substitutions),
                 ));
@@ -2099,6 +2125,32 @@ impl<'builder> ModuleBuilder<'builder> {
                     .collect::<Vec<_>>()
             ),
         ))
+    }
+
+    /// Score how free a matching overload's inferences are of `undefined` collapse.
+    ///
+    /// Smelt interns TypeScript `void`, `undefined`, and `null` as one `None`
+    /// type, so a candidate can bind a type parameter to `None` (for example
+    /// `R := void` when a `noop` callback argument matches a
+    /// `customizer: (...) => R` parameter) and still pass constraint checks
+    /// that `tsc` would have failed on the distinct `void` type. When another
+    /// candidate matches the same call *without* collapsing any type parameter
+    /// to `None` — its signature absorbs the `undefined` through an explicit
+    /// `R | undefined` or optional slot — that candidate mirrors the checker's
+    /// real selection (e.g. `cloneWith(value, noop)` picks the
+    /// `customizer: (...) => R | undefined` overload returning `R | T`).
+    /// Returns `usize::MAX` minus the number of `None` substitutions so a
+    /// larger score is better; used as a tie-break after literal and
+    /// specificity scores in [`Self::selected_overload_signature`].
+    fn overload_substitution_none_collapse_score(
+        &self,
+        substitutions: &HashMap<smelt_hir::Symbol, smelt_hir::TypeId>,
+    ) -> usize {
+        usize::MAX
+            - substitutions
+                .values()
+                .filter(|ty| matches!(self.ctx.krate.types.get(**ty), Some(Type::None)))
+                .count()
     }
 
     /// Build the active constraint scope needed while matching a stored overload signature.

--- a/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
@@ -1292,6 +1292,42 @@ impl ModuleBuilder<'_> {
         ) && self.has_ts_expect_error_before(start, "ts7053")
     }
 
+    /// Return whether a TypeScript error-suppression pragma covers this position.
+    ///
+    /// `tsc` suppresses every diagnostic on the line that follows a
+    /// `// @ts-expect-error` or `// @ts-ignore` comment, so a call marked this
+    /// way is *intentionally* invalid source: the author is probing runtime
+    /// behavior that the static signature rejects (for example calling an
+    /// overloaded function with too few arguments). Lowering uses this to
+    /// distinguish such deliberate probes from genuine signature mismatches.
+    /// Only the contiguous comment-only lines directly above the line
+    /// containing `start` are inspected, so a pragma cannot leak past the
+    /// statement it annotates onto later code.
+    pub(in crate::lowering) fn has_ts_error_suppression_before(&self, start: u32) -> bool {
+        let Ok(start) = usize::try_from(start) else {
+            return false;
+        };
+        let Some(prefix) = self.source.get(..start) else {
+            return false;
+        };
+        let mut lines = prefix.lines().rev();
+        // Drop the (partial) line that contains `start` itself; the pragma
+        // must sit on a preceding line to apply to this one.
+        let _current_line = lines.next();
+        for line in lines {
+            let trimmed = line.trim_start();
+            let is_comment_line =
+                trimmed.starts_with("//") || trimmed.starts_with("/*") || trimmed.starts_with('*');
+            if !is_comment_line {
+                return false;
+            }
+            if trimmed.contains("@ts-expect-error") || trimmed.contains("@ts-ignore") {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Return whether a nearby preceding comment expects the given TS error code.
     pub(in crate::lowering) fn has_ts_expect_error_before(&self, start: u32, code: &str) -> bool {
         let Ok(start) = usize::try_from(start) else {

--- a/crates/smelt-frontend-ts/src/lowering/testing/matchers.rs
+++ b/crates/smelt-frontend-ts/src/lowering/testing/matchers.rs
@@ -803,7 +803,9 @@ impl ModuleBuilder<'_> {
     ///
     /// A statically-typed record/map (`Type::Dict`) checks key membership
     /// directly and requires the key type to match. An erased actual
-    /// (`Unknown`/`Union`/unconstrained type param) is a runtime JavaScript
+    /// (`Unknown`/`Union`/unconstrained type param, or a class-shaped type
+    /// with no local declaration such as the ambient `IArguments` interface —
+    /// see [`Self::class_type_erases_to_unknown`]) is a runtime JavaScript
     /// value — for example the erased return of an imported helper — so the
     /// emitted `DictContainsKey` inspects the live `SmeltUnknown::Object` at
     /// runtime; the key may be any string-convertible value there, so no
@@ -827,10 +829,14 @@ impl ModuleBuilder<'_> {
                 }
             }
             Some(Type::Unknown | Type::Union(_) | Type::TypeParam { .. }) => {}
+            _ if self.class_type_erases_to_unknown(actual_ty) => {}
             _ => {
                 return Err(SmeltError::unsupported(
                     self.span(span.start, span.end),
-                    "expect(...).toHaveProperty(...) requires an object or map actual value",
+                    format!(
+                        "expect(...).toHaveProperty(...) requires an object or map actual value (actual: {:?})",
+                        self.ctx.krate.types.get(actual_ty)
+                    ),
                 ));
             }
         }

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -8087,3 +8087,178 @@ function useClock(): void {
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
     Ok(())
 }
+
+#[test]
+fn lowers_suppressed_zero_argument_overload_call_against_implementation() -> Result<(), String> {
+    // A `@ts-expect-error` pragma on the preceding line marks the call as
+    // deliberately invalid source (a lodash-compat runtime probe such as
+    // `expect(split())`), so overload resolution falls back to the
+    // implementation signature instead of aborting on the overload table.
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+function joinText(left: string | null | undefined, right?: string): string;
+function joinText(left: string | null | undefined, index: number, guard: object): string;
+function joinText(left?: any, right?: any, sep?: any): string {
+  return `${left ?? ''}${sep ?? '-'}${right ?? ''}`;
+}
+
+function probe(): string {
+  // @ts-expect-error
+  return joinText();
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_ts_ignore_suppressed_under_applied_overload_call() -> Result<(), String> {
+    // `@ts-ignore` also suppresses the checker on the next line (the compat
+    // specs mix both pragmas), so an under-applied call — one argument where
+    // every overload demands at least two — lowers against the implementation
+    // types and keeps the implementation return type.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function scale(value: number, factor: number): number;
+function scale(value: number, factor: number, offset: number): number;
+function scale(value: number, factor?: number, offset?: number): number {
+  if (factor === undefined) {
+    return value;
+  }
+  return value * factor + (offset ?? 0);
+}
+
+function probe(): number {
+  // @ts-ignore - testing runtime behavior when only one argument is provided
+  return scale(5);
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = function_item(&ctx, module, 1)?;
+    ensure!(
+        matches!(ctx.krate.types.get(function.return_ty), Some(Type::Float)),
+        "suppressed under-applied call should keep the implementation return type"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn rejects_unsuppressed_overload_call_with_missing_arguments() -> Result<(), String> {
+    // Without a suppression pragma the overload table stays authoritative: a
+    // zero-argument call over required-parameter overloads must keep failing
+    // so genuine signature mismatches are still surfaced.
+    let mut ctx = HirCtx::new();
+    let errors = lowering_errors(
+        ts!(r#"
+function scale(value: number, factor: number): number;
+function scale(value: number, factor: number, offset: number): number;
+function scale(value: number, factor?: number, offset?: number): number {
+  return value * (factor ?? 1) + (offset ?? 0);
+}
+
+function probe(): number {
+  return scale();
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(
+        errors
+            .iter()
+            .any(|error| error.message.contains("no overload of `scale`")),
+        "unsuppressed overload mismatch should still be rejected"
+    );
+    Ok(())
+}
+
+#[test]
+fn suppression_pragma_does_not_leak_past_intervening_code() -> Result<(), String> {
+    // The pragma applies to the line that follows it; a later statement in
+    // the same block must not inherit the suppression through the 256-byte
+    // window heuristic used for coded `@ts-expect-error` scans.
+    let mut ctx = HirCtx::new();
+    let errors = lowering_errors(
+        ts!(r#"
+function scale(value: number, factor: number): number;
+function scale(value: number, factor: number, offset: number): number;
+function scale(value: number, factor?: number, offset?: number): number {
+  return value * (factor ?? 1) + (offset ?? 0);
+}
+
+function probe(): number {
+  // @ts-expect-error
+  const first = scale();
+  const second = scale();
+  return second;
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(
+        errors
+            .iter()
+            .any(|error| error.message.contains("no overload of `scale`")),
+        "suppression must stop at the line the pragma annotates"
+    );
+    Ok(())
+}
+
+#[test]
+fn prefers_undefined_absorbing_overload_for_void_callback() -> Result<(), String> {
+    // `void`, `undefined`, and `null` intern as one `None` type, so the first
+    // overload can bind `R := None` and slip past a constraint that tsc would
+    // fail for `void`. The candidate that absorbs the callback's undefined
+    // return through an explicit `R | undefined` slot mirrors the checker's
+    // real selection and must win, keeping the value type (`R | T`) instead of
+    // collapsing the call's result to `None`.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+type Customizer<T, R> = (value: T, key: number | string | undefined) => R;
+
+function cloneWith<T, R extends object | string | number | boolean | null>(
+  value: T,
+  customizer: Customizer<T, R>
+): R;
+function cloneWith<T, R>(value: T, customizer: Customizer<T, R | undefined>): R | T;
+function cloneWith<T, R>(value: T, customizer?: Customizer<T, R | undefined>): T | R {
+  return value;
+}
+
+function noop(): void {}
+
+function probe(): unknown {
+  return cloneWith({ a: 1 }, noop);
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = function_item(&ctx, module, 3)?;
+    let body = function_body(&ctx, function)?;
+    let call_types = body
+        .exprs
+        .iter()
+        .filter(|expr| matches!(expr.kind, ExprKind::Call { .. }))
+        .map(|expr| expr.ty)
+        .collect::<Vec<_>>();
+    ensure!(
+        !call_types.is_empty(),
+        "probe should lower the cloneWith call"
+    );
+    ensure!(
+        call_types
+            .iter()
+            .all(|ty| !matches!(ctx.krate.types.get(*ty), Some(Type::None))),
+        "void callback must not collapse the overload result to None"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}

--- a/crates/smelt-frontend-ts/src/tests/part06_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part06_tests.rs
@@ -1186,3 +1186,66 @@ export function useit(): number {
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
     Ok(())
 }
+
+#[test]
+fn lowers_to_have_property_over_erased_class_actual() -> Result<(), String> {
+    // The actual is typed by an ambient class-shaped interface with no local
+    // declaration (`IArguments`), which erases to a runtime `SmeltUnknown`
+    // value; `toHaveProperty` lowers to the same live key-containment check
+    // used for `unknown` actuals.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+import { expect, it } from "vitest";
+
+function toArgs(array: unknown[]): IArguments {
+  return (function (..._: unknown[]) {
+    return arguments;
+  })(...array);
+}
+
+it("has property", () => {
+  const actual = toArgs([1, 2, 3]);
+  expect(actual).toHaveProperty("length");
+});
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = function_item(&ctx, module, 1)?;
+    let body = function_body(&ctx, function)?;
+    ensure!(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::DictContainsKey { .. })),
+        "erased-class actual should lower to a runtime key-containment check"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn rejects_to_have_property_over_primitive_actual() -> Result<(), String> {
+    // A statically primitive actual has no runtime object shape to inspect, so
+    // the matcher must keep rejecting it even though erased class-shaped
+    // actuals are now accepted.
+    let mut ctx = HirCtx::new();
+    let errors = lowering_errors(
+        ts!(r#"
+import { expect, it } from "vitest";
+
+it("has property", () => {
+  const actual = 42;
+  expect(actual).toHaveProperty("length");
+});
+"#),
+        &mut ctx,
+    )?;
+    ensure!(
+        errors.iter().any(|error| error
+            .message
+            .contains("toHaveProperty(...) requires an object or map actual value")),
+        "primitive actual should still be rejected by toHaveProperty"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Eliminates the `no overload of X matches this call` blocker family (11 es-toolkit compat spec files) and the `toHaveProperty requires an object or map actual value` matcher gap (2 files).

- The `args: []` failures were calls under `// @ts-expect-error` / `// @ts-ignore` pragmas — deliberate lodash-compat runtime probes that only pass `tsc` because the author suppressed the checker. New line-precise `has_ts_error_suppression_before` (next-line semantics, cannot leak past the annotated statement); suppressed calls skip overload selection and lower against the implementation signature with padded defaults.
- Genuine matching gap: `void`/`undefined`/`null` intern to one `None` type, letting a candidate bind `R := None` and beat the `R | undefined` overload `tsc` selects. New `overload_substitution_none_collapse_score` tie-break (after literal/specificity, before declaration order).
- `toHaveProperty` now accepts erased-class actuals (ambient `IArguments`) and emits live-object inspection instead of constant `false`; statically-primitive actuals stay rejected. No new `SmeltUnknown` — reuses the value's existing erased representation.

## Verification

- clippy (pedantic) + `cargo test --workspace --exclude smelt-gui` green; 7 new regression tests (suppression, no-leak, unsuppressed-still-rejected, tie-break, matcher accept/reject).
- Two E2E fixtures: `smelt build` + generated `cargo test` green.
- dump-hir: all 13 files clear of the two families; 8 fully clean, rest hit unrelated pre-existing families. Whole-crate abort unchanged (no regression).
- Investigation report committed at `blocker-logs/estk-overload-resolution.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_