### PR TITLE
feat(lowering): close six es-toolkit array/callback lowering gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ blocker-logs/*.md
 !blocker-logs/estk-const-item-inlining.md
 # estk-overload-resolution.md documents the overload-resolution blocker fix
 !blocker-logs/estk-overload-resolution.md
+# estk-array-misc.md documents the array/callback misc blocker fixes
+!blocker-logs/estk-array-misc.md
 
 # Generated docs site output
 _site/

--- a/blocker-logs/estk-array-misc.md
+++ b/blocker-logs/estk-array-misc.md
@@ -1,0 +1,177 @@
+# es-toolkit array/callback misc lowering gaps (`claude/estk-array-misc`)
+
+Investigation and fixes for six small array/callback lowering sub-families
+observed on es-toolkit (pinned `e008a2818cd8`), nine spec files. Each family
+was attributed with `smelt dump-hir`, reproduced in a minimal TS fixture
+project, fixed with a general rule (no per-library special cases), and
+verified end to end (`smelt build` + `cargo test` on the generated crate).
+
+Baseline whole-project first abort (unchanged by this work, different family):
+`src/predicate/isEqualWith.spec.ts` — "const item expression shape is not
+supported for inlining yet".
+
+Stale-binary correction: an earlier draft of this report attributed the root
+abort to "dynamic computed access on the global object requires the runtime
+global object (not yet modeled)". That message came from a stale debug binary
+left in the scratchpad (the on-disk `baseline-abort.txt` / `eqw.err` captures
+reflect it). Re-verified with three freshly compared binaries — the pre-change
+baseline, the prior WIP build, and this finalized `target/debug/smelt` — all
+abort at the identical point on `src/predicate/isEqualWith.spec.ts` with "const
+item expression shape is not supported for inlining yet". The whole-project root
+abort is therefore genuinely IDENTICAL before and after this work, and unrelated
+to the six families fixed here.
+
+## 1. Default `sort()` on union/erased element arrays — FIXED
+
+- Files: `compat/array/shuffle.spec.ts`, `compat/array/sampleSize.spec.ts`,
+  `compat/object/values.spec.ts`, `compat/object/valuesIn.spec.ts`.
+- Diagnostic: `array sort supports boolean, number, and string arrays for now`.
+- Root cause: the mission's guess (comparator support) was already implemented;
+  the actual failures are comparator-**less** `.sort()` calls whose receiver
+  element type is a union (`values(object)` → `string | number`) or an erased
+  indexed-access surface (`shuffle(object)` → `Array<T[keyof T]>` → `unknown`).
+  Both the frontend (`stdlib.rs::list_sort_call`) and the emitter
+  (`list_mutation.rs::list_sort_text`) restricted default sort to scalar
+  elements.
+- Rule implemented: JavaScript's default sort compares the `ToString` coercion
+  of each element. The frontend now accepts `Unknown` and `Union` element
+  types for comparator-less sorts; the emitter sorts them with a stable
+  `sort_by` over the shared JS string-coercion match (factored into
+  `js_string_coercion_match_text`, reused by `string_like_operand_text`).
+  Concrete unions project through `into_smelt_unknown` first. Structured
+  concrete shapes (nested lists/records) stay rejected because their JS
+  `ToString` (`"1,2"` for arrays) is not modeled yet.
+- Known divergence (documented in code): JS hoists `undefined` elements to the
+  end without comparing; the coercion sorts them as the string `"undefined"`.
+- Verification: `sortgen` fixture (mixed `string | number` values sorted as
+  `[2, 'a', 'b']`, plus scalar regression) passes end to end; frontend tests
+  `lowers_default_sort_on_{union,erased}_element_arrays`; codegen test
+  `emits_string_coercion_default_sort_for_union_elements`.
+
+## 2. `concat` widening for non-matching arguments — FIXED
+
+- File: `compat/array/reverse.spec.ts` (`range(n).concat([null as any])`).
+- Diagnostic: `array concat requires an array or element argument matching the
+  receiver`.
+- Root cause: `null as any` lowers to `None`, so the argument is `List<None>`;
+  `list_ops.rs::list_concat_argument` only accepted arguments whose element
+  type matched (or erased into) the receiver's `Float`.
+- Rule implemented: JavaScript `A[].concat(B[])` yields `Array<A | B>`. The
+  concat lowering now widens the result element type using the same
+  unification array literals use (`T`/`null` mixes widen to `Optional<T>`,
+  exactly how `[0, 1, 2, null]` infers), re-typing the accumulated left list
+  so the emitter injects elements at use. Pairs that would only unify by
+  erasing to `unknown` still keep the explicit diagnostic instead of silently
+  introducing a tagged dynamic value (per the SmeltUnknown enforcement rules).
+- Verification: `concatnull` fixture (null appended after `range(3)`, plus
+  plain scalar/array concat regressions) passes end to end; frontend test
+  `concat_widens_element_type_for_null_list_argument` asserts the
+  `List<Optional<Float>>` result type.
+
+## 3. Lodash `[path, srcValue]` array iteratee — FIXED
+
+- File: `compat/function/memoize.spec.ts`.
+- Diagnostic: `array callback methods currently require arrow function
+  callbacks`.
+- Root cause: the mission's guess (function expressions/references) was
+  already supported; the real span is
+  `lodashStable.find(this.__data__, ['key', key])` — the lodash
+  `matchesProperty` array iteratee shorthand, an `ArrayExpression` in callback
+  position that the classifier rejected.
+- Rule implemented: callback classification now lowers a two-element
+  `[stringLiteral, expr]` array argument as the matchesProperty predicate
+  `element[path] === srcValue` (`classify.rs::matches_property_iteratee_callback`).
+  A callable is required in that position for native array methods, so an
+  array literal reaching callback classification can only be this iteratee
+  form; non-literal paths keep the existing diagnostic.
+- Verification: `matchprop` fixture (memoize-style `CustomCache` class using
+  `utils.find(this.__data__, ['key', key])`) passes end to end; frontend test
+  `lowers_matches_property_array_iteratee_callback`.
+
+## 4. `Object` as a callback — FIXED
+
+- File: `compat/math/parseInt.spec.ts` (`['6', '08', '10'].map(Object)`).
+- Diagnostic: `array callback local callback `Object` is not in scope`.
+- Root cause: the builtin-function-as-callback table (`Number`, `Boolean`,
+  `parseInt`, ...) did not model the global `Object` function.
+- Rule implemented: `Object(value)` boxes a primitive into its wrapper object;
+  Smelt does not model wrapper objects separately from their primitive values
+  (a boxed string coerces back to the same string everywhere), so `Object` in
+  callback position lowers as the typed identity closure on the receiver's
+  element type (`dispatch.rs::callback_argument`). This keeps the mapped
+  list's concrete element type (`string[]` stays `string[]`) instead of
+  erasing it, so the follow-up `strings.map(parseInt)` keeps its real parse.
+  Shadowed local/imported `Object` bindings take precedence.
+- Verification: `objcb` fixture (`map(Object)` then a compat-parseInt-shaped
+  helper mapping to `[6, 8, 10]`) passes end to end; frontend test
+  `lowers_object_builtin_as_identity_callback` asserts the mapped list keeps
+  `List<String>`.
+
+## 5. `in` operator inside callback array literals — FIXED
+
+- File: `compat/object/unset.spec.ts`
+  (`props.map(key => { ...; return [unset(object, key), toString(key) in object]; })`).
+- Diagnostic: `callback binary operator is not supported yet`.
+- Root cause: the callback array-literal lowering in `dispatch.rs` had its own
+  restricted per-element `BinaryExpression` arm that called
+  `callback_binary_op` directly, bypassing the full callback expression
+  dispatcher's dedicated `in`/`typeof`/`instanceof`/nullish handling.
+- Rule implemented: the duplicated arm was removed; binary elements now fall
+  through to the general `as_expression → callback_expression` path, so every
+  operator form works inside array literals exactly as in any other callback
+  position. (`callback_binary_op`'s residual diagnostic now names the
+  offending operator.)
+- Verification: `incb` fixture (`keys.map(key => [key !== '', key in object])`
+  with expected truth table, plus a direct `key in object` predicate) passes
+  end to end; frontend test `lowers_in_operator_inside_callback_array_literal`.
+
+## 6. Compound member assignment in callbacks — FIXED
+
+- File: `compat/object/pickBy.spec.ts` (`args => { args[1] += ''; return args; }`).
+- Diagnostic: `callback assignment targets must be captured locals`.
+- Root cause: member-target stores inside the side-effect-free callback
+  expression IR already retried through full closure-body lowering, but only
+  for plain `=`; compound operators (`+=`, ...) fell through to the hard
+  error.
+- Rule implemented: any member-target assignment operator now raises the
+  `callback member assignment needs closure-body lowering` retry signal, and
+  the closure-body path lowers the compound store as a real indexed mutation.
+- Verification: `memberassign` fixture (`row[1] += ''` and a suffix-appending
+  helper asserting the mutated rows) passes end to end; frontend test
+  `compound_member_assignment_in_callback_retries_closure_body`; codegen test
+  `emits_member_store_for_compound_callback_assignment`.
+
+## Remaining diagnostics on the nine files (different families, not in scope)
+
+- `compat/array/shuffle.spec.ts` — clean (lowers fully).
+- `compat/array/reverse.spec.ts` — clean.
+- `compat/math/parseInt.spec.ts` — clean.
+- `compat/object/unset.spec.ts` — clean.
+- `compat/object/pickBy.spec.ts` — clean.
+- `compat/array/sampleSize.spec.ts`, `compat/object/values.spec.ts`,
+  `compat/object/valuesIn.spec.ts` — next blocker is
+  `const item expression shape is not supported for inlining yet` (const-item
+  inlining family, unrelated to the six above).
+- `compat/function/memoize.spec.ts` — next blocker is
+  `this class type is not resolvable yet` (`new ImmutableCache() as this`,
+  polymorphic-this family).
+
+## Whole-project abort point
+
+- Before: aborts at `src/predicate/isEqualWith.spec.ts` ("const item expression
+  shape is not supported for inlining yet").
+- After: identical — same file, same "const item expression shape is not
+  supported for inlining yet" message (that file sorts before the nine fixed
+  files in the build order and belongs to a different family). The nine target
+  files no longer raise any of the six diagnostics above.
+- See the stale-binary correction near the top of this report: the abort is
+  provably unchanged; the previously reported "dynamic computed access on the
+  global object" message was a stale-binary artifact, not a real difference.
+
+## Deferrals
+
+- None of the six sub-families were deferred. Two adjacent gaps observed while
+  fixturing were left out of scope and are noted for follow-up:
+  `js_strict_eq` is not implemented on concrete `SmeltUnion*` enums (field
+  compare on a mixed-type record), and `String.length` comparisons against
+  float literals inside compact callbacks emit an `i64`/`f64` mismatch.

--- a/crates/smelt-codegen-rust/src/emitter/list_mutation.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_mutation.rs
@@ -569,8 +569,25 @@ impl FunctionEmitter<'_> {
             Some(Type::Float) => Ok(format!(
                 "{{ {list_text}.sort_by(|left, right| left.partial_cmp(right).expect(\"list sort incomparable float\")); {result_text} }}"
             )),
+            // Erased and union elements follow JavaScript's default sort:
+            // compare the `ToString` coercion of each element. Concrete unions
+            // project through `into_smelt_unknown` first so the coercion match
+            // sees the erased `SmeltUnknown` shape. Rust's `sort_by` is stable,
+            // so equal-key structured values ("[object Object]") keep their
+            // original order, matching the JS default sort on objects.
+            Some(Type::Unknown | Type::Union(_) | Type::Never) => {
+                let left_key = Self::js_string_coercion_match_text(
+                    &self.erase_concrete_union_text("left.clone()", element_ty),
+                );
+                let right_key = Self::js_string_coercion_match_text(
+                    &self.erase_concrete_union_text("right.clone()", element_ty),
+                );
+                Ok(format!(
+                    "{{ {list_text}.sort_by(|left, right| ({left_key}).cmp(&({right_key}))); {result_text} }}"
+                ))
+            }
             _ => Err(EmitError::new(
-                "list sort supports bool, int, float, and string items",
+                "list sort supports bool, int, float, string, and erased items",
             )),
         }
     }

--- a/crates/smelt-codegen-rust/src/emitter/strings.rs
+++ b/crates/smelt-codegen-rust/src/emitter/strings.rs
@@ -508,6 +508,17 @@ impl FunctionEmitter<'_> {
         Ok(())
     }
 
+    /// Renders the JavaScript `ToString` coercion of an owned erased value.
+    ///
+    /// `scrutinee_text` must be an owned `SmeltUnknown` expression (the match
+    /// arms consume string payloads). The mapping mirrors JS primitive string
+    /// coercion; structured values use the platform object placeholder.
+    pub(super) fn js_string_coercion_match_text(scrutinee_text: &str) -> String {
+        format!(
+            "match {scrutinee_text} {{ SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"undefined\".to_owned(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"[object Object]\".to_owned(), SmeltUnknown::Function(_) => \"function () {{ [native code] }}\".to_owned(), SmeltUnknown::Promise(_) => \"[object Promise]\".to_owned() }}"
+        )
+    }
+
     /// Renders an operand as a Rust `String` expression for string methods.
     ///
     /// Statically known strings are emitted directly. Unknown values use the
@@ -530,9 +541,7 @@ impl FunctionEmitter<'_> {
             Some(Type::Unknown | Type::Union(_) | Type::TypeParam { .. }) => {
                 let text = self
                     .erase_concrete_union_text(&self.operand_text(operand)?, self.operand_ty(operand)?);
-                Ok(format!(
-                    "match {text} {{ SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"undefined\".to_owned(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"[object Object]\".to_owned(), SmeltUnknown::Function(_) => \"function () {{ [native code] }}\".to_owned(), SmeltUnknown::Promise(_) => \"[object Promise]\".to_owned() }}"
-                ))
+                Ok(Self::js_string_coercion_match_text(&text))
             }
             Some(Type::Class { name, .. }) if self.is_regexp_class_symbol(*name)? => {
                 Ok(format!("{}.source.clone()", self.operand_text(operand)?))

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -6503,3 +6503,56 @@ export function run(values: number[]): number[] {
         "{source}"
     );
 }
+
+
+#[test]
+fn emits_string_coercion_default_sort_for_union_elements() {
+    // A comparator-less `sort()` on a union-element list follows JavaScript's
+    // default ordering: elements compare by their `ToString` coercion. The
+    // concrete union projects through `into_smelt_unknown` before the coercion
+    // match, and the sort itself is a stable `sort_by` over the coerced keys.
+    let source = source_for(
+        r#"
+function sortMixed(values: Array<string | number>): Array<string | number> {
+  return values.sort();
+}
+"#,
+    );
+
+    assert!(
+        source.contains(".sort_by(|left, right| (match left.clone().into_smelt_unknown()"),
+        "union default sort should compare erased string coercions\n{source}"
+    );
+    assert!(
+        source.contains("SmeltUnknown::Number(value) => value.to_string()"),
+        "the coercion match should stringify numeric elements\n{source}"
+    );
+}
+
+#[test]
+fn emits_member_store_for_compound_callback_assignment() {
+    // `row[0] += suffix` inside a `.map` callback is a member-target compound
+    // store; the compact callback IR cannot represent it, so the arrow retries
+    // through full closure-body lowering, which emits a real indexed store
+    // instead of silently dropping the mutation (or rejecting the file with
+    // "callback assignment targets must be captured locals").
+    let source = source_for(
+        r#"
+function tag(rows: string[][], suffix: string): string[][] {
+  return rows.map(row => {
+    row[0] += suffix;
+    return row;
+  });
+}
+"#,
+    );
+
+    assert!(
+        source.contains("closure_arg_0[smelt_assign_index] ="),
+        "the compound member assignment should emit an indexed store into the row\n{source}"
+    );
+    assert!(
+        !source.contains("callback assignment targets must be captured locals"),
+        "the member-assignment blocker must be gone\n{source}"
+    );
+}

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs
@@ -514,6 +514,12 @@ impl ModuleBuilder<'_> {
             ) {
                 return Ok(self.opaque_member_callback(expected_param_tys));
             }
+            if let Argument::ArrayExpression(array) = argument
+                && let Some(callback) =
+                    self.matches_property_iteratee_callback(array, expected_param_tys, body)?
+            {
+                return Ok(callback);
+            }
             return Err(SmeltError::unsupported(
                 self.span(argument.span().start, argument.span().end),
                 "array callback methods currently require arrow function callbacks",
@@ -626,6 +632,59 @@ impl ModuleBuilder<'_> {
             return Ok(Some(self.opaque_member_callback(expected_param_tys)));
         }
         Ok(None)
+    }
+
+    /// Lower the lodash array iteratee shorthand `[path, srcValue]` passed as a
+    /// callback (`_.find(list, ['key', key])`).
+    ///
+    /// Lodash-style collection functions accept a two-element array in callback
+    /// position as a `matchesProperty(path, srcValue)` predicate: it returns
+    /// whether `element[path] === srcValue`. A callable is required in the same
+    /// position for native array methods, so an array literal reaching callback
+    /// classification can only be this iteratee form. Only a string-literal
+    /// path is modeled; other shapes return `Ok(None)` so the caller keeps its
+    /// unsupported-callback diagnostic.
+    fn matches_property_iteratee_callback(
+        &mut self,
+        array: &oxc::ast::ast::ArrayExpression<'_>,
+        expected_param_tys: &[smelt_hir::TypeId],
+        body: &Body,
+    ) -> Result<Option<CallbackExpr>, SmeltError> {
+        let [first, second] = array.elements.as_slice() else {
+            return Ok(None);
+        };
+        let oxc::ast::ast::ArrayExpressionElement::StringLiteral(path) = first else {
+            return Ok(None);
+        };
+        let Some(value_expression) = second.as_expression() else {
+            return Ok(None);
+        };
+        let item_ty = expected_param_tys
+            .first()
+            .copied()
+            .unwrap_or_else(|| self.ctx.krate.types.intern(Type::Unknown));
+        let params = HashMap::default();
+        let value = self.callback_expression(value_expression, &params, body)?;
+        let field = self.intern_source_name(path.value.as_str());
+        let bool_ty = self.ctx.krate.types.intern(Type::Bool);
+        let field_ty = self.ctx.krate.types.intern(Type::Unknown);
+        Ok(Some(CallbackExpr {
+            kind: CallbackExprKind::Binary {
+                op: BinOp::JsStrictEq,
+                lhs: Box::new(CallbackExpr {
+                    kind: CallbackExprKind::Field {
+                        receiver: Box::new(CallbackExpr {
+                            kind: CallbackExprKind::Param(0),
+                            ty: item_ty,
+                        }),
+                        field,
+                    },
+                    ty: field_ty,
+                }),
+                rhs: Box::new(value),
+            },
+            ty: bool_ty,
+        }))
     }
 
     /// Lower common lodash/fp predicate factories when they are passed as array callbacks.

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/dispatch.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/dispatch.rs
@@ -65,6 +65,34 @@ impl ModuleBuilder<'_> {
                 )?;
                 return Ok(ClosureCallback { expr, return_ty });
             }
+            // The global `Object` function passed as a callback
+            // (`xs.map(Object)`) boxes each element into its wrapper object.
+            // Smelt does not model wrapper objects separately from their
+            // primitive values — a boxed string coerces back to the same
+            // string everywhere it is used — so the conversion is the identity
+            // on the receiver's element type. Lowering it as a typed identity
+            // closure keeps the mapped list's concrete element type instead of
+            // erasing it.
+            if identifier.name == "Object"
+                && !self.builtin_call_identifier_is_shadowed("Object")
+            {
+                let span = self.span(identifier.span.start, identifier.span.end);
+                let param_ty = expected_param_tys
+                    .first()
+                    .copied()
+                    .unwrap_or_else(|| self.ctx.krate.types.intern(Type::Unknown));
+                let expr = self.builtin_unary_closure_expression(
+                    param_ty,
+                    param_ty,
+                    span,
+                    body,
+                    |value_expr| ExprKind::TypeAssert { value: value_expr },
+                );
+                return Ok(ClosureCallback {
+                    expr,
+                    return_ty: param_ty,
+                });
+            }
             // Recognized global builtin *functions* passed as callbacks
             // (`xs.map(Number)`, `xs.filter(Boolean)`, `xs.map(parseInt)`).
             // Lower them to the same concrete single-argument closures used in
@@ -739,24 +767,13 @@ impl ModuleBuilder<'_> {
                                 ));
                             }
                         }
-                        ArrayExpressionElement::BinaryExpression(binary) => {
-                            let op = self.callback_binary_op(
-                                binary.operator,
-                                binary.span.start,
-                                binary.span.end,
-                            )?;
-                            let lhs = self.callback_expression(&binary.left, params, body)?;
-                            let rhs = self.callback_expression(&binary.right, params, body)?;
-                            let ty = self.binary_result_type(op, lhs.ty, rhs.ty);
-                            CallbackExpr {
-                                kind: CallbackExprKind::Binary {
-                                    op,
-                                    lhs: Box::new(lhs),
-                                    rhs: Box::new(rhs),
-                                },
-                                ty,
-                            }
-                        }
+                        // Binary elements deliberately have no dedicated arm:
+                        // they fall through to the `as_expression` case below so
+                        // the full callback expression dispatcher handles them.
+                        // That keeps operator forms with dedicated lowering —
+                        // `in`, `typeof` comparisons, `instanceof`, nullish
+                        // checks — working inside array literals exactly as
+                        // they do in any other callback position.
                         ArrayExpressionElement::ComputedMemberExpression(member) => {
                             let receiver =
                                 self.callback_expression(&member.object, params, body)?;
@@ -1498,15 +1515,15 @@ impl ModuleBuilder<'_> {
                         &assign.left,
                         AssignmentTarget::StaticMemberExpression(_)
                             | AssignmentTarget::ComputedMemberExpression(_)
-                    ) && assign.operator == AssignmentOperator::Assign
-                    {
-                        // A member-target store (`obj[k] = v` / `obj.k = v`) mutates the
-                        // receiver, but the side-effect-free callback expression IR cannot
-                        // represent the store — only its right-hand value. Bail so the caller
-                        // re-lowers this arrow through full closure-body lowering, which keeps
-                        // the mutation. (Previously the store was silently dropped, leaving
-                        // mutating reducers like `(acc, x) => { acc[x] = x; return acc; }` as
-                        // identity functions.)
+                    ) {
+                        // A member-target store (`obj[k] = v` / `obj.k = v`, including
+                        // compound forms like `args[1] += ''`) mutates the receiver, but
+                        // the side-effect-free callback expression IR cannot represent
+                        // the store — only its right-hand value. Bail so the caller
+                        // re-lowers this arrow through full closure-body lowering, which
+                        // keeps the mutation. (Previously the store was silently dropped,
+                        // leaving mutating reducers like `(acc, x) => { acc[x] = x;
+                        // return acc; }` as identity functions.)
                         return Err(SmeltError::unsupported(
                             self.span(assign.span.start, assign.span.end),
                             "callback member assignment needs closure-body lowering",

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/list_ops.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/list_ops.rs
@@ -65,7 +65,7 @@ impl ModuleBuilder<'_> {
         body: &mut Body,
     ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
         let mut ty = Self::expr_ty(body, left);
-        let item_ty = match self.ctx.krate.types.get(ty).cloned() {
+        let mut item_ty = match self.ctx.krate.types.get(ty).cloned() {
             Some(Type::List(list_item_ty)) => list_item_ty,
             Some(Type::Optional(inner)) => {
                 let Some(Type::List(list_item_ty)) = self.ctx.krate.types.get(inner).cloned()
@@ -134,7 +134,7 @@ impl ModuleBuilder<'_> {
             return Ok(Some(left));
         }
         for right_argument in right_arguments {
-            let right = self.list_concat_argument(
+            let (right, widened_item_ty) = self.list_concat_argument(
                 call,
                 right_argument,
                 ty,
@@ -142,6 +142,23 @@ impl ModuleBuilder<'_> {
                 right_prefers_list,
                 body,
             )?;
+            // JavaScript `concat` widens: `A[].concat(B[])` yields
+            // `Array<A | B>`. When the argument's element type is not
+            // assignable to the receiver's, the result list element widens
+            // (using the same nullable/erased unification as array literals)
+            // and the accumulated left side re-types into the widened list so
+            // the emitter injects each element at use.
+            if let Some(widened) = widened_item_ty
+                && widened != item_ty
+            {
+                item_ty = widened;
+                ty = self.ctx.krate.types.intern(Type::List(item_ty));
+                left = body.push_expr(Expr {
+                    kind: ExprKind::TypeAssert { value: left },
+                    ty,
+                    span: self.span(call.span.start, call.span.end),
+                });
+            }
             left = body.push_expr(Expr {
                 kind: ExprKind::ListConcat { left, right },
                 ty,
@@ -151,12 +168,58 @@ impl ModuleBuilder<'_> {
         Ok(Some(left))
     }
 
+    /// Unify a concat argument element type with the receiver's element type
+    /// the way array-literal inference does, or `None` when the pair has no
+    /// concrete widened shape.
+    ///
+    /// JavaScript `concat` produces `Array<A | B>`; internally a `T`/`null`
+    /// mix widens to `Optional<T>`, matching how `[0, 1, null]` lowers.
+    /// Pairs that would only unify by erasing to `unknown` return `None` so
+    /// the caller keeps its explicit unsupported diagnostic instead of
+    /// silently introducing a tagged dynamic value.
+    fn concat_widened_element_type(
+        &mut self,
+        item_ty: smelt_hir::TypeId,
+        right_ty: smelt_hir::TypeId,
+    ) -> Option<smelt_hir::TypeId> {
+        if right_ty == item_ty {
+            return Some(item_ty);
+        }
+        let none_ty = self.ctx.krate.types.intern(Type::None);
+        if right_ty == none_ty {
+            if matches!(self.ctx.krate.types.get(item_ty), Some(Type::Optional(_))) {
+                return Some(item_ty);
+            }
+            return Some(self.ctx.krate.types.intern(Type::Optional(item_ty)));
+        }
+        if item_ty == none_ty {
+            if matches!(self.ctx.krate.types.get(right_ty), Some(Type::Optional(_))) {
+                return Some(right_ty);
+            }
+            return Some(self.ctx.krate.types.intern(Type::Optional(right_ty)));
+        }
+        if let Some(Type::Optional(inner)) = self.ctx.krate.types.get(item_ty)
+            && *inner == right_ty
+        {
+            return Some(item_ty);
+        }
+        if let Some(Type::Optional(inner)) = self.ctx.krate.types.get(right_ty)
+            && *inner == item_ty
+        {
+            return Some(right_ty);
+        }
+        None
+    }
+
     /// Normalize a single `concat(...)` argument into a list of the receiver's
     /// element type so it can be appended with [`ExprKind::ListConcat`].
     ///
     /// `concat` accepts both arrays (spread) and scalar elements (wrapped into a
     /// singleton list); this picks between the two based on the argument's lowered
     /// type, matching the receiver's element type (`item_ty`) and list type (`ty`).
+    /// When the argument's element type only combines with the receiver's by
+    /// widening (e.g. appending `null` onto `number[]`), the widened element type
+    /// is returned alongside the value so the caller can re-type the result list.
     pub(in crate::lowering) fn list_concat_argument(
         &mut self,
         call: &oxc::ast::ast::CallExpression<'_>,
@@ -165,7 +228,7 @@ impl ModuleBuilder<'_> {
         item_ty: smelt_hir::TypeId,
         right_prefers_list: bool,
         body: &mut Body,
-    ) -> Result<smelt_hir::ExprId, SmeltError> {
+    ) -> Result<(smelt_hir::ExprId, Option<smelt_hir::TypeId>), SmeltError> {
         let mut right = self.argument(right_argument, body)?;
         let right_ty = Self::expr_ty(body, right);
         let right = if right_ty == ty {
@@ -240,12 +303,52 @@ impl ModuleBuilder<'_> {
                 span: self.span(right_argument.span().start, right_argument.span().end),
             })
         } else {
-            return Err(SmeltError::unsupported(
-                self.span(call.span.start, call.span.end),
-                "array concat requires an array or element argument matching the receiver",
-            ));
+            // The argument neither matches the receiver's element type nor is
+            // erased: JavaScript still concatenates by widening the result
+            // element type (`A[].concat(B[])` is `Array<A | B>`). Compute the
+            // widened element shape (a `T`/`null` mix widens to `Optional<T>`
+            // like array literals) and hand it back so the caller re-types the
+            // accumulated result list.
+            let right_element_ty =
+                if let Some(Type::List(right_item_ty)) = self.ctx.krate.types.get(right_ty) {
+                    Some(*right_item_ty)
+                } else {
+                    None
+                };
+            let Some(widened) =
+                self.concat_widened_element_type(item_ty, right_element_ty.unwrap_or(right_ty))
+            else {
+                return Err(SmeltError::unsupported(
+                    self.span(call.span.start, call.span.end),
+                    "array concat requires an array or element argument matching the receiver",
+                ));
+            };
+            let widened_list_ty = self.ctx.krate.types.intern(Type::List(widened));
+            let span = self.span(right_argument.span().start, right_argument.span().end);
+            let widened_right = if right_element_ty.is_some() {
+                // An array argument spreads into the widened result list.
+                body.push_expr(Expr {
+                    kind: ExprKind::TypeAssert { value: right },
+                    ty: widened_list_ty,
+                    span,
+                })
+            } else {
+                // A scalar argument appends as a singleton of the widened
+                // element type.
+                let element = body.push_expr(Expr {
+                    kind: ExprKind::TypeAssert { value: right },
+                    ty: widened,
+                    span,
+                });
+                body.push_expr(Expr {
+                    kind: ExprKind::ListLit(vec![element]),
+                    ty: widened_list_ty,
+                    span,
+                })
+            };
+            return Ok((widened_right, Some(widened)));
         };
-        Ok(right)
+        Ok((right, None))
     }
 
     /// Lower callback-heavy TypeScript array methods.

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/transforms.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/transforms.rs
@@ -490,7 +490,7 @@ impl ModuleBuilder<'_> {
             BinaryOperator::ShiftRightZeroFill => Ok(BinOp::UShr),
             _ => Err(SmeltError::unsupported(
                 self.span(start, end),
-                "callback binary operator is not supported yet",
+                format!("callback binary operator is not supported yet: {operator:?}"),
             )),
         }
     }

--- a/crates/smelt-frontend-ts/src/lowering/stdlib.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib.rs
@@ -1818,9 +1818,24 @@ impl ModuleBuilder<'_> {
                 span: self.span(call.span.start, call.span.end),
             })));
         }
+        // Comparator-less `sort()` uses JavaScript's default ordering: elements
+        // are compared by their `ToString` coercion. Scalars compare directly;
+        // erased (`unknown`) and union elements go through the emitter's
+        // string-coercion comparison, so mixed-value lists (`values(object)`,
+        // `Array<T[keyof T]>` results) sort with real JS semantics instead of
+        // being rejected. Structured concrete shapes (nested lists, records)
+        // stay unsupported because their JS `ToString` (e.g. `1,2` for arrays)
+        // is not modeled yet.
         if !matches!(
             self.ctx.krate.types.get(element_ty),
-            Some(Type::Bool | Type::Int | Type::Float | Type::String)
+            Some(
+                Type::Bool
+                    | Type::Int
+                    | Type::Float
+                    | Type::String
+                    | Type::Unknown
+                    | Type::Union(_)
+            )
         ) {
             return Err(SmeltError::unsupported(
                 self.span(member.object.span().start, member.object.span().end),

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -8262,3 +8262,196 @@ function probe(): unknown {
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
     Ok(())
 }
+
+
+#[test]
+fn lowers_default_sort_on_union_element_arrays() -> Result<(), String> {
+    // JavaScript's comparator-less `sort()` compares the `ToString` coercion of
+    // each element, so mixed string/number lists (es-toolkit
+    // `values(object).sort()`) must lower to a `ListSort` instead of failing
+    // with "array sort supports boolean, number, and string arrays for now".
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function sortMixed(values: Array<string | number>): Array<string | number> {
+  return values.sort();
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(ctx.krate.bodies.iter().any(|body| body.exprs.iter().any(
+        |expr| matches!(
+            expr.kind,
+            ExprKind::ListSort {
+                comparator: None,
+                ..
+            }
+        )
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_default_sort_on_erased_element_arrays() -> Result<(), String> {
+    // Erased (`unknown`) element lists also default-sort by string coercion
+    // (es-toolkit `shuffle(object).sort()` where the element type is an
+    // indexed-access surface).
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function sortErased(values: unknown[]): unknown[] {
+  return values.sort();
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(ctx.krate.bodies.iter().any(|body| body.exprs.iter().any(
+        |expr| matches!(
+            expr.kind,
+            ExprKind::ListSort {
+                comparator: None,
+                ..
+            }
+        )
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn concat_widens_element_type_for_null_list_argument() -> Result<(), String> {
+    // JavaScript `A[].concat(B[])` yields `Array<A | B>`. Appending a
+    // null-element list onto `number[]` (es-toolkit reverse.spec's
+    // `range(n).concat([null as any])`) must widen the result element to the
+    // nullable form (`Optional<Float>`, the same shape `[0, 1, null]` infers)
+    // instead of failing with "array concat requires an array or element
+    // argument matching the receiver".
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function pad(values: number[]): unknown {
+  return values.concat([null as any]);
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(ctx.krate.bodies.iter().any(|body| body
+        .exprs
+        .iter()
+        .any(|expr| matches!(expr.kind, ExprKind::ListConcat { .. }))));
+    let float_ty = ctx.krate.types.intern(Type::Float);
+    let optional_float = ctx.krate.types.intern(Type::Optional(float_ty));
+    let widened_list = ctx.krate.types.intern(Type::List(optional_float));
+    ensure!(
+        ctx.krate.bodies.iter().any(|body| body
+            .exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::ListConcat { .. })
+                && expr.ty == widened_list)),
+        "concat with a null-element list should produce a List<Optional<Float>> result"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_matches_property_array_iteratee_callback() -> Result<(), String> {
+    // The lodash array iteratee shorthand `[path, srcValue]` is a
+    // matchesProperty predicate (es-toolkit memoize.spec's
+    // `lodashStable.find(this.__data__, ['key', key])`); it must classify as a
+    // callback instead of failing with "array callback methods currently
+    // require arrow function callbacks".
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+import * as utils from "./utils";
+
+function lookup(entries: Array<{ key: string; value: string }>, key: string): unknown {
+  return utils.find(entries, ['key', key]);
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_object_builtin_as_identity_callback() -> Result<(), String> {
+    // `xs.map(Object)` boxes each element; Smelt does not model wrapper
+    // objects separately from their primitives, so the callback is the typed
+    // identity and the mapped list keeps its concrete `string` element type
+    // (es-toolkit parseInt.spec's `['6', '08', '10'].map(Object)`).
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function boxAll(values: string[]): unknown {
+  const boxed = values.map(Object);
+  return boxed;
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    let string_ty = ctx.krate.types.intern(Type::String);
+    let string_list = ctx.krate.types.intern(Type::List(string_ty));
+    ensure!(
+        ctx.krate.bodies.iter().any(|body| body
+            .exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::ListCallback { .. })
+                && expr.ty == string_list)),
+        "map(Object) should keep the concrete string element type"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_in_operator_inside_callback_array_literal() -> Result<(), String> {
+    // Binary elements of a callback array literal route through the full
+    // callback expression dispatcher, so `in` works there just like in any
+    // other callback position (es-toolkit unset.spec's
+    // `props.map(key => [unset(object, key), toString(key) in object])`).
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function flags(keys: string[], object: { [key: string]: number }): boolean[][] {
+  return keys.map(key => [key !== '', key in object]);
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn compound_member_assignment_in_callback_retries_closure_body() -> Result<(), String> {
+    // A compound member-target store inside a callback (`args[1] += ''`,
+    // es-toolkit pickBy.spec) cannot be modeled by the side-effect-free
+    // callback expression IR; it must retry through full closure-body lowering
+    // instead of failing with "callback assignment targets must be captured
+    // locals".
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function tag(rows: string[][], suffix: string): string[][] {
+  return rows.map(row => {
+    row[0] += suffix;
+    return row;
+  });
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes six small array/callback lowering blocker families (9 es-toolkit spec files), all through general rules:

1. Default `sort()` on union/erased element arrays (was limited to boolean/number/string arrays).
2. `concat` element-type widening for non-matching arguments — unifies through `Optional`, not erasure.
3. lodash-style `[path, srcValue]` matchesProperty array iteratees.
4. `Object` referenced as a callback lowers to a typed identity closure.
5. Binary operators (including `in`) inside callback array literals.
6. Compound member assignment inside callbacks.

## Verification

- clippy (pedantic) clean on touched crates; `cargo test --workspace --exclude smelt-gui` green; 8 new regression tests (6 frontend, 2 codegen).
- Six minimal fixture projects: `smelt build` + generated `cargo test` green end to end (11 generated tests).
- dump-hir: all six target diagnostics gone from the 9 files; 5 files now lower fully clean, the rest hit unrelated pre-existing families.
- Whole-crate abort verified UNCHANGED across baseline/WIP/final binaries (a prior draft claim of a changed abort was a stale-binary artifact — corrected in the committed report `blocker-logs/estk-array-misc.md`).
- Rebased onto main past #128/#129/#131; combined suites green (506 codegen, 810 frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_