### PR TITLE
feat(frontend-ts): clear the last HIR-lowering gates for the es-toolkit crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ blocker-logs/*.md
 !blocker-logs/estk-globalthis.md
 # estk-lowering-tail.md documents the small es-toolkit lowering tail blocker fixes
 !blocker-logs/estk-lowering-tail.md
+# estk-transpile-gate.md documents the five whole-crate transpile-gate blocker fixes
+!blocker-logs/estk-transpile-gate.md
 
 # Generated docs site output
 _site/

--- a/blocker-logs/estk-transpile-gate.md
+++ b/blocker-logs/estk-transpile-gate.md
@@ -1,0 +1,116 @@
+# es-toolkit whole-crate transpile gate
+
+Work toward es-toolkit's first whole-crate transpile (pinned ref `e008a2818cd8`,
+tracked fixture `.github/compat/es-toolkit/Smelt.toml`). The scan named five
+single-file blockers; each is fixed here as a general lowering rule (no per-file
+special cases). Clearing them exposed several further blockers in the same files
+(the scan reported only the first-failing test per file), which are also fixed.
+
+## The five named blockers (all fixed)
+
+1. **`unresolved class \`Request\`` — `src/predicate/isPlainObject.spec.ts`.**
+   `Request` joins the marker-only host-object registry
+   (`crates/smelt-stdlib/src/host_object.rs`) alongside `WeakMap`/`DataView`.
+   es-toolkit only does `new Request('http://localhost')` and checks
+   `isPlainObject(...) === false`; no structural surface is read, so construction
+   stamps `__smelt_request` on an erased record and `instanceof`/presence-guard
+   folding resolve through the marker (wired via `marker_only_builtin_marker`).
+
+2. **`RegExp construction requires a string pattern and optional flags` —
+   `src/compat/object/merge.spec.ts`.** Zero-argument `new RegExp()` (legal JS for
+   the empty pattern `/(?:)/`) now lowers to an empty pattern string, exactly like
+   `new RegExp('')` (`regexp_constructor_expression`).
+
+3. **`for...in is only lowered for record-like objects` —
+   `src/compat/object/defaultsDeep.spec.ts`.** `for (const key in fn)` over a
+   function value. Smelt models a function as a **property-less closure** with no
+   `SmeltUnknown`/record view, so casting it to a record would emit non-compiling
+   Rust. The sound projection for Smelt's function model is the **empty** key
+   list, and `Object.hasOwn(fn, key)` folds to a constant `false`. Both compile
+   cleanly. (Attaching enumerable properties to a function is a dynamic-JS shape
+   Smelt does not yet model, so the spec's own property assertions on `fn` would
+   fail at runtime — a runtime-representation gap, not a transpile gap.)
+
+4. **`TypeScript instanceof target \`Array\` is not a lowered class` —
+   `src/compat/function/memoize.spec.ts`.** `x instanceof Array` now folds exactly
+   like `Array.isArray(x)`: a list/tuple operand is `true`, an erased operand
+   resolves through the runtime `UnknownIs { Array }` probe, any other concrete
+   type is `false` (`instanceof_expression` in `lowering/guards.rs`).
+
+5. **`function parameters must have explicit type annotations or default
+   initializers` — `src/compat/predicate/matchesProperty.spec.ts`.** **FIXED, not
+   excluded.** The shape is a constructor function
+   `function Foo(object) { Object.assign(this, object); }` used with `new`. Smelt
+   already synthesizes such functions into classes (the `object: any` form in
+   `merge.spec.ts` works). A synthesized constructor's own fields are all typed
+   `unknown`, so an *unannotated, non-defaulted* constructor parameter is the same
+   genuinely dynamic boundary and defaults to `unknown`
+   (`constructor_parameter_type` in `lowering/decls/constructor.rs`) — matching
+   TypeScript's implicit-any inference for the identical idiom. The fallback is
+   scoped to the constructor-function synthesis path; ordinary untyped function
+   declarations still require explicit annotations.
+
+## Further blockers exposed and fixed (same files)
+
+Once a file's first-failing test lowered, later tests surfaced their own
+blockers:
+
+- **`String.raw` tagged template** (`isPlainObject.spec.ts`): `String.raw` is the
+  one tagged template Smelt models — its raw quasi text with substitutions
+  interpolated (`tagged_template_expression`). Other tags stay unsupported.
+- **Cross-`it`-block class scope** (`matchesProperty.spec.ts`): a `function Foo`
+  synthesized into a class in one `it` leaked into a sibling `it` declaring a
+  differently-shaped `Foo`, blocking its re-synthesis. `self.locals` was already
+  scoped per test case; the class registry now is too
+  (`test_case_class_scope`/`restore_test_case_class_scope` in
+  `lowering/testing/suites.rs`).
+- **`Object.hasOwn` over a function value** (`defaultsDeep.spec.ts`): folds to
+  `false`, consistent with the empty `for...in` projection above.
+- **Constructor-presence-guard ternary** (`merge.spec.ts`):
+  `Uint8Array ? new Uint8Array([1]) : { buffer: [1] }`. `Uint8Array` is a bare
+  host constructor Smelt always models as present, so the probe is always true;
+  the ternary folds to its consequent and keeps the concrete `List` shape.
+  Reconciling the mismatched `List`/`Dict` arms through `SmeltUnknown` is exactly
+  the avoidable erasure the ABI rules forbid
+  (`identifier_is_always_present_global_constructor`).
+
+## Status
+
+- **All five named spec files now fully HIR-lower** (`smelt dump-hir`, which
+  collects every error per file, is clean for each).
+- **The whole crate now fully HIR-lowers.** `smelt build` previously aborted at
+  the first spec file; it now clears HIR lowering for the entire crate and
+  advances to **MIR lowering / HIR validation**.
+- **The whole-crate transpile does NOT yet fully succeed.** MIR/validation
+  reveals further, unrelated blockers beyond the five, in files the earlier abort
+  never reached:
+  - `await outside an async function` in async closures (e.g. `promise/**`,
+    `array/**Async**` spec callbacks) — async-arrow *value* closures whose async
+    state machine is not built on their body.
+  - `only local, field, and index expressions can be assigned at
+    src/array/pull.ts` — an assignment-target lowering blocker in a source module.
+  These are the next gates; a full clean whole-crate transpile requires clearing
+  this cascade. Because the transpile does not complete, `rust-test-report` was
+  not run.
+
+## Verification
+
+- New regression tests (repo test style):
+  `crates/smelt-frontend-ts/src/tests/estk_transpile_gate_tests.rs` (Request
+  marker, zero-arg RegExp, `for...in`/`hasOwn` over a function value,
+  `instanceof Array` list/unknown, `String.raw`, constructor-presence-guard
+  fold) and additions to
+  `crates/smelt-frontend-ts/src/tests/constructor_function_tests.rs`
+  (unannotated constructor param, plain-function rejection preserved, sibling-`it`
+  class scoping).
+- End-to-end fixture (`smelt build` + generated `cargo test`): zero-arg RegExp,
+  `instanceof Array`, `String.raw`, the presence-guard ternary, and the
+  function-value `for...in`/`hasOwn` all **compile and run green**. The
+  `Object.assign(this, object)` constructor populates no fields at runtime — a
+  pre-existing synthesized-class limitation shared with the annotated `object:
+  any` form, independent of the parameter-type fix.
+- `cargo check --workspace`: clean.
+- `cargo clippy --lib -- -W clippy::pedantic` on `smelt-stdlib` +
+  `smelt-frontend-ts`: clean.
+- `cargo test`: `smelt-frontend-ts` (841) + `smelt-stdlib` (21) + `smelt-hir`
+  (511) + `smelt-codegen-rust` suite all green.

--- a/crates/smelt-frontend-ts/src/lowering/decls/constructor.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/constructor.rs
@@ -558,6 +558,37 @@ impl ModuleBuilder<'_> {
         methods
     }
 
+    /// Resolve the HIR type of a synthesized constructor function's parameter.
+    ///
+    /// An annotated or default-initialized parameter keeps the ordinary
+    /// [`Self::function_parameter_type`] resolution. An *unannotated,
+    /// non-defaulted* constructor parameter, however, is a genuinely dynamic
+    /// boundary: a synthesized constructor's own fields are all typed `unknown`
+    /// (their shapes come from whatever `new Foo(args)` passes and the
+    /// `this.x = …` / `Object.assign(this, …)` writes Smelt cannot see
+    /// statically), so the value the parameter carries into those writes has no
+    /// recoverable static shape either. It defaults to `unknown`, matching both
+    /// the `unknown` field ABI and TypeScript's own implicit-any inference for
+    /// the identical `function Foo(object) { Object.assign(this, object); }`
+    /// idiom (es-toolkit spells the very same shape `object: any` in its `merge`
+    /// spec). This fallback stays inside the constructor-function synthesis path,
+    /// so ordinary untyped function declarations still require explicit
+    /// annotations via [`Self::function_parameter_type`].
+    fn constructor_parameter_type(
+        &mut self,
+        param: &oxc::ast::ast::FormalParameter<'_>,
+    ) -> Result<smelt_hir::TypeId, SmeltError> {
+        if param.type_annotation.is_some() || param.initializer.is_some() {
+            return self.function_parameter_type(param);
+        }
+        let unknown_ty = self.ctx.krate.types.intern(Type::Unknown);
+        if param.optional {
+            Ok(self.ctx.krate.types.intern(Type::Optional(unknown_ty)))
+        } else {
+            Ok(unknown_ty)
+        }
+    }
+
     /// Lower a constructor function body into the class constructor item.
     ///
     /// Mirrors the constructor path of `class_function`: `this` is bound as a
@@ -597,7 +628,7 @@ impl ModuleBuilder<'_> {
         let mut params = Vec::new();
         let mut errors = Vec::new();
         for (index, param) in function.params.items.iter().enumerate() {
-            let ty = match self.function_parameter_type(param) {
+            let ty = match self.constructor_parameter_type(param) {
                 Ok(ty) => ty,
                 Err(error) => {
                     errors.push(error);

--- a/crates/smelt-frontend-ts/src/lowering/guards.rs
+++ b/crates/smelt-frontend-ts/src/lowering/guards.rs
@@ -76,6 +76,40 @@ impl ModuleBuilder<'_> {
                 span: self.span(binary.span.start, binary.span.end),
             }));
         }
+        // `x instanceof Array`. Smelt backs a JavaScript array with a plain list,
+        // so this folds exactly like `Array.isArray(x)` (see `array_is_array_call`):
+        // a list/tuple-typed operand *is* an array and folds to `true`, an erased
+        // operand (`unknown`/generic/union) resolves through the runtime array
+        // probe `UnknownIs { Array }`, and any other concrete type carries no array
+        // identity and folds to `false`. A user-declared `class Array` owns the
+        // name and falls through to the ordinary class path below.
+        if class_text == "Array" && !self.classes.contains_key("Array") {
+            let operand_ty = self.type_param_constraint_or_self(value_ty);
+            if matches!(
+                self.ctx.krate.types.get(operand_ty),
+                Some(Type::Unknown | Type::TypeParam { .. } | Type::Union(_))
+            ) {
+                let ty = self.ctx.krate.types.intern(Type::Bool);
+                return Ok(body.push_expr(Expr {
+                    kind: ExprKind::UnknownIs {
+                        value,
+                        kind: UnknownKind::Array,
+                    },
+                    ty,
+                    span: self.span(binary.span.start, binary.span.end),
+                }));
+            }
+            let result = matches!(
+                self.ctx.krate.types.get(operand_ty),
+                Some(Type::List(_) | Type::Tuple(_))
+            );
+            let ty = self.ctx.krate.types.intern(Type::Bool);
+            return Ok(body.push_expr(Expr {
+                kind: ExprKind::Literal(Literal::Bool(result)),
+                ty,
+                span: self.span(binary.span.start, binary.span.end),
+            }));
+        }
         if Self::is_ts_stdlib_class_name(class_text, smelt_stdlib::StdlibClass::Date)
             && self.expression_is_known_date_value(value, body)
         {
@@ -1054,6 +1088,9 @@ impl ModuleBuilder<'_> {
             Argument::CallExpression(call) => self.call_expression(call, body),
             Argument::ChainExpression(chain) => self.chain_expression(chain, body),
             Argument::TemplateLiteral(template) => self.template_literal_expression(template, body),
+            Argument::TaggedTemplateExpression(tagged) => {
+                self.tagged_template_expression(tagged, body)
+            }
             Argument::TSAsExpression(as_expr) => self.type_assertion_expression(
                 &as_expr.expression,
                 &as_expr.type_annotation,

--- a/crates/smelt-frontend-ts/src/lowering/new_expr.rs
+++ b/crates/smelt-frontend-ts/src/lowering/new_expr.rs
@@ -864,7 +864,10 @@ impl ModuleBuilder<'_> {
     /// excluded here even though they share the registry.
     pub(crate) fn marker_only_builtin_marker(name: &str) -> Option<&'static str> {
         match name {
-            "WeakMap" | "WeakSet" | "DataView" | "SharedArrayBuffer" => {
+            // `Request` joins the marker-only set: es-toolkit constructs it only
+            // to probe host identity (`isPlainObject(new Request(url))`), reading
+            // none of its structural surface, exactly like the other entries here.
+            "WeakMap" | "WeakSet" | "DataView" | "SharedArrayBuffer" | "Request" => {
                 smelt_stdlib::host_object_marker(name)
             }
             _ => None,
@@ -2053,6 +2056,17 @@ impl ModuleBuilder<'_> {
                 }))
             }
             Expression::ConditionalExpression(conditional) => {
+                // Fold `Ctor ? new Ctor(...) : fallback` where `Ctor` is a host
+                // constructor Smelt always models as present (see
+                // `identifier_is_always_present_global_constructor`): the probe is
+                // always true, so the ternary yields its consequent and keeps its
+                // concrete shape instead of forcing the mismatched branches to
+                // reconcile through `SmeltUnknown`.
+                if let Expression::Identifier(test) = &conditional.test
+                    && self.identifier_is_always_present_global_constructor(test.name.as_str())
+                {
+                    return self.expression_with_hint(&conditional.consequent, body, type_hint);
+                }
                 let cond = self.condition_expression(&conditional.test, body)?;
                 let then_narrowing = self.guard_narrowing(&conditional.test, body);
                 if let Some(narrowing) = then_narrowing.clone() {
@@ -2352,10 +2366,9 @@ impl ModuleBuilder<'_> {
                 member.span,
                 body,
             ),
-            Expression::TaggedTemplateExpression(tagged) => Err(SmeltError::unsupported(
-                self.span(tagged.span.start, tagged.span.end),
-                "tagged template literals are not supported",
-            )),
+            Expression::TaggedTemplateExpression(tagged) => {
+                self.tagged_template_expression(tagged, body)
+            }
             _ => Err(SmeltError::unsupported(
                 self.expression_span(expression),
                 format!("expression kind is not lowered yet: {expression:?}"),
@@ -2431,6 +2444,21 @@ impl ModuleBuilder<'_> {
         body: &mut Body,
         type_hint: Option<smelt_hir::TypeId>,
     ) -> Result<smelt_hir::ExprId, SmeltError> {
+        // A constructor-presence guard `Ctor ? new Ctor(...) : fallback` where
+        // `Ctor` is a bare host constructor Smelt always models as present (typed
+        // arrays, `ArrayBuffer`/`Blob`/`Buffer`, the marker-only host builtins).
+        // The environment probe is always true in Smelt's model, so the ternary
+        // yields its consequent; folding to that branch keeps its concrete shape
+        // (es-toolkit's `merge` spec writes `Uint8Array ? new Uint8Array([1]) : {
+        // buffer: [1] }`, whose `List` and `Dict` arms have no common concrete
+        // Rust type — widening the merge to `SmeltUnknown` to reconcile them is
+        // exactly the avoidable erasure the ABI rules forbid). A user binding or
+        // class of the same name shadows the global and is not folded.
+        if let Expression::Identifier(test) = &conditional.test
+            && self.identifier_is_always_present_global_constructor(test.name.as_str())
+        {
+            return self.expression_with_hint(&conditional.consequent, body, type_hint);
+        }
         let cond = self.condition_expression(&conditional.test, body)?;
         let then_expr = self.expression_with_hint(&conditional.consequent, body, type_hint)?;
         let branch_hint = Some(Self::expr_ty(body, then_expr));
@@ -2453,6 +2481,23 @@ impl ModuleBuilder<'_> {
             ty,
             span: self.span(conditional.span.start, conditional.span.end),
         }))
+    }
+
+    /// Return whether a bare identifier names a host constructor that Smelt
+    /// always models as present, so a `Ctor ? … : …` environment-presence guard
+    /// folds to its consequent.
+    ///
+    /// The set matches the constructors with a concrete construct + `instanceof`
+    /// lowering: typed-array views (backed by numeric lists),
+    /// `ArrayBuffer`/`Blob`/`File`/`Buffer`, and the marker-only host builtins.
+    /// A local binding or user class of the same name shadows the global, so it
+    /// is excluded — the guard then lowers normally.
+    fn identifier_is_always_present_global_constructor(&self, name: &str) -> bool {
+        if self.locals.contains_key(name) || self.classes.contains_key(name) {
+            return false;
+        }
+        smelt_stdlib::is_typed_array_class_name(name)
+            || Self::is_known_defined_global_constructor(name)
     }
 
     /// Compute the result type for a conditional expression's branches.
@@ -2847,6 +2892,84 @@ impl ModuleBuilder<'_> {
                     .cooked
                     .as_ref()
                     .map_or_else(|| quasi.value.raw.as_str(), |c| c.as_str());
+                if !s.is_empty() {
+                    let lit = body.push_expr(Expr {
+                        kind: ExprKind::Literal(Literal::String(s.to_owned())),
+                        ty: str_ty,
+                        span,
+                    });
+                    acc = body.push_expr(Expr {
+                        kind: ExprKind::BinOp {
+                            op: BinOp::Add,
+                            lhs: acc,
+                            rhs: lit,
+                        },
+                        ty: str_ty,
+                        span,
+                    });
+                }
+            }
+        }
+        Ok(acc)
+    }
+
+    /// Lower a `String.raw` tagged template literal into string concatenation.
+    ///
+    /// `String.raw` is the one tagged template Smelt models: it yields the
+    /// template's *raw* (un-escaped) text with the substitutions interpolated,
+    /// i.e. ``String.raw`a${x}b` `` is `"a" + String(x) + "b"` built from the raw
+    /// quasi segments rather than the cooked ones. es-toolkit's `isPlainObject`
+    /// spec constructs the substitution-free ``String.raw`rawtemplate` `` as a
+    /// representative non-object value. Any other tag is a user/host function
+    /// whose "call with a `TemplateStringsArray` plus substitutions" protocol
+    /// Smelt does not model, so it keeps reporting the unsupported error.
+    pub(super) fn tagged_template_expression(
+        &mut self,
+        tagged: &oxc::ast::ast::TaggedTemplateExpression<'_>,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let is_string_raw = matches!(
+            &tagged.tag,
+            Expression::StaticMemberExpression(member)
+                if member.property.name == "raw"
+                    && matches!(
+                        &member.object,
+                        Expression::Identifier(object) if object.name == "String"
+                    )
+        );
+        if !is_string_raw {
+            return Err(SmeltError::unsupported(
+                self.span(tagged.span.start, tagged.span.end),
+                "tagged template literals are not supported",
+            ));
+        }
+        let tpl = &tagged.quasi;
+        let str_ty = self.ctx.krate.types.intern(Type::String);
+        let span = self.span(tagged.span.start, tagged.span.end);
+        let Some(first_quasi) = tpl.quasis.first() else {
+            return Err(SmeltError::unsupported(
+                span,
+                "template literals must contain at least one quasi",
+            ));
+        };
+        let mut acc = body.push_expr(Expr {
+            kind: ExprKind::Literal(Literal::String(first_quasi.value.raw.as_str().to_owned())),
+            ty: str_ty,
+            span,
+        });
+        for (i, interp) in tpl.expressions.iter().enumerate() {
+            let part = self.expression(interp, body)?;
+            acc = body.push_expr(Expr {
+                kind: ExprKind::BinOp {
+                    op: BinOp::Add,
+                    lhs: acc,
+                    rhs: part,
+                },
+                ty: str_ty,
+                span,
+            });
+            if let Some(quasi) = tpl.quasis.get(i.saturating_add(1)) {
+                let s = quasi.value.raw.as_str();
                 if !s.is_empty() {
                     let lit = body.push_expr(Expr {
                         kind: ExprKind::Literal(Literal::String(s.to_owned())),

--- a/crates/smelt-frontend-ts/src/lowering/stdlib.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib.rs
@@ -1403,19 +1403,32 @@ impl ModuleBuilder<'_> {
         new_expr: &oxc::ast::ast::NewExpression<'_>,
         body: &mut Body,
     ) -> Result<smelt_hir::ExprId, SmeltError> {
-        let ([pattern_argument] | [pattern_argument, _]) = new_expr.arguments.as_slice() else {
-            return Err(SmeltError::unsupported(
-                self.span(new_expr.span.start, new_expr.span.end),
-                "RegExp construction requires a string pattern and optional flags",
-            ));
+        // `new RegExp()` (zero arguments) is legal JavaScript for the empty
+        // pattern `/(?:)/`, which es-toolkit's `merge` spec constructs as a
+        // representative non-plain-object source value. Model it as an empty
+        // pattern string so it lowers exactly like `new RegExp('')`.
+        let pattern = match new_expr.arguments.as_slice() {
+            [] => body.push_expr(Expr {
+                kind: ExprKind::Literal(Literal::String(String::new())),
+                ty: self.ctx.krate.types.intern(Type::String),
+                span: self.span(new_expr.span.start, new_expr.span.end),
+            }),
+            [pattern_argument] | [pattern_argument, _] => {
+                let pattern = self.argument(pattern_argument, body)?;
+                self.regexp_pattern_operand(pattern, body)?.ok_or_else(|| {
+                    SmeltError::unsupported(
+                        self.span(new_expr.span.start, new_expr.span.end),
+                        "RegExp construction requires a string pattern",
+                    )
+                })?
+            }
+            _ => {
+                return Err(SmeltError::unsupported(
+                    self.span(new_expr.span.start, new_expr.span.end),
+                    "RegExp construction requires a string pattern and optional flags",
+                ));
+            }
         };
-        let pattern = self.argument(pattern_argument, body)?;
-        let pattern = self.regexp_pattern_operand(pattern, body)?.ok_or_else(|| {
-            SmeltError::unsupported(
-                self.span(new_expr.span.start, new_expr.span.end),
-                "RegExp construction requires a string pattern",
-            )
-        })?;
         let flags = if let Some(flags_argument) = new_expr.arguments.get(1) {
             let flags = self.argument(flags_argument, body)?;
             self.regexp_text_operand(flags, body).ok_or_else(|| {

--- a/crates/smelt-frontend-ts/src/lowering/stdlib/objects.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/objects.rs
@@ -1043,7 +1043,26 @@ return_ty,
             Some(Type::Dict(key_ty, _)) => *key_ty,
             Some(Type::Unknown) => Self::expr_ty(body, key),
             Some(Type::String) => self.ctx.krate.types.intern(Type::String),
+            Some(Type::Function(_)) => {
+                // `Object.hasOwn(fn, key)` on a function value (paired with
+                // `for (const key in fn)` in es-toolkit's `defaultsDeep` spec).
+                // Smelt models a function as a property-less closure with no
+                // enumerable own keys, so the ownership check is a constant
+                // `false` — the sound answer for Smelt's function representation,
+                // and it compiles cleanly without casting the closure to a
+                // record. The receiver and key were already lowered above for
+                // their effects/types.
+                let bool_ty = self.ctx.krate.types.intern(Type::Bool);
+                return Ok(Some(body.push_expr(Expr {
+                    kind: ExprKind::Literal(Literal::Bool(false)),
+                    ty: bool_ty,
+                    span: self.span(call.span.start, call.span.end),
+                })));
+            }
             Some(Type::TypeParam { .. } | Type::Class { .. }) => {
+                // A generic or erased object is treated as a string-keyed
+                // record, matching the `for...in` lowering that casts the same
+                // value to `Record<string, unknown>`.
                 let key_ty = self.ctx.krate.types.intern(Type::String);
                 let value_ty = self.ctx.krate.types.intern(Type::Unknown);
                 let target = self.ctx.krate.types.intern(Type::Dict(key_ty, value_ty));

--- a/crates/smelt-frontend-ts/src/lowering/stmt/control_flow.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/control_flow.rs
@@ -273,11 +273,30 @@ impl ModuleBuilder<'_> {
                     span: self.expression_span(source),
                 }))
             }
+            Some(Type::Function(_)) => {
+                // A `for...in` over a function value (`function fn() {}; fn.a = 1;
+                // for (const key in fn)`, the lodash-compat idiom es-toolkit's
+                // `defaultsDeep` spec iterates). Smelt models a function as a
+                // property-less closure, so it exposes no enumerable own string
+                // keys: the loop iterates the empty list. This is the sound
+                // projection for Smelt's function representation and compiles
+                // cleanly (a closure has no `SmeltUnknown`/record view to cast
+                // into); attaching enumerable properties to a function is a
+                // dynamic-JS shape Smelt does not yet model.
+                let key_ty = self.ctx.krate.types.intern(Type::String);
+                let list_ty = self.ctx.krate.types.intern(Type::List(key_ty));
+                Ok(body.push_expr(Expr {
+                    kind: ExprKind::ListLit(Vec::new()),
+                    ty: list_ty,
+                    span: self.expression_span(source),
+                }))
+            }
             Some(Type::Unknown | Type::Class { .. } | Type::TypeParam { .. } |
 Type::Optional(_)) => {
                 // A `for...in` over an erased object surface — an unconstrained
-                // generic `T`, an erased object, or an optional object — iterates
-                // string-keyed properties, so it is cast to `Record<string, unknown>`.
+                // generic `T`, an erased object, or an optional object —
+                // iterates string-keyed properties, so it is cast to
+                // `Record<string, unknown>`.
                 let key_ty = self.ctx.krate.types.intern(Type::String);
                 let value_ty = self.ctx.krate.types.intern(Type::Unknown);
                 let dict_ty = self.ctx.krate.types.intern(Type::Dict(key_ty, value_ty));

--- a/crates/smelt-frontend-ts/src/lowering/testing/suites.rs
+++ b/crates/smelt-frontend-ts/src/lowering/testing/suites.rs
@@ -12,6 +12,21 @@ use oxc::span::GetSpan;
 use smelt_hir::{
     Body, Function, FunctionOwner, Item, LocalDecl, Pattern, Span, Stmt, Type,
 };
+use std::collections::HashSet;
+
+/// Class-registry names captured before a test case is lowered so that
+/// block-local synthesized constructor classes can be rolled back afterwards.
+///
+/// See [`ModuleBuilder::test_case_class_scope`] for why per-case class scoping
+/// is needed even though `self.locals` is already saved and restored.
+struct TestCaseClassScope {
+    /// Names present in the `classes` registry on entry to the test case.
+    classes: HashSet<String>,
+    /// Names present in the `class_fields` registry on entry to the test case.
+    fields: HashSet<String>,
+    /// Names present in the `class_methods` registry on entry to the test case.
+    methods: HashSet<String>,
+}
 
 impl ModuleBuilder<'_> {
     /// Lower a `describe` test-suite declaration and its inherited hooks.
@@ -495,6 +510,35 @@ impl ModuleBuilder<'_> {
         }
     }
 
+    /// Snapshot the class-registry names present before a test case is lowered.
+    ///
+    /// Constructor functions declared inside a test case (`function Foo(){}`
+    /// used as `new Foo()` / `instanceof Foo` / `Foo.prototype.x = …`) are
+    /// synthesized into the class registry during per-case predeclaration and
+    /// setup replay, but they are *block-local*: a differently-shaped
+    /// `function Foo` in a sibling `it` must synthesize its own class rather than
+    /// reuse a stale one. `self.locals` is already scoped per case; the class
+    /// registry is not. Pairing this snapshot with
+    /// [`Self::restore_test_case_class_scope`] drops any class added during the
+    /// case while preserving module-level and imported classes.
+    fn test_case_class_scope(&self) -> TestCaseClassScope {
+        TestCaseClassScope {
+            classes: self.classes.keys().cloned().collect(),
+            fields: self.class_fields.keys().cloned().collect(),
+            methods: self.class_methods.keys().cloned().collect(),
+        }
+    }
+
+    /// Drop class-registry entries added while lowering a test case, restoring
+    /// the block-local class scope captured by [`Self::test_case_class_scope`].
+    fn restore_test_case_class_scope(&mut self, scope: &TestCaseClassScope) {
+        self.classes.retain(|name, _| scope.classes.contains(name));
+        self.class_fields
+            .retain(|name, _| scope.fields.contains(name));
+        self.class_methods
+            .retain(|name, _| scope.methods.contains(name));
+    }
+
     /// Lower a prepared test callback into an HIR test function.
     pub(in crate::lowering) fn test_function_from_arrow(
         &mut self,
@@ -509,6 +553,7 @@ impl ModuleBuilder<'_> {
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_date_value_locals = std::mem::take(&mut self.date_value_locals);
         let saved_async = self.current_async;
+        let class_scope = self.test_case_class_scope();
         self.current_async = arrow.r#async;
         let mut body = Body::new(None, self.span(arrow.body.span.start, arrow.body.span.end));
         let mut errors = Vec::new();
@@ -556,6 +601,7 @@ impl ModuleBuilder<'_> {
         self.locals = saved_locals;
         self.date_value_locals = saved_date_value_locals;
         self.current_async = saved_async;
+        self.restore_test_case_class_scope(&class_scope);
         if let Some(error) = errors.into_iter().next() {
             return Err(error);
         }
@@ -611,6 +657,7 @@ return_ty: none,
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_date_value_locals = std::mem::take(&mut self.date_value_locals);
         let saved_async = self.current_async;
+        let class_scope = self.test_case_class_scope();
         self.current_async = function.r#async;
         // A `function () { ... }` test callback (as opposed to an arrow) has its
         // own `arguments` binding, so make the array-like `arguments` object
@@ -671,6 +718,7 @@ return_ty: none,
         self.locals = saved_locals;
         self.date_value_locals = saved_date_value_locals;
         self.current_async = saved_async;
+        self.restore_test_case_class_scope(&class_scope);
         if let Some(error) = errors.into_iter().next() {
             return Err(error);
         }

--- a/crates/smelt-frontend-ts/src/tests/constructor_function_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/constructor_function_tests.rs
@@ -181,3 +181,93 @@ export function fillRange<T>(array: T[], value: T, start = 0, end = array.length
     )?;
     Ok(())
 }
+
+#[test]
+fn unannotated_constructor_parameter_defaults_to_unknown() -> Result<(), String> {
+    // `function Foo(object) { Object.assign(this, object); }` used with `new`
+    // is a constructor function whose single parameter carries no annotation.
+    // A synthesized constructor's own fields are all `unknown`, so the parameter
+    // that flows into `this` is the same dynamic boundary and defaults to
+    // `unknown` (es-toolkit's `merge` spec spells the identical shape
+    // `object: any`). Ordinary untyped functions still require an annotation.
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+import { describe, expect, it } from 'vitest';
+
+describe('nonplain', () => {
+  it('constructs from an object', () => {
+    function Foo(object) {
+      Object.assign(this, object);
+    }
+    const object = new Foo({ a: new Foo({ b: 1, c: 2 }) });
+    expect((object as any).a.b).toBe(1);
+  });
+});
+"#),
+        &mut ctx,
+    )?;
+    let class = class_by_name(&ctx, "Foo").ok_or("expected synthesized class `Foo`")?;
+    ensure!(
+        class.constructor.is_some(),
+        "unannotated constructor function should still synthesize a class",
+    );
+    Ok(())
+}
+
+#[test]
+fn plain_unannotated_function_parameter_still_rejected() -> Result<(), String> {
+    // The unknown-parameter fallback is scoped to constructor functions. A plain
+    // function declaration that is never used as a `new` target keeps requiring
+    // explicit annotations, so this must still fail to lower.
+    let mut ctx = HirCtx::new();
+    let errors = lowering_errors(
+        ts!(r#"
+export function plain(object) {
+  return object;
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(
+        errors.iter().any(|error| error
+            .message
+            .contains("explicit type annotations or default initializers")),
+        "plain untyped function parameter should still be rejected: {errors:?}",
+    );
+    Ok(())
+}
+
+#[test]
+fn sibling_it_blocks_synthesize_independent_constructor_classes() -> Result<(), String> {
+    // A `function Foo` synthesized as a class in one `it` block must not leak
+    // into a sibling block that declares a differently-shaped `function Foo`.
+    // The class registry is scoped per test case, so the second block
+    // re-synthesizes its own `Foo` (whose unannotated constructor parameter
+    // would otherwise fall back to the plain-function path and fail to lower).
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+import { describe, expect, it } from 'vitest';
+
+describe('scoping', () => {
+  it('inherited constructor', () => {
+    function Foo() {}
+    Foo.prototype.b = 2;
+    const object = { a: new Foo() };
+    expect((object as any).a).toBeDefined();
+  });
+
+  it('non-plain constructor', () => {
+    function Foo(object) {
+      Object.assign(this, object);
+    }
+    const object = new Foo({ a: new Foo({ b: 1, c: 2 }) });
+    expect((object as any).a.b).toBe(1);
+  });
+});
+"#),
+        &mut ctx,
+    )?;
+    Ok(())
+}

--- a/crates/smelt-frontend-ts/src/tests/estk_transpile_gate_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/estk_transpile_gate_tests.rs
@@ -1,0 +1,257 @@
+//! Regression coverage for the es-toolkit whole-crate transpile-gate lowerings.
+//!
+//! Each test pins a general lowering rule cleared while unblocking es-toolkit's
+//! first whole-crate transpile: the `Request` marker host object, zero-argument
+//! `new RegExp()`, `for...in` / `Object.hasOwn` over function values carrying
+//! attached properties, `x instanceof Array`, `String.raw` tagged templates, and
+//! folding an always-present constructor-presence-guard ternary. They are
+//! positive HIR-shape assertions plus one negative check per family where a
+//! distinct alternative would be the regression to guard against.
+
+use super::*;
+use smelt_hir::{DictProjectionOp, Literal, UnknownKind};
+
+/// Return whether any body in the crate contains an expression matching `pred`.
+fn crate_has(ctx: &HirCtx, pred: impl Fn(&ExprKind) -> bool) -> bool {
+    ctx.krate
+        .bodies
+        .iter()
+        .any(|body| body.exprs.iter().any(|expr| pred(&expr.kind)))
+}
+
+/// Return whether any body in the crate contains a string literal `text`.
+fn crate_has_string_literal(ctx: &HirCtx, text: &str) -> bool {
+    ctx.krate.bodies.iter().any(|body| {
+        body.exprs.iter().any(|expr| {
+            matches!(&expr.kind, ExprKind::Literal(Literal::String(value)) if value == text)
+        })
+    })
+}
+
+// ---------------------------------------------------------------------------
+// `Request` marker host object.
+//
+// es-toolkit's `isPlainObject` spec constructs `new Request('http://localhost')`
+// only to probe host identity. It joins the marker-only host registry, so
+// construction stamps `__smelt_request` on an erased record.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn request_construction_stamps_marker_record() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+export function make(): unknown {
+  return new Request('http://localhost');
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(
+        crate_has_string_literal(&ctx, "__smelt_request"),
+        "Request construction should stamp the `__smelt_request` marker",
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Zero-argument `new RegExp()`.
+//
+// Legal JavaScript for the empty pattern `/(?:)/`. es-toolkit's `merge` spec
+// constructs it as a representative non-plain-object value.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn zero_argument_regexp_lowers_to_empty_pattern() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+export function make() {
+  return new RegExp();
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(
+        crate_has(&ctx, |kind| matches!(
+            kind,
+            ExprKind::New { .. }
+        )),
+        "`new RegExp()` should still lower to a RegExp construction",
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `for...in` and `Object.hasOwn` over a function value.
+//
+// `function fn() {}; for (const key in fn)` is the lodash-compat idiom
+// es-toolkit's `defaultsDeep` spec pairs with `Object.hasOwn`. Smelt models a
+// function as a property-less closure, so `for...in` iterates the empty list and
+// `Object.hasOwn(fn, key)` folds to `false` — the sound projection for Smelt's
+// function representation, and it compiles without casting the closure to a
+// record (a closure has no `SmeltUnknown` view).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn for_in_over_function_value_iterates_empty() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+export function run(): Record<string, number> {
+  function fn() {}
+  const result: Record<string, number> = {};
+  for (const key in fn) {
+    if (Object.hasOwn(fn, key)) {
+      result[key] = 1;
+    }
+  }
+  return result;
+}
+"#),
+        &mut ctx,
+    )?;
+    // The function value must NOT be cast to a record for key projection: a
+    // closure has no `SmeltUnknown` view, so that would emit non-compiling Rust.
+    ensure!(!crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::DictProjection {
+            op: DictProjectionOp::ForInKeys,
+            ..
+        }
+    )));
+    // `Object.hasOwn(fn, key)` folds to a constant `false`.
+    ensure!(crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::Literal(Literal::Bool(false))
+    )));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `x instanceof Array`.
+//
+// Folds like `Array.isArray(x)`: a list/tuple operand is `true`, an erased
+// operand resolves through the runtime `UnknownIs { Array }` probe.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn instanceof_array_on_list_folds_true() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+export function check(values: number[]): boolean {
+  return values instanceof Array;
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::Literal(Literal::Bool(true))
+    )));
+    // It must NOT emit a nominal `InstanceOf` node for the built-in `Array`.
+    ensure!(!crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::InstanceOf { .. }
+    )));
+    Ok(())
+}
+
+#[test]
+fn instanceof_array_on_unknown_probes_runtime() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+export function check(value: unknown): boolean {
+  return value instanceof Array;
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::UnknownIs {
+            kind: UnknownKind::Array,
+            ..
+        }
+    )));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `String.raw` tagged template.
+//
+// The one tagged template Smelt models: the raw text with substitutions
+// interpolated. es-toolkit's `isPlainObject` spec uses the substitution-free
+// ``String.raw`rawtemplate` ``.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn string_raw_tagged_template_lowers_to_raw_text() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+export function raw(): string {
+  return String.raw`rawtemplate`;
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(
+        crate_has_string_literal(&ctx, "rawtemplate"),
+        "`String.raw` should lower to its raw quasi text",
+    );
+    Ok(())
+}
+
+#[test]
+fn non_string_raw_tagged_template_still_rejected() -> Result<(), String> {
+    // Only `String.raw` is modeled; an arbitrary tag keeps failing to lower
+    // rather than silently dropping its call-with-strings-array protocol.
+    let mut ctx = HirCtx::new();
+    let errors = lowering_errors(
+        ts!(r#"
+declare function tag(strings: TemplateStringsArray): string;
+export function use(): string {
+  return tag`hello`;
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(
+        errors
+            .iter()
+            .any(|error| error.message.contains("tagged template literals are not supported")),
+        "non-`String.raw` tagged templates should still be rejected: {errors:?}",
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Constructor-presence-guard ternary fold.
+//
+// `Ctor ? new Ctor(...) : fallback` where `Ctor` is a host constructor Smelt
+// always models as present folds to its consequent, keeping the concrete shape
+// instead of reconciling the mismatched branches through `SmeltUnknown`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn typed_array_presence_guard_folds_to_consequent() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+export function make() {
+  const typedArray = Uint8Array ? new Uint8Array([1]) : { buffer: [1] };
+  return { value: typedArray };
+}
+"#),
+        &mut ctx,
+    )?;
+    // The always-true probe is folded away: no conditional node survives.
+    ensure!(!crate_has(&ctx, |kind| matches!(
+        kind,
+        ExprKind::Conditional { .. }
+    )));
+    Ok(())
+}

--- a/crates/smelt-frontend-ts/src/tests/mod.rs
+++ b/crates/smelt-frontend-ts/src/tests/mod.rs
@@ -223,6 +223,7 @@ mod part06_tests;
 mod specialization_tests;
 mod part07_tests;
 mod estk6_coverage_tests;
+mod estk_transpile_gate_tests;
 mod class_module_tests;
 mod enum_switch_tests;
 mod array_literal_expr_tests;

--- a/crates/smelt-stdlib/src/host_object.rs
+++ b/crates/smelt-stdlib/src/host_object.rs
@@ -85,6 +85,13 @@ pub const HOST_OBJECTS: &[HostObject] = &[
     host("File", "__smelt_file"),
     host("Blob", "__smelt_blob"),
     host("DOMException", "__smelt_domexception"),
+    // The Fetch `Request` host object. es-toolkit constructs it only to probe
+    // host identity (`isPlainObject(new Request('http://localhost')) === false`);
+    // none of its structural surface (`url`/`method`/headers) is read, so it is
+    // a marker-only host object like `WeakMap`/`DataView`. Construction stamps
+    // `__smelt_request` and `instanceof`/presence-guard folding resolve through
+    // the marker (see `marker_only_builtin_marker`).
+    host("Request", "__smelt_request"),
     // ECMA-402 `Intl` namespace constructors. Source code constructs these only
     // to probe host identity (`isPlainObject(new Intl.Locale('en')) === false`);
     // none of their structural surface is read, so each is a marker-only host


### PR DESCRIPTION
## Summary

Clears the five remaining HIR-lowering blockers gating es-toolkit's whole-crate build, plus four blockers they exposed — all general rules:

1. `Request` joins the marker-only host-object registry (`__smelt_request`), with instanceof/presence-guard folding.
2. Zero-arg `new RegExp()` lowers to the empty pattern `/(?:)/`.
3. `for...in` over a function value iterates the empty key list and `Object.hasOwn(fn, k)` folds `false` — the sound projection for property-less closures (a record-cast alternative emitted non-compiling Rust and was rejected via e2e verification).
4. `instanceof Array` folds like `Array.isArray`: list/tuple → `true`, erased → runtime `UnknownIs{Array}`, else `false`.
5. Unannotated constructor-function parameters default to `unknown`, scoped to the constructor-function synthesis path (synthesized fields are all `unknown` anyway; plain untyped functions still require annotations). Resolves the previously deferred matchesProperty shape — no fixture exclusion needed.

Also fixed en route: `String.raw` tagged templates, cross-`it`-block synthesized-class scoping, and a constructor-presence-guard ternary fold that avoids `SmeltUnknown` reconciliation of mismatched arms.

**Milestone**: the whole es-toolkit crate now fully HIR-lowers. `smelt build` advances to MIR, where two separate families remain (`await` outside an async function in async-closure values; an assignment-target blocker in `src/array/pull.ts`).

## Verification

- `cargo check --workspace` clean; clippy (pedantic, lib) clean on touched crates; frontend 841 / stdlib 21 / hir 511 / codegen suites green; new regression tests in `estk_transpile_gate_tests.rs` + `constructor_function_tests.rs`.
- Per-family e2e fixtures compile and run green.
- Report committed at `blocker-logs/estk-transpile-gate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_