### PR TITLE
feat: module-level mutable state via thread-local global cells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ blocker-logs/*.md
 !blocker-logs/estk-transpile-gate.md
 # estk-mir-gates.md documents the es-toolkit MIR-lowering gate fixes (await/assignment/postfix)
 !blocker-logs/estk-mir-gates.md
+# estk-module-globals.md documents module-level mutable state (thread-local mutable globals)
+!blocker-logs/estk-module-globals.md
 
 # Generated docs site output
 _site/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4496,6 +4496,7 @@ checksum = "877f4f705cb80d82d68e25b7db5dd8551d0f21c584c3457e90968502e6b65c0d"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
+ "oxc_ast_visit",
  "oxc_diagnostics",
  "oxc_parser",
  "oxc_regular_expression",

--- a/blocker-logs/estk-module-globals.md
+++ b/blocker-logs/estk-module-globals.md
@@ -1,0 +1,155 @@
+# Module-level mutable state (mutable globals)
+
+Implements the last known gate before es-toolkit's first whole-crate transpile:
+`smelt build` aborted at `src/compat/util/uniqueId.ts` on
+`let idCounter = 0; ... ++idCounter` ("only local, field, and index expressions
+can be assigned"). Module-level `let`/`var` bindings mutated from hoisted item
+bodies now lift to first-class "mutable globals" backed by per-test-thread
+`thread_local!` cells.
+
+## Design
+
+- **HIR**: `Item::MutableGlobal` (name, primitive type, literal initializer,
+  visibility, span) plus two expression kinds:
+  - `GlobalGet { item }` — read, typed as the binding's type.
+  - `GlobalSet { item, value }` — store; evaluates to the stored value so
+    `++`/`+=` compose as expressions.
+- **Frontend classification** (`collect_mutable_globals`,
+  `crates/smelt-frontend-ts/src/lowering/module_init.rs`): a module-level
+  `let`/`var` binding lifts iff it is mutated (reassignment, `++`/`--`,
+  compound assignment) inside a *hoisted item body*: a top-level function
+  declaration, class declaration, or `const` arrow/function initializer —
+  the positions that lower to items with no module-body local to assign
+  through. Mutations written directly in module-body statements (including
+  inline `forEach` callbacks and vitest `it()` callbacks) keep today's
+  module-body-local path, byte-identical. `var` is treated like `let`.
+- **Desugaring** (`stmt/assignments.rs`): `x = e` → `GlobalSet(x, e)`;
+  `x op= e` → `GlobalSet(x, GlobalGet(x) op e)`; `++x` →
+  `GlobalSet(x, GlobalGet(x) + 1)` (value = new); `x++` in value position
+  captures `GlobalGet(x)` in a temp `let`, emits the store as a side
+  statement, and evaluates to the temp (value = old). Statement-position
+  updates skip the old-value temp. A same-named local (function body or
+  replayed test setup declaring its own binding) always shadows the global.
+- **Same-declaration recognition**: the lifted binding's *own* declaration —
+  in the module body or replayed as top-level test setup into a test body —
+  is recognized by binding span (`is_lifted_global_declarator`) and skipped,
+  so reads/writes resolve to the global. A different same-named declaration
+  (other span) still creates its ordinary shadowing local.
+- **Cross-module**: the lifted item is a module item; exports/imports resolve
+  through the existing item-visibility machinery, so importer reads/writes
+  reference the same `ItemId` and the same cell.
+- **MIR**: `Mir.globals: Vec<MirGlobal { name, ty, init }>` populated by
+  `lower_globals`; `Rvalue::GlobalGet { global: u32 }` /
+  `Rvalue::GlobalSet { global, value }` (Set's result is the stored value).
+  No new `Place` variant — global writes never reach `lower_place`.
+- **Codegen** (`emit_mutable_globals`, gated on `!mir.globals.is_empty()`):
+  one `thread_local!` per global, named `SMELT_GLOBAL_<NAME>_<index>`
+  (index-disambiguated across modules; program-specific, never in the fixed
+  runtime-symbol registry). Copy primitives use
+  `Cell<f64/i64/bool> = const { Cell::new(init) }`; strings use
+  `RefCell<String> = RefCell::new("…".to_owned())` (owned init cannot be
+  `const`). Reads: `.with(Cell::get)` / `.with(|v| v.borrow().clone())`.
+  Writes hoist the operand and evaluate to it. **Per-test semantics**: every
+  `#[test]` runs on its own thread, so each test observes fresh module state
+  initialized from the source literal — deterministic, mirroring vitest's
+  per-file module isolation.
+
+## V1 constraints (named blockers)
+
+- Non-literal initializer → "module-level mutable binding initializer must be
+  a literal for now".
+- Non-primitive type (not Float/Int/Bool/String) → "module-level mutable
+  bindings support primitive types for now".
+
+Both fire only for bindings that classify as mutable globals — shapes whose
+function-body writes previously always aborted MIR with the generic
+"only local, field, and index expressions can be assigned", so the named
+blockers strictly improve the failure without regressing anything that
+transpiled before. Two pre-existing tests were updated accordingly:
+`lowers_module_mutable_default_options_accessors` (date-fns `defaultOptions`
+object initializer: HIR-lowered before but could never pass MIR; now the named
+initializer blocker) and
+`vitest_describe_expression_setup_is_replayed_into_nested_tests` (now lifts
+`clock`, 3 module items, and the replayed setup observes the real global).
+
+### Scope refinement vs. the original design note
+
+The design said "mutated anywhere in the crate". Implemented as "mutated in
+any hoisted item body" because module-body-only mutations already lower
+correctly as module-body locals; lifting them would have imposed the literal
+initializer constraint on working code (4 pre-existing codegen/snapshot tests
+went red under the broad rule; all green under the refined rule). For valid
+ES modules the two rules agree on cross-module behavior: assigning to an
+*imported* binding is illegal TS, so cross-module mutations always occur in
+the defining module's functions.
+
+## First-abort loop after uniqueId
+
+With uniqueId cleared, `smelt build` at the pinned es-toolkit root advances
+to further pre-existing families (verified pre-existing by re-running main's
+binary, which still aborts at uniqueId.ts first). Fixed generally here:
+
+1. **Narrowing leak across sibling tests** (`isEqualWith.spec.ts`): an
+   observed-type narrowing recorded in one `it` body
+   (`array1 = /c/.exec(...)` → `Optional<SmeltMatch>`) leaked into a sibling
+   `it` declaring its own `array1`, turning its indexed write into a
+   non-assignable `OptionalIndex`. Narrowing facts are now scoped per test
+   case exactly like `self.locals`
+   (`lowering/testing/suites.rs`).
+2. **`delete list[i]`** (compat `unset` specialized over lists): dense
+   `Vec<T>` lists cannot represent holes, so the delete emits a successful
+   no-op `true` — the same explicit-deferral style as no-op list `length`
+   growth (`emitter/map.rs`).
+3. **List-extend coercion** (`emitter/list_mutation.rs`): a generic
+   `SmeltList<T>` argument extending an erased `SmeltList<SmeltUnknown>`
+   receiver now coerces through the shared `value_at_type` conversion instead
+   of erroring.
+4. **String-contains erased haystack** (`emitter/strings.rs`): unscoped
+   type-parameter/union/`never`/erased-class haystacks route through the same
+   runtime `.includes` boundary as plain `Unknown`; the positional form
+   coerces via `value_at_type`. Several emit errors in this loop also now
+   include the offending types in their messages.
+
+## Status / remaining families
+
+- The pinned es-toolkit root still does **not** emit `dist-smelt`. The abort
+  order after this work (first-error at a time, enumerated in a scratch copy
+  with per-family excludes):
+  1. **`globalThis.File = class …` / `global.Buffer = …` monkey-patching**
+     (`isBlob.spec.ts`, `isFile.spec.ts`, `isBuffer.spec.ts`) — the
+     documented dynamic non-goal (global-object member writes); these specs
+     are exclusion candidates like the DOM specs, or need a modeled
+     global-property store. This is now the first abort at the pinned root.
+  2. **Optional-chained methods on modeled collection receivers**
+     (`stack?.has(source)` / `stack?.set(...)` on `Map | undefined` in
+     `compat/predicate/isMatchWith.ts`): the stdlib method dispatch handles
+     the non-optional receiver; the optional form falls through to the
+     generic `OptionalMethod`, whose codegen has no JS-Map surface. Needs an
+     optional-receiver desugar in the stdlib dispatch (architectural, not a
+     one-line arm).
+  3. Unknown further tail behind (2) — enumeration stopped there.
+- `delete array[i]` sparse-hole *runtime semantics* remain deferred (the
+  no-op transpiles; hole observations diverge at runtime).
+
+## Verification
+
+- Frontend: `crates/smelt-frontend-ts/src/tests/module_globals_tests.rs`
+  (lift + GlobalGet/GlobalSet shapes, prefix/postfix value semantics,
+  compound reads, `var`, non-mutated inline path unchanged, local shadowing,
+  both named blockers, narrowing scope regression).
+- Codegen: `crates/smelt-codegen-rust/src/tests/module_globals_tests.rs`
+  (const-init `Cell` and `RefCell<String>` thread-locals, get/set text,
+  gating with no globals, delete-on-list no-op).
+- End-to-end fixture mirroring uniqueId (module counter,
+  `uniqueId(prefix?)` returning `` `${prefix}${++counter}` ``, spec asserting
+  increments across calls in one test): `smelt build` + generated
+  `cargo test` green.
+- `cargo check --workspace --exclude smelt-gui`: clean.
+- `cargo clippy --lib -W clippy::pedantic` on smelt-hir, smelt-mir,
+  smelt-codegen-rust, smelt-frontend-ts, smelt-frontend-py,
+  smelt-transpiler: clean.
+- `cargo test --workspace --exclude smelt-gui`: 1755 passed, 0 failed.
+- No net `SmeltUnknown` increase: the new expression kinds and cells are
+  fully concrete (primitive `Cell`/`RefCell` ABI); the string-contains /
+  list-extend changes reuse existing erased boundaries for values that were
+  already erased.

--- a/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
@@ -1149,6 +1149,10 @@ impl FunctionEmitter<'_> {
             }
             Rvalue::JsonParse { text } => self.json_parse_text(text, dest_ty),
             Rvalue::HttpGetText { url } => self.http_get_text(url),
+            Rvalue::GlobalGet { global } => self.global_get_text(*global),
+            Rvalue::GlobalSet { global, value: stored } => {
+                self.global_set_text(*global, stored)
+            }
             Rvalue::DateNow => {
                 let text = "SMELT_DATE_NOW.with(::std::cell::Cell::get).unwrap_or_else(|| chrono::Utc::now().timestamp_millis())";
                 self.date_timestamp_result_text(text, dest_ty)
@@ -1307,6 +1311,49 @@ impl FunctionEmitter<'_> {
             "reqwest::blocking::get({}).expect(\"HTTP GET failed\").text().expect(\"HTTP response body read failed\")",
             self.operand_text(url)?
         ))
+    }
+
+    /// Emit a read of a mutable global's thread-local cell.
+    ///
+    /// Copy primitives read through `Cell::get`; strings clone the borrowed
+    /// `RefCell<String>` contents.
+    fn global_get_text(&self, global: u32) -> Result<String, EmitError> {
+        let name = crate::global_static_name(self.mir, global);
+        let ty = self.global_ty(global)?;
+        if matches!(self.mir.types.get(ty), Some(Type::String)) {
+            Ok(format!("{name}.with(|value| value.borrow().clone())"))
+        } else {
+            Ok(format!("{name}.with(::std::cell::Cell::get)"))
+        }
+    }
+
+    /// Emit a store into a mutable global's thread-local cell.
+    ///
+    /// The stored value is hoisted to a temporary so the block evaluates to the
+    /// stored value, letting `++`/`+=` compose as expressions. Copy primitives
+    /// use `Cell::set`; strings replace the `RefCell<String>` contents.
+    fn global_set_text(&self, global: u32, value: &Operand) -> Result<String, EmitError> {
+        let name = crate::global_static_name(self.mir, global);
+        let ty = self.global_ty(global)?;
+        let value_text = self.value_at_type(value, ty)?;
+        if matches!(self.mir.types.get(ty), Some(Type::String)) {
+            Ok(format!(
+                "{{ let smelt_global_value = {value_text}; {name}.with(|value| *value.borrow_mut() = smelt_global_value.clone()); smelt_global_value }}"
+            ))
+        } else {
+            Ok(format!(
+                "{{ let smelt_global_value = {value_text}; {name}.with(|value| value.set(smelt_global_value)); smelt_global_value }}"
+            ))
+        }
+    }
+
+    /// Look up the primitive type of a mutable global by index.
+    fn global_ty(&self, global: u32) -> Result<TypeId, EmitError> {
+        self.mir
+            .globals
+            .get(id_index(global, "mutable global index does not fit usize")?)
+            .map(|entry| entry.ty)
+            .ok_or_else(|| EmitError::new("mutable global index is out of range"))
     }
 
     /// Converts a function call to its Rust text representation.
@@ -2753,9 +2800,12 @@ impl FunctionEmitter<'_> {
             ));
         }
         let Some(Type::Class { name, .. }) = self.mir.types.get(receiver_ty) else {
-            return Err(EmitError::new(
-                "optional field codegen requires a class or string-keyed dict receiver",
-            ));
+            return Err(EmitError::new(format!(
+                "optional field codegen requires a class or string-keyed dict receiver, got {} for field `{}`",
+                Self::type_text_for(self.mir, receiver_ty)
+                    .unwrap_or_else(|_error| format!("{receiver_ty:?}")),
+                self.symbol_source_name(field).unwrap_or_default()
+            )));
         };
         if let Some(method_text) = self.class_method_reference_text(receiver_text, *name, field)? {
             return Ok(method_text);

--- a/crates/smelt-codegen-rust/src/emitter/list_mutation.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_mutation.rs
@@ -195,11 +195,15 @@ impl FunctionEmitter<'_> {
         if !matches!(self.mir.types.get(list_ty), Some(Type::List(_))) {
             return Err(EmitError::new("list extend receiver must be a list"));
         }
-        if self.operand_ty(other)? != list_ty {
-            return Err(EmitError::new(
-                "list extend argument must match the receiver list type",
-            ));
-        }
+        // A mismatched argument list (e.g. a generic `SmeltList<T>` extending an
+        // erased `SmeltList<SmeltUnknown>` receiver) coerces through the shared
+        // `value_at_type` conversion instead of failing; genuinely unconvertible
+        // shapes still produce that helper's honest error.
+        let other_text = if self.operand_ty(other)? == list_ty {
+            self.operand_text(other)?
+        } else {
+            self.value_at_type(other, list_ty)?
+        };
         let returns_length = match self.mir.types.get(dest_ty) {
             Some(Type::Float) => true,
             Some(Type::None) => false,
@@ -215,7 +219,6 @@ impl FunctionEmitter<'_> {
             ));
         };
         let list_text = self.local_mut_value_text(*local)?;
-        let other_text = self.operand_text(other)?;
         if returns_length {
             Ok(format!(
                 "{{ {list_text}.extend({other_text}.iter().cloned()); {list_text}.len() as f64 }}"

--- a/crates/smelt-codegen-rust/src/emitter/literals.rs
+++ b/crates/smelt-codegen-rust/src/emitter/literals.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::rust::RustExpr;
 
 /// Converts a MIR constant to Rust source text.
-pub(super) fn constant_text(constant: &Constant) -> String {
+pub(crate) fn constant_text(constant: &Constant) -> String {
     match constant {
         Constant::Bool(value) => value.to_string(),
         Constant::Int(value) => value.to_string(),

--- a/crates/smelt-codegen-rust/src/emitter/map.rs
+++ b/crates/smelt-codegen-rust/src/emitter/map.rs
@@ -313,7 +313,22 @@ impl FunctionEmitter<'_> {
                 }
                 return Ok("true".to_owned());
             }
-            return Err(EmitError::new("dict remove receiver must be a dict"));
+            // JavaScript `delete list[i]` punches a hole while preserving
+            // length. Smelt lists are dense `Vec<T>` with no hole
+            // representation, so the delete lowers to a successful no-op —
+            // the same explicit deferral style as no-op list `length` growth.
+            // Subsequent reads observe the retained element instead of a hole.
+            if matches!(self.mir.types.get(dict_ty), Some(Type::List(_) | Type::Tuple(_))) {
+                if !matches!(self.mir.types.get(dest_ty), Some(Type::Bool)) {
+                    return Err(EmitError::new("dict remove destination must be bool"));
+                }
+                return Ok("true".to_owned());
+            }
+            return Err(EmitError::new(format!(
+                "dict remove receiver must be a dict, got {}",
+                Self::type_text_for(self.mir, dict_ty)
+                    .unwrap_or_else(|_error| format!("{dict_ty:?}"))
+            )));
         };
         // Coerce a dynamically-typed (`Unknown`/optional/union) key to the dict's
         // key type instead of dropping the removal — mirrors `dict_set_text`.

--- a/crates/smelt-codegen-rust/src/emitter/mod.rs
+++ b/crates/smelt-codegen-rust/src/emitter/mod.rs
@@ -31,7 +31,7 @@ mod list;
 mod list_mutation;
 mod list_ordering;
 mod list_query;
-mod literals;
+pub(crate) mod literals;
 mod map;
 mod numeric;
 mod place;

--- a/crates/smelt-codegen-rust/src/emitter/strings.rs
+++ b/crates/smelt-codegen-rust/src/emitter/strings.rs
@@ -664,6 +664,25 @@ impl FunctionEmitter<'_> {
                 self.operand_text(needle)?
             ));
         }
+        // Other erased haystacks (unscoped type parameters, unions, `never`,
+        // erased classes) reach here through specialization; erase the value to
+        // the runtime `SmeltUnknown` boundary and use the same `.includes`
+        // helper as the plain-`Unknown` fast path above.
+        if from_index.is_none()
+            && (matches!(
+                self.mir.types.get(haystack_ty),
+                Some(Type::Union(_) | Type::TypeParam { .. } | Type::Never)
+            ) || self.is_erased_class_type(haystack_ty))
+        {
+            let erased_haystack = self.erase_value_text(
+                &format!("{}.clone()", self.operand_text(haystack)?),
+                haystack_ty,
+            )?;
+            return Ok(format!(
+                "{erased_haystack}.includes({})",
+                self.operand_text(needle)?
+            ));
+        }
         if from_index.is_none()
             && self.mir.types.get(needle_ty) == Some(&Type::Unknown)
             && self.mir.types.get(haystack_ty) == Some(&Type::String)
@@ -677,18 +696,35 @@ impl FunctionEmitter<'_> {
                 self.operand_text(needle)?
             ));
         }
-        if !matches!(self.mir.types.get(haystack_ty), Some(Type::String))
-            || !matches!(self.mir.types.get(needle_ty), Some(Type::String))
-        {
-            return Err(EmitError::new("string contains operands must be strings"));
+        if !matches!(self.mir.types.get(needle_ty), Some(Type::String)) {
+            return Err(EmitError::new(format!(
+                "string contains needle must be a string, got {}",
+                Self::type_text_for(self.mir, needle_ty)
+                    .unwrap_or_else(|_error| format!("{needle_ty:?}"))
+            )));
         }
         if let Some(from_index_operand) = from_index {
-            let haystack_text = self.operand_text(haystack)?;
+            // A non-string haystack (e.g. an erased value reaching the
+            // positional form through specialization) coerces through the
+            // shared `value_at_type` conversion; genuinely unconvertible
+            // shapes still produce that helper's honest error.
+            let haystack_text = if matches!(self.mir.types.get(haystack_ty), Some(Type::String)) {
+                self.operand_text(haystack)?
+            } else {
+                self.value_at_type(haystack, self.type_id(Type::String)?)?
+            };
             let needle_text = self.operand_text(needle)?;
             let index_text = self.value_at_type(from_index_operand, self.type_id(Type::Float)?)?;
             return Ok(format!(
                 "{{ let smelt_haystack = {haystack_text}; let smelt_from = ({index_text} as i64).max(0) as usize; let smelt_prefix_bytes = smelt_haystack.char_indices().nth(smelt_from).map_or(smelt_haystack.len(), |(byte, _)| byte); smelt_haystack.get(smelt_prefix_bytes..).map_or(false, |suffix| suffix.contains(&{needle_text})) }}"
             ));
+        }
+        if !matches!(self.mir.types.get(haystack_ty), Some(Type::String)) {
+            return Err(EmitError::new(format!(
+                "string contains haystack must be a string, got {}",
+                Self::type_text_for(self.mir, haystack_ty)
+                    .unwrap_or_else(|_error| format!("{haystack_ty:?}"))
+            )));
         }
         Ok(format!(
             "{}.contains(&{})",

--- a/crates/smelt-codegen-rust/src/lib.rs
+++ b/crates/smelt-codegen-rust/src/lib.rs
@@ -2189,6 +2189,17 @@ fn emit_source_with_free_function_router(
     }
     out.push_str(&format!("\n\n{PRELUDE_END_MARKER}\n"));
 
+    // Emit one thread-local cell per module-level mutable global. These are
+    // program-specific mangled names (not fixed runtime symbols): each `#[test]`
+    // thread observes fresh module state initialized from the source literal,
+    // deterministic and mirroring vitest's per-file module isolation. Copy
+    // primitives use a `const`-initialized `Cell`; strings use the non-const
+    // `RefCell` form because a `.to_owned()` initializer cannot be `const`.
+    if !mir.globals.is_empty() {
+        out.push('\n');
+        out.push_str(&emit_mutable_globals(mir)?);
+    }
+
     let mut has_emitted_root_function = false;
     for function in &mir.functions {
         if matches!(
@@ -2967,6 +2978,71 @@ fn generated_deps(mir: &Mir) -> Vec<GeneratedDep> {
 /// Helper struct for emitting Rust code from a MirFunction.
 fn sanitize_ident(name: &str) -> String {
     RustIdent::new(name).into_string()
+}
+
+/// Emit the `thread_local!` block declaring every mutable global's cell.
+///
+/// Each `#[test]` runs on its own thread, so a `thread_local!` cell gives every
+/// test a fresh copy of module state initialized from the source literal —
+/// deterministic, mirroring vitest's per-file module isolation. Copy primitives
+/// (`f64`/`i64`/`bool`) use a `const`-initialized [`std::cell::Cell`]; strings
+/// use a [`std::cell::RefCell`] with the non-const initializer form because a
+/// `.to_owned()` initializer cannot appear in a `const` block.
+fn emit_mutable_globals(mir: &Mir) -> Result<String, EmitError> {
+    let mut writer = CodeWriter::new();
+    writer.line("thread_local! {");
+    for (index, global) in mir.globals.iter().enumerate() {
+        let name = global_static_name(mir, compact_index(index, "global index")?);
+        let init = emitter::literals::constant_text(&global.init);
+        match mir.types.get(global.ty) {
+            Some(Type::String) => {
+                // `init` is already the owned-string expression (`"…".to_owned()`),
+                // which cannot appear in a `const` block, hence the non-const form.
+                writer.line(format!(
+                    "    static {name}: ::std::cell::RefCell<String> = ::std::cell::RefCell::new({init});"
+                ));
+            }
+            Some(Type::Float) => {
+                writer.line(format!(
+                    "    static {name}: ::std::cell::Cell<f64> = const {{ ::std::cell::Cell::new({init}) }};"
+                ));
+            }
+            Some(Type::Int) => {
+                writer.line(format!(
+                    "    static {name}: ::std::cell::Cell<i64> = const {{ ::std::cell::Cell::new({init}) }};"
+                ));
+            }
+            Some(Type::Bool) => {
+                writer.line(format!(
+                    "    static {name}: ::std::cell::Cell<bool> = const {{ ::std::cell::Cell::new({init}) }};"
+                ));
+            }
+            _ => {
+                return Err(EmitError::new(
+                    "mutable global has a non-primitive type; only Float/Int/Bool/String are supported",
+                ));
+            }
+        }
+    }
+    writer.line("}");
+    Ok(writer.finish())
+}
+
+/// Compute the thread-local static name for a mutable global by index.
+///
+/// The name is derived from the binding's source symbol (sanitized and
+/// uppercased) with the global's dense `Mir::globals` index appended, prefixed
+/// `SMELT_GLOBAL_`. Including the index disambiguates cross-module bindings
+/// that share a source name so each mutable global gets a unique per-program
+/// static. These names are program-specific and never enter the fixed
+/// runtime-symbol registry.
+pub(crate) fn global_static_name(mir: &Mir, index: u32) -> String {
+    let base = usize::try_from(index)
+        .ok()
+        .and_then(|idx| mir.globals.get(idx))
+        .and_then(|global| mir.symbols.get(global.name))
+        .map_or_else(|| "global".to_owned(), sanitize_ident);
+    format!("SMELT_GLOBAL_{}_{index}", base.to_uppercase())
 }
 
 #[cfg(test)]

--- a/crates/smelt-codegen-rust/src/tests/mod.rs
+++ b/crates/smelt-codegen-rust/src/tests/mod.rs
@@ -62,5 +62,6 @@ mod part_5_tests;
 mod part_6_tests;
 mod part_7_tests;
 mod generics_tests;
+mod module_globals_tests;
 mod snapshot_tests;
 mod snapshot_tests_part_2;

--- a/crates/smelt-codegen-rust/src/tests/module_globals_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/module_globals_tests.rs
@@ -1,0 +1,128 @@
+//! Codegen coverage for module-level mutable globals.
+//!
+//! Each lifted mutable global emits one `thread_local!` cell (const-init `Cell`
+//! for copy primitives, `RefCell<String>` for strings); reads go through
+//! `.with(::std::cell::Cell::get)` / `.with(|value| value.borrow().clone())`
+//! and writes through a block that stores and evaluates to the stored value.
+//! Emission is gated on the MIR globals table being non-empty.
+
+use super::*;
+
+#[test]
+fn mutated_module_let_emits_const_init_cell_thread_local() {
+    let source = source_for(
+        r#"
+let idCounter = 0;
+
+export function uniqueId(): number {
+  return ++idCounter;
+}
+"#,
+    );
+    assert!(
+        source.contains(
+            "static SMELT_GLOBAL_ID_COUNTER_0: ::std::cell::Cell<f64> = const { ::std::cell::Cell::new(0.0) };"
+        ),
+        "expected const-init Cell thread_local, got:\n{source}"
+    );
+    assert!(
+        source.contains("SMELT_GLOBAL_ID_COUNTER_0.with(::std::cell::Cell::get)"),
+        "expected Cell get read, got:\n{source}"
+    );
+    assert!(
+        source.contains("SMELT_GLOBAL_ID_COUNTER_0.with(|value| value.set(smelt_global_value))"),
+        "expected Cell set write returning the stored value, got:\n{source}"
+    );
+}
+
+#[test]
+fn mutated_module_string_let_emits_refcell_thread_local() {
+    let source = source_for(
+        r#"
+let lastTag = '';
+
+export function remember(tag: string): string {
+  lastTag = tag;
+  return lastTag;
+}
+"#,
+    );
+    assert!(
+        source.contains(
+            "static SMELT_GLOBAL_LAST_TAG_0: ::std::cell::RefCell<String> = ::std::cell::RefCell::new(\"\".to_owned());"
+        ),
+        "expected RefCell<String> thread_local, got:\n{source}"
+    );
+    assert!(
+        source.contains("SMELT_GLOBAL_LAST_TAG_0.with(|value| value.borrow().clone())"),
+        "expected RefCell clone read, got:\n{source}"
+    );
+    assert!(
+        source.contains(
+            "SMELT_GLOBAL_LAST_TAG_0.with(|value| *value.borrow_mut() = smelt_global_value.clone())"
+        ),
+        "expected RefCell replace write, got:\n{source}"
+    );
+}
+
+#[test]
+fn bool_global_emits_bool_cell() {
+    let source = source_for(
+        r#"
+let enabled = false;
+
+export function toggle(): boolean {
+  enabled = !enabled;
+  return enabled;
+}
+"#,
+    );
+    assert!(
+        source.contains(
+            "static SMELT_GLOBAL_ENABLED_0: ::std::cell::Cell<bool> = const { ::std::cell::Cell::new(false) };"
+        ),
+        "expected bool Cell thread_local, got:\n{source}"
+    );
+}
+
+#[test]
+fn no_globals_emits_no_global_thread_locals() {
+    let source = source_for(
+        r#"
+let greeting = 'hello';
+
+export function greet(): string {
+  return greeting;
+}
+"#,
+    );
+    assert!(
+        !source.contains("SMELT_GLOBAL_"),
+        "non-mutated module let must not emit global thread_locals, got:\n{source}"
+    );
+}
+
+#[test]
+fn delete_on_list_receiver_emits_noop_true() {
+    // JavaScript `delete list[i]` punches a hole; Smelt lists are dense
+    // `Vec<T>` with no hole representation, so the delete lowers to a
+    // successful no-op (`true`) — the explicit-deferral style shared with
+    // no-op list `length` growth. Regression for the es-toolkit compat
+    // `unset(list, index)` specialization.
+    let source = source_for(
+        r#"
+export function unsetIndex(values: number[], index: number): boolean {
+  // @ts-expect-error delete on a dense array models a sparse hole
+  return delete values[index];
+}
+"#,
+    );
+    assert!(
+        source.contains("fn unset_index"),
+        "expected the function to emit, got:\n{source}"
+    );
+    assert!(
+        source.contains("bool = true"),
+        "expected the delete to emit a successful no-op `true`, got:\n{source}"
+    );
+}

--- a/crates/smelt-frontend-py/src/lowering/call.rs
+++ b/crates/smelt-frontend-py/src/lowering/call.rs
@@ -400,7 +400,10 @@ impl ModuleBuilder<'_> {
                             span,
                         })));
                     }
-                    Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) => {}
+                    Item::Interface(_)
+                    | Item::TypeAlias(_)
+                    | Item::Const(_)
+                    | Item::MutableGlobal(_) => {}
                 }
             }
         }

--- a/crates/smelt-frontend-py/src/lowering/member.rs
+++ b/crates/smelt-frontend-py/src/lowering/member.rs
@@ -22,7 +22,7 @@ impl ModuleBuilder<'_> {
         let span = self.span(call.range);
         let return_ty = match self.item_ref(item_id) {
             Item::Function(function) => function.return_ty,
-            Item::Class(_) | Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) => {
+            Item::Class(_) | Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) | Item::MutableGlobal(_) => {
                 return Ok(None);
             }
         };
@@ -123,7 +123,7 @@ impl ModuleBuilder<'_> {
         let span = self.span(call.range);
         let return_ty = match self.item_ref(item_id) {
             Item::Function(function) => function.return_ty,
-            Item::Class(_) | Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) => {
+            Item::Class(_) | Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) | Item::MutableGlobal(_) => {
                 return Ok(None);
             }
         };
@@ -292,9 +292,13 @@ impl ModuleBuilder<'_> {
                     span,
                 })))
             }
-            Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) => Err(
-                SmeltError::unsupported(span, "module namespace member is not callable"),
-            ),
+            Item::Interface(_)
+            | Item::TypeAlias(_)
+            | Item::Const(_)
+            | Item::MutableGlobal(_) => Err(SmeltError::unsupported(
+                span,
+                "module namespace member is not callable",
+            )),
         }
     }
 
@@ -323,12 +327,14 @@ impl ModuleBuilder<'_> {
                     args: vec![],
                 })
             }
-            Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) => {
-                match self.item_ref(item_id) {
-                    Item::Const(const_item) => const_item.ty,
-                    _ => self.intern_type(Type::None),
-                }
-            }
+            Item::Interface(_)
+            | Item::TypeAlias(_)
+            | Item::Const(_)
+            | Item::MutableGlobal(_) => match self.item_ref(item_id) {
+                Item::Const(const_item) => const_item.ty,
+                Item::MutableGlobal(global_item) => global_item.ty,
+                _ => self.intern_type(Type::None),
+            },
         }
     }
 

--- a/crates/smelt-frontend-py/src/lowering/specialization.rs
+++ b/crates/smelt-frontend-py/src/lowering/specialization.rs
@@ -1152,7 +1152,10 @@ impl ModuleBuilder<'_> {
                     self.ctx.krate.symbols.get(class.name) == Some(source_name)
                         && owner_name.is_none()
                 }
-                Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) => false,
+                Item::Interface(_)
+                | Item::TypeAlias(_)
+                | Item::Const(_)
+                | Item::MutableGlobal(_) => false,
             })
             .ok_or_else(|| {
                 SmeltError::native_specialization_adapter_required(

--- a/crates/smelt-frontend-py/src/lowering/validate.rs
+++ b/crates/smelt-frontend-py/src/lowering/validate.rs
@@ -178,6 +178,7 @@ fn item_name<'a>(krate: &'a smelt_hir::Crate, hir_item: &Item) -> Option<&'a str
         Item::Interface(interface) => interface.name,
         Item::TypeAlias(alias) => alias.name,
         Item::Const(const_item) => const_item.name,
+        Item::MutableGlobal(global_item) => global_item.name,
     };
     krate.symbols.get(symbol)
 }

--- a/crates/smelt-frontend-ts/Cargo.toml
+++ b/crates/smelt-frontend-ts/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 smelt-hir = { path = "../smelt-hir", version = "0.1.0" }
 smelt-specialize = { path = "../smelt-specialize", version = "0.1.0" }
 smelt-stdlib = { path = "../smelt-stdlib", version = "0.1.0" }
-oxc = { version = "0.138.0", features = ["semantic"] }
+oxc = { version = "0.138.0", features = ["semantic", "ast_visit"] }
 
 [dev-dependencies]
 pico-args = "0.5"

--- a/crates/smelt-frontend-ts/src/lowering.rs
+++ b/crates/smelt-frontend-ts/src/lowering.rs
@@ -417,6 +417,10 @@ struct ModuleBuilder<'ctx> {
     date_value_locals: HashSet<smelt_hir::LocalId>,
     /// Typed top-level mutable bindings visible from nested function bodies.
     module_globals: HashMap<String, smelt_hir::TypeId>,
+    /// Module-level `let`/`var` bindings lifted to mutable globals, mapped to
+    /// their HIR item id. Reads of these names lower to `GlobalGet` and writes
+    /// to `GlobalSet` instead of the const-inline or local-assignment paths.
+    mutable_global_items: HashMap<String, smelt_hir::ItemId>,
     /// Declared and imported items (functions, classes, interfaces).
     items: HashMap<String, smelt_hir::ItemId>,
     /// Class definitions by name.

--- a/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
@@ -627,6 +627,13 @@ impl ModuleBuilder<'_> {
                     return Ok(());
                 }
                 if let Expression::AssignmentExpression(assign) = &expr_stmt.expression {
+                    // A write to a lifted mutable global desugars to a
+                    // `GlobalSet` expression statement; it must intercept before
+                    // the discard-only module-global path below.
+                    if let Some(set) = self.try_global_assignment_expression(assign, body)? {
+                        body.push_stmt_to_block(block, Stmt::Expr(set));
+                        return Ok(());
+                    }
                     if block == body.root
                         && self.module_global_assignment_statement(assign, body, block)?
                     {
@@ -646,6 +653,12 @@ impl ModuleBuilder<'_> {
                     return Ok(());
                 }
                 if let Expression::UpdateExpression(update) = &expr_stmt.expression {
+                    // Statement-position `++`/`--` of a lifted mutable global
+                    // discards its result, so the old-value temp is skipped.
+                    if let Some(set) = self.try_global_update_expression(update, body, false)? {
+                        body.push_stmt_to_block(block, Stmt::Expr(set));
+                        return Ok(());
+                    }
                     let (target, value) = self.update_parts(update, body)?;
                     body.push_stmt_to_block(block, Stmt::Assign { target, value });
                     return Ok(());
@@ -1479,6 +1492,10 @@ impl ModuleBuilder<'_> {
         let result = match statement {
             Statement::ExpressionStatement(expr_stmt) => {
                 if let Expression::AssignmentExpression(assign) = &expr_stmt.expression {
+                    if let Some(set) = self.try_global_assignment_expression(assign, body)? {
+                        body.push_stmt_to_block(block, Stmt::Expr(set));
+                        return Ok(());
+                    }
                     if self.try_lower_negative_bracket_write_statement(assign, body, block)? {
                         return Ok(());
                     }

--- a/crates/smelt-frontend-ts/src/lowering/expr/references.rs
+++ b/crates/smelt-frontend-ts/src/lowering/expr/references.rs
@@ -136,6 +136,21 @@ impl ModuleBuilder<'_> {
             );
         }
         let Some(local) = self.locals.get(name).copied() else {
+            // A module-level `let`/`var` binding lifted to a mutable global (and
+            // not shadowed by a local) reads through `GlobalGet`, never the
+            // const-inline path. This also resolves imported mutated bindings,
+            // which appear in `items` as the same `MutableGlobal` item.
+            if let Some(item) = self.mutable_global_item(name) {
+                let ty = match self.item_ref(item) {
+                    Item::MutableGlobal(global_item) => global_item.ty,
+                    _ => self.ctx.krate.types.intern(Type::Unknown),
+                };
+                return Ok(body.push_expr(Expr {
+                    kind: ExprKind::GlobalGet { item },
+                    ty,
+                    span: self.span(start, end),
+                }));
+            }
             if let Some((pattern, flags, ty)) = self.const_regexps.get(name).cloned() {
                 let span = self.span(start, end);
                 let string_ty = self.ctx.krate.types.intern(Type::String);
@@ -257,6 +272,19 @@ impl ModuleBuilder<'_> {
             .ok()
             .is_none_or(|index| index >= body.locals.len())
         {
+            // A stale local entry from another body must not hide a lifted
+            // mutable global: the read still resolves through `GlobalGet`.
+            if let Some(item) = self.mutable_global_item(name) {
+                let ty = match self.item_ref(item) {
+                    Item::MutableGlobal(global_item) => global_item.ty,
+                    _ => self.ctx.krate.types.intern(Type::Unknown),
+                };
+                return Ok(body.push_expr(Expr {
+                    kind: ExprKind::GlobalGet { item },
+                    ty,
+                    span: self.span(start, end),
+                }));
+            }
             if let Some(value) = self.const_objects.get(name).cloned() {
                 return Ok(self.object_const_expression(&value, start, end, body));
             }

--- a/crates/smelt-frontend-ts/src/lowering/module_init.rs
+++ b/crates/smelt-frontend-ts/src/lowering/module_init.rs
@@ -23,8 +23,35 @@ use oxc::ast::ast::{
 use oxc::span::GetSpan;
 use smelt_hir::{
     Body, ConstItem, Expr, ExprKind, FileId, Function, FunctionOwner, FunctionType, Import, Item,
-    Language, Literal, Module, ModuleId, Param, SourceFile, Span, Type,
+    Language, Literal, Module, ModuleId, Param, SourceFile, Span, Type, Visibility,
 };
+
+/// Collects the names of every binding that is reassigned or `++`/`--` updated
+/// anywhere in a program, used to decide which module-level `let`/`var`
+/// bindings must be lifted to mutable globals.
+///
+/// Overriding [`oxc::ast_visit::Visit::visit_simple_assignment_target`] catches
+/// both assignment left-hand sides and increment/decrement arguments, since the
+/// default traversal routes both through a simple assignment target. Walking
+/// continues into nested nodes so function and method bodies are covered.
+struct MutatedNameCollector {
+    /// Names observed as an assignment or update target.
+    names: HashSet<String>,
+}
+
+impl<'a> oxc::ast_visit::Visit<'a> for MutatedNameCollector {
+    fn visit_simple_assignment_target(
+        &mut self,
+        target: &oxc::ast::ast::SimpleAssignmentTarget<'a>,
+    ) {
+        if let oxc::ast::ast::SimpleAssignmentTarget::AssignmentTargetIdentifier(identifier) =
+            target
+        {
+            self.names.insert(identifier.name.as_str().to_owned());
+        }
+        oxc::ast_visit::walk::walk_simple_assignment_target(self, target);
+    }
+}
 
 impl<'ctx> ModuleBuilder<'ctx> {
     /// Create a new module builder.
@@ -61,6 +88,7 @@ impl<'ctx> ModuleBuilder<'ctx> {
             locals: HashMap::new(),
             date_value_locals: HashSet::new(),
             module_globals: HashMap::new(),
+            mutable_global_items: HashMap::new(),
             items,
             classes,
             pending_class_names: HashSet::new(),
@@ -220,6 +248,7 @@ impl<'ctx> ModuleBuilder<'ctx> {
         self.predeclare_type_alias_items(program);
         self.collect_module_enums(program);
         self.collect_module_globals(program);
+        self.collect_mutable_globals(program, &mut module, &mut errors);
         self.pending_class_names = Self::program_class_names(program);
         self.collect_overload_signatures(program, &implemented_functions);
         self.collect_forward_function_types(program, &implemented_functions);
@@ -673,6 +702,257 @@ impl<'ctx> ModuleBuilder<'ctx> {
                     .insert(binding.name.as_str().to_owned(), ty);
             }
         }
+    }
+
+    /// Classify module-level `let`/`var` bindings that are mutated anywhere in
+    /// the module and lift each to a [`Item::MutableGlobal`].
+    ///
+    /// A binding is lifted only when it is reassigned or updated somewhere (the
+    /// [`MutatedNameCollector`] scan). Lifted bindings register a HIR item so
+    /// reads lower to `GlobalGet` and writes to `GlobalSet`; the item is added
+    /// to the module's item list so exported globals are visible cross-module.
+    /// V1 constraints — literal initializer and primitive type — are enforced
+    /// here with named blocker errors; a violating binding is not lifted.
+    pub(super) fn collect_mutable_globals(
+        &mut self,
+        program: &Program<'_>,
+        module: &mut Module,
+        errors: &mut Vec<SmeltError>,
+    ) {
+        let mutated = Self::collect_mutated_names(program);
+        if mutated.is_empty() {
+            return;
+        }
+        for statement in &program.body {
+            match statement {
+                Statement::VariableDeclaration(variable) => {
+                    self.register_mutable_global_decl(
+                        variable,
+                        &mutated,
+                        Visibility::Private,
+                        module,
+                        errors,
+                    );
+                }
+                Statement::ExportNamedDeclaration(export) => {
+                    if let Some(Declaration::VariableDeclaration(variable)) = &export.declaration {
+                        self.register_mutable_global_decl(
+                            variable,
+                            &mutated,
+                            Visibility::Public,
+                            module,
+                            errors,
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Lift each mutated identifier binding in one declaration to a global.
+    fn register_mutable_global_decl(
+        &mut self,
+        decl: &oxc::ast::ast::VariableDeclaration<'_>,
+        mutated: &HashSet<String>,
+        visibility: Visibility,
+        module: &mut Module,
+        errors: &mut Vec<SmeltError>,
+    ) {
+        // `var` is treated like `let`; `const` bindings can never be reassigned
+        // and keep the existing inline/const-item path.
+        if !matches!(
+            decl.kind,
+            oxc::ast::ast::VariableDeclarationKind::Let
+                | oxc::ast::ast::VariableDeclarationKind::Var
+        ) {
+            return;
+        }
+        for declarator in &decl.declarations {
+            let BindingPattern::BindingIdentifier(binding) = &declarator.id else {
+                continue;
+            };
+            let name = binding.name.as_str();
+            if !mutated.contains(name) {
+                continue;
+            }
+            let span = self.span(binding.span.start, binding.span.end);
+            let Some(init) = &declarator.init else {
+                errors.push(SmeltError::unsupported(
+                    span,
+                    "module-level mutable binding initializer must be a literal for now",
+                ));
+                continue;
+            };
+            let Some(literal) = self.mutable_global_literal_init(init) else {
+                errors.push(SmeltError::unsupported(
+                    span,
+                    "module-level mutable binding initializer must be a literal for now",
+                ));
+                continue;
+            };
+            let ty = match &declarator.type_annotation {
+                Some(annotation) => self
+                    .ts_type_to_hir(&annotation.type_annotation)
+                    .unwrap_or(literal.ty),
+                None => literal.ty,
+            };
+            if !self.mutable_global_type_is_primitive(ty) {
+                errors.push(SmeltError::unsupported(
+                    span,
+                    "module-level mutable bindings support primitive types for now",
+                ));
+                continue;
+            }
+            let symbol = self.intern_source_name(name);
+            let item = self.ctx.krate.push_item(Item::MutableGlobal(smelt_hir::MutableGlobalItem {
+                name: symbol,
+                ty,
+                init: literal.literal.clone(),
+                visibility,
+                span,
+            }));
+            module.items.push(item);
+            self.items.insert(name.to_owned(), item);
+            self.mutable_global_items.insert(name.to_owned(), item);
+        }
+    }
+
+    /// Accept only a direct number/string/bool literal initializer (through
+    /// transparent parenthesis/cast wrappers) for a mutable global.
+    fn mutable_global_literal_init(&mut self, expression: &Expression<'_>) -> Option<ConstLiteral> {
+        match expression {
+            Expression::NumericLiteral(literal) => Some(ConstLiteral {
+                literal: Literal::Float(literal.value),
+                ty: self.ctx.krate.types.intern(Type::Float),
+            }),
+            Expression::StringLiteral(literal) => Some(ConstLiteral {
+                literal: Literal::String(literal.value.to_string()),
+                ty: self.ctx.krate.types.intern(Type::String),
+            }),
+            Expression::BooleanLiteral(literal) => Some(ConstLiteral {
+                literal: Literal::Bool(literal.value),
+                ty: self.ctx.krate.types.intern(Type::Bool),
+            }),
+            Expression::ParenthesizedExpression(inner) => {
+                self.mutable_global_literal_init(&inner.expression)
+            }
+            Expression::TSAsExpression(inner) => {
+                self.mutable_global_literal_init(&inner.expression)
+            }
+            Expression::TSSatisfiesExpression(inner) => {
+                self.mutable_global_literal_init(&inner.expression)
+            }
+            Expression::TSNonNullExpression(inner) => {
+                self.mutable_global_literal_init(&inner.expression)
+            }
+            _ => None,
+        }
+    }
+
+    /// Return whether a lowered type is a primitive a mutable global supports.
+    fn mutable_global_type_is_primitive(&self, ty: smelt_hir::TypeId) -> bool {
+        matches!(
+            self.ctx.krate.types.get(ty),
+            Some(Type::Float | Type::Int | Type::Bool | Type::String)
+        )
+    }
+
+    /// Collect the names of every binding reassigned or updated inside a
+    /// hoisted item body: top-level function declarations, class declarations,
+    /// and `const` arrow/function initializers (all of which lower to items
+    /// with no access to a module-body local).
+    ///
+    /// Mutations written directly in module-body statements — including inline
+    /// callbacks such as `forEach` bodies — are deliberately NOT collected:
+    /// there the binding lowers to an ordinary mutable module-body local and
+    /// the existing assignment path already works, byte-identical to today.
+    /// Within each scanned subtree the collection is a conservative
+    /// over-approximation (it ignores inner shadowing scopes), which is
+    /// sufficient to decide which module-level `let`/`var` bindings need the
+    /// mutable-global lift.
+    fn collect_mutated_names(program: &Program<'_>) -> HashSet<String> {
+        use oxc::ast_visit::Visit;
+        let mut collector = MutatedNameCollector {
+            names: HashSet::new(),
+        };
+        for statement in &program.body {
+            let declaration = match statement {
+                Statement::FunctionDeclaration(function) => {
+                    collector.visit_function(function, oxc::semantic::ScopeFlags::Function);
+                    continue;
+                }
+                Statement::ClassDeclaration(class) => {
+                    collector.visit_class(class);
+                    continue;
+                }
+                Statement::VariableDeclaration(decl) => {
+                    Self::collect_mutated_names_in_const_callables(&mut collector, decl);
+                    continue;
+                }
+                Statement::ExportNamedDeclaration(export) => export.declaration.as_ref(),
+                Statement::ExportDefaultDeclaration(_) => None,
+                _ => None,
+            };
+            match declaration {
+                Some(Declaration::FunctionDeclaration(function)) => {
+                    collector.visit_function(function, oxc::semantic::ScopeFlags::Function);
+                }
+                Some(Declaration::ClassDeclaration(class)) => {
+                    collector.visit_class(class);
+                }
+                Some(Declaration::VariableDeclaration(decl)) => {
+                    Self::collect_mutated_names_in_const_callables(&mut collector, decl);
+                }
+                _ => {}
+            }
+        }
+        collector.names
+    }
+
+    /// Scan `const name = <arrow/function>` initializers for mutation targets.
+    ///
+    /// Const arrow/function bindings lift to items (the compact callback and
+    /// function-item forms), so their bodies — like function declarations —
+    /// have no module-body local to assign through and need the global lift.
+    fn collect_mutated_names_in_const_callables(
+        collector: &mut MutatedNameCollector,
+        decl: &oxc::ast::ast::VariableDeclaration<'_>,
+    ) {
+        use oxc::ast_visit::Visit;
+        if decl.kind != oxc::ast::ast::VariableDeclarationKind::Const {
+            return;
+        }
+        for declarator in &decl.declarations {
+            if let Some(
+                init @ (Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_)),
+            ) = &declarator.init
+            {
+                collector.visit_expression(init);
+            }
+        }
+    }
+
+    /// Return the mutable-global HIR item id for a name, if it was lifted.
+    pub(in crate::lowering) fn mutable_global_item(&self, name: &str) -> Option<smelt_hir::ItemId> {
+        let item = self.items.get(name).copied()?;
+        matches!(self.item_ref(item), Item::MutableGlobal(_)).then_some(item)
+    }
+
+    /// Return whether a binding declarator IS the lifted module-level
+    /// declaration of a mutable global (same name and binding span).
+    pub(in crate::lowering) fn is_lifted_global_declarator(
+        &self,
+        name: &str,
+        binding_span: oxc::span::Span,
+    ) -> bool {
+        let Some(item) = self.mutable_global_items.get(name).copied() else {
+            return false;
+        };
+        let Item::MutableGlobal(global_item) = self.item_ref(item) else {
+            return false;
+        };
+        global_item.span.start == binding_span.start && global_item.span.end == binding_span.end
     }
 
     /// Register simple names from a non-identifier module-level binding pattern.

--- a/crates/smelt-frontend-ts/src/lowering/new_expr.rs
+++ b/crates/smelt-frontend-ts/src/lowering/new_expr.rs
@@ -2308,6 +2308,9 @@ impl ModuleBuilder<'_> {
             }
             Expression::CallExpression(call) => self.call_expression(call, body),
             Expression::AssignmentExpression(assign) => {
+                if let Some(expr) = self.try_global_assignment_expression(assign, body)? {
+                    return Ok(expr);
+                }
                 let (_target, value) = self.assignment_parts(assign, body)?;
                 Ok(value)
             }

--- a/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
@@ -1539,6 +1539,153 @@ impl ModuleBuilder<'_> {
         }
     }
 
+    /// Return the mutable-global item id an assignment target names, if any.
+    ///
+    /// A function-local or test-body binding with the same name shadows the
+    /// module global, so a registered local always wins over the global path.
+    fn assignment_target_mutable_global(
+        &self,
+        target: &AssignmentTarget<'_>,
+    ) -> Option<smelt_hir::ItemId> {
+        let AssignmentTarget::AssignmentTargetIdentifier(identifier) = target else {
+            return None;
+        };
+        if self.locals.contains_key(identifier.name.as_str()) {
+            return None;
+        }
+        self.mutable_global_item(identifier.name.as_str())
+    }
+
+    /// Desugar an assignment to a lifted mutable global into a `GlobalSet`.
+    ///
+    /// Reuses [`Self::assignment_parts`] to compute the stored value (which
+    /// reads the current value through `GlobalGet` for compound and logical
+    /// operators), then wraps it in a `GlobalSet` that evaluates to the stored
+    /// value so `x = e` / `x += e` compose as expressions. Returns `Ok(None)`
+    /// when the target is not a lifted global so ordinary lowering proceeds.
+    pub(in crate::lowering) fn try_global_assignment_expression(
+        &mut self,
+        assign: &oxc::ast::ast::AssignmentExpression<'_>,
+        body: &mut Body,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        let Some(item) = self.assignment_target_mutable_global(&assign.left) else {
+            return Ok(None);
+        };
+        let (_target, value) = self.assignment_parts(assign, body)?;
+        let ty = Self::expr_ty(body, value);
+        Ok(Some(body.push_expr(Expr {
+            kind: ExprKind::GlobalSet { item, value },
+            ty,
+            span: self.span(assign.span.start, assign.span.end),
+        })))
+    }
+
+    /// Desugar an increment/decrement of a lifted mutable global.
+    ///
+    /// Prefix `++x` evaluates to the stored (new) value, so the `GlobalSet`
+    /// itself is returned. Postfix `x++` must evaluate to the old value while
+    /// still storing the incremented one; when `keep_old_value` is set (an
+    /// expression-value position) the old value is captured in a temporary
+    /// before the store is emitted as a side statement. In statement/loop
+    /// positions the result is discarded, so the `GlobalSet` is returned
+    /// directly. Returns `Ok(None)` when the target is not a lifted global.
+    pub(in crate::lowering) fn try_global_update_expression(
+        &mut self,
+        update: &oxc::ast::ast::UpdateExpression<'_>,
+        body: &mut Body,
+        keep_old_value: bool,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        let SimpleAssignmentTarget::AssignmentTargetIdentifier(identifier) = &update.argument else {
+            return Ok(None);
+        };
+        // A same-named local (function body or re-lowered test setup) shadows
+        // the module global; the ordinary local update path handles it.
+        if self.locals.contains_key(identifier.name.as_str()) {
+            return Ok(None);
+        }
+        let Some(item) = self.mutable_global_item(identifier.name.as_str()) else {
+            return Ok(None);
+        };
+        let span = self.span(update.span.start, update.span.end);
+        let ty = match self.item_ref(item) {
+            Item::MutableGlobal(global_item) => global_item.ty,
+            _ => self.ctx.krate.types.intern(Type::Unknown),
+        };
+        let op = match update.operator {
+            UpdateOperator::Increment => BinOp::Add,
+            UpdateOperator::Decrement => BinOp::Sub,
+        };
+        let build_set = |target_body: &mut Body| {
+            let current = target_body.push_expr(Expr {
+                kind: ExprKind::GlobalGet { item },
+                ty,
+                span,
+            });
+            let one = target_body.push_expr(Expr {
+                kind: ExprKind::Literal(Literal::Float(1.0)),
+                ty,
+                span,
+            });
+            let next = target_body.push_expr(Expr {
+                kind: ExprKind::BinOp {
+                    op,
+                    lhs: current,
+                    rhs: one,
+                },
+                ty,
+                span,
+            });
+            target_body.push_expr(Expr {
+                kind: ExprKind::GlobalSet { item, value: next },
+                ty,
+                span,
+            })
+        };
+        if update.prefix || !keep_old_value {
+            let set = build_set(body);
+            return Ok(Some(set));
+        }
+        // Postfix in an expression-value position: capture the old value in a
+        // temporary, emit the store as a side statement, then evaluate to the
+        // captured old value.
+        let old = body.push_expr(Expr {
+            kind: ExprKind::GlobalGet { item },
+            ty,
+            span,
+        });
+        let temp_local = body.push_local(LocalDecl {
+            name: Some(self.ctx.krate.symbols.intern("__smelt_global_old")),
+            ty,
+            mutable: false,
+            span,
+        });
+        let temp_pat = body.push_pattern(Pattern::Binding(temp_local));
+        let set = build_set(body);
+        if let Some(block) = self.current_statement_block {
+            body.push_stmt_to_block(
+                block,
+                Stmt::Let {
+                    pat: temp_pat,
+                    ty,
+                    value: Some(old),
+                },
+            );
+            body.push_stmt_to_block(block, Stmt::Expr(set));
+        } else {
+            body.push_stmt(Stmt::Let {
+                pat: temp_pat,
+                ty,
+                value: Some(old),
+            });
+            body.push_stmt(Stmt::Expr(set));
+        }
+        Ok(Some(body.push_expr(Expr {
+            kind: ExprKind::Local(temp_local),
+            ty,
+            span,
+        })))
+    }
+
     /// Extract target and value from assignment expression.
     pub(in crate::lowering) fn assignment_parts(
         &mut self,
@@ -1893,6 +2040,12 @@ impl ModuleBuilder<'_> {
         update: &oxc::ast::ast::UpdateExpression<'_>,
         body: &mut Body,
     ) -> Result<smelt_hir::ExprId, SmeltError> {
+        // A `++`/`--` of a lifted mutable global desugars to a `GlobalSet` that
+        // preserves JavaScript's prefix (new value) / postfix (old value)
+        // result semantics.
+        if let Some(expr) = self.try_global_update_expression(update, body, true)? {
+            return Ok(expr);
+        }
         let (target, value) = self.update_parts(update, body)?;
         if !update.prefix
             && let Some(deferred_updates) = self.deferred_postfix_updates.as_mut()

--- a/crates/smelt-frontend-ts/src/lowering/stmt/control_flow.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/control_flow.rs
@@ -22,8 +22,12 @@ impl ModuleBuilder<'_> {
                     self.variable_declaration(decl, body, block)?;
                 }
                 ForStatementInit::AssignmentExpression(assign) => {
-                    let (target, value) = self.assignment_parts(assign, body)?;
-                    body.push_stmt_to_block(block, Stmt::Assign { target, value });
+                    if let Some(set) = self.try_global_assignment_expression(assign, body)? {
+                        body.push_stmt_to_block(block, Stmt::Expr(set));
+                    } else {
+                        let (target, value) = self.assignment_parts(assign, body)?;
+                        body.push_stmt_to_block(block, Stmt::Assign { target, value });
+                    }
                 }
                 _ => {
                     return Err(SmeltError::unsupported(
@@ -80,11 +84,19 @@ impl ModuleBuilder<'_> {
                 Ok(())
             }
             Expression::AssignmentExpression(assign) => {
+                if let Some(set) = self.try_global_assignment_expression(assign, body)? {
+                    body.push_stmt_to_block(loop_body, Stmt::Expr(set));
+                    return Ok(());
+                }
                 let (target, value) = self.assignment_parts(assign, body)?;
                 body.push_stmt_to_block(loop_body, Stmt::Assign { target, value });
                 Ok(())
             }
             Expression::UpdateExpression(update_expr) => {
+                if let Some(set) = self.try_global_update_expression(update_expr, body, false)? {
+                    body.push_stmt_to_block(loop_body, Stmt::Expr(set));
+                    return Ok(());
+                }
                 let (target, value) = self.update_parts(update_expr, body)?;
                 body.push_stmt_to_block(loop_body, Stmt::Assign { target, value });
                 Ok(())

--- a/crates/smelt-frontend-ts/src/lowering/support.rs
+++ b/crates/smelt-frontend-ts/src/lowering/support.rs
@@ -14,6 +14,7 @@ pub(super) fn item_name<'a>(krate: &'a smelt_hir::Crate, item: &Item) -> Option<
         Item::Interface(interface) => interface.name,
         Item::TypeAlias(alias) => alias.name,
         Item::Const(const_item) => const_item.name,
+        Item::MutableGlobal(global_item) => global_item.name,
     };
     krate
         .names
@@ -52,7 +53,10 @@ pub(super) fn insert_visible_item(
         Item::Interface(_) => {
             interfaces.insert(name.to_owned(), item_id);
         }
-        Item::Function(_) | Item::TypeAlias(_) | Item::Const(_) => {}
+        Item::Function(_)
+        | Item::TypeAlias(_)
+        | Item::Const(_)
+        | Item::MutableGlobal(_) => {}
     }
 }
 

--- a/crates/smelt-frontend-ts/src/lowering/testing/matchers.rs
+++ b/crates/smelt-frontend-ts/src/lowering/testing/matchers.rs
@@ -2202,6 +2202,19 @@ impl ModuleBuilder<'_> {
         block: smelt_hir::BlockId,
     ) -> Result<(), SmeltError> {
         for declarator in &decl.declarations {
+            // A module-level `let`/`var` binding lifted to a mutable global is
+            // fully represented by its thread-local item (its literal
+            // initializer is the cell's initial value), so lowering the SAME
+            // source declaration — in the module body or replayed as top-level
+            // test setup — must not re-declare it as a shadowing local. The
+            // declaration is recognized by its binding span; a same-named
+            // binding declared elsewhere (a function or block scope) has a
+            // different span and still creates its ordinary shadowing local.
+            if let BindingPattern::BindingIdentifier(binding) = &declarator.id
+                && self.is_lifted_global_declarator(binding.name.as_str(), binding.span)
+            {
+                continue;
+            }
             // A `const Foo = function () { … }` binding recognized as a
             // constructor function was already synthesized into a class during
             // the block prepass; its declarator contributes no runtime binding.

--- a/crates/smelt-frontend-ts/src/lowering/testing/suites.rs
+++ b/crates/smelt-frontend-ts/src/lowering/testing/suites.rs
@@ -552,6 +552,13 @@ impl ModuleBuilder<'_> {
     ) -> Result<smelt_hir::ItemId, SmeltError> {
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_date_value_locals = std::mem::take(&mut self.date_value_locals);
+        // Flow-narrowing facts are keyed by NAME, so a fact recorded in one test
+        // body (e.g. `array1 = /c/.exec(...)` observing `Optional<SmeltMatch>`)
+        // must not leak into a sibling test that declares its own same-named
+        // binding — a stale optional narrowing would turn its indexed writes
+        // into non-assignable optional projections. Scope them per test case
+        // exactly like `self.locals`.
+        let saved_narrowed_locals = std::mem::take(&mut self.narrowed_locals);
         let saved_async = self.current_async;
         let class_scope = self.test_case_class_scope();
         self.current_async = arrow.r#async;
@@ -600,6 +607,7 @@ impl ModuleBuilder<'_> {
         }
         self.locals = saved_locals;
         self.date_value_locals = saved_date_value_locals;
+        self.narrowed_locals = saved_narrowed_locals;
         self.current_async = saved_async;
         self.restore_test_case_class_scope(&class_scope);
         if let Some(error) = errors.into_iter().next() {
@@ -662,6 +670,13 @@ return_ty: none,
 
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_date_value_locals = std::mem::take(&mut self.date_value_locals);
+        // Flow-narrowing facts are keyed by NAME, so a fact recorded in one test
+        // body (e.g. `array1 = /c/.exec(...)` observing `Optional<SmeltMatch>`)
+        // must not leak into a sibling test that declares its own same-named
+        // binding — a stale optional narrowing would turn its indexed writes
+        // into non-assignable optional projections. Scope them per test case
+        // exactly like `self.locals`.
+        let saved_narrowed_locals = std::mem::take(&mut self.narrowed_locals);
         let saved_async = self.current_async;
         let class_scope = self.test_case_class_scope();
         self.current_async = function.r#async;
@@ -723,6 +738,7 @@ return_ty: none,
         self.current_arguments_arities.pop();
         self.locals = saved_locals;
         self.date_value_locals = saved_date_value_locals;
+        self.narrowed_locals = saved_narrowed_locals;
         self.current_async = saved_async;
         self.restore_test_case_class_scope(&class_scope);
         if let Some(error) = errors.into_iter().next() {

--- a/crates/smelt-frontend-ts/src/tests/mod.rs
+++ b/crates/smelt-frontend-ts/src/tests/mod.rs
@@ -228,3 +228,4 @@ mod class_module_tests;
 mod enum_switch_tests;
 mod array_literal_expr_tests;
 mod estk_mir_gate_tests;
+mod module_globals_tests;

--- a/crates/smelt-frontend-ts/src/tests/module_globals_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/module_globals_tests.rs
@@ -1,0 +1,340 @@
+//! Regression coverage for module-level mutable state (mutable globals).
+//!
+//! A module-level `let`/`var` binding mutated anywhere in the module is lifted
+//! to an `Item::MutableGlobal`: reads lower to `ExprKind::GlobalGet` and writes
+//! desugar to `ExprKind::GlobalSet` (whose value is the stored value, so
+//! `++`/`+=` compose). Non-mutated module `let`s keep the existing inline
+//! paths, and the V1 constraints (literal initializer, primitive type) are
+//! explicit named blockers.
+
+use super::*;
+
+/// Return whether any body in the crate contains an expression matching `pred`.
+fn crate_has(ctx: &HirCtx, pred: impl Fn(&ExprKind) -> bool) -> bool {
+    ctx.krate
+        .bodies
+        .iter()
+        .any(|body| body.exprs.iter().any(|expr| pred(&expr.kind)))
+}
+
+/// Return whether the crate contains a lifted mutable-global item.
+fn crate_has_mutable_global(ctx: &HirCtx) -> bool {
+    ctx.krate
+        .items
+        .iter()
+        .any(|item| matches!(item, Item::MutableGlobal(_)))
+}
+
+#[test]
+fn mutated_module_let_lowers_reads_and_writes_through_globals() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+let idCounter = 0;
+
+export function uniqueId(): number {
+  return ++idCounter;
+}
+
+export function current(): number {
+  return idCounter;
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(
+        crate_has_mutable_global(&ctx),
+        "mutated module let should lift to an Item::MutableGlobal",
+    );
+    ensure!(
+        crate_has(&ctx, |kind| matches!(kind, ExprKind::GlobalGet { .. })),
+        "reads of a lifted binding should lower to GlobalGet",
+    );
+    ensure!(
+        crate_has(&ctx, |kind| matches!(kind, ExprKind::GlobalSet { .. })),
+        "`++` of a lifted binding should lower to GlobalSet",
+    );
+    Ok(())
+}
+
+#[test]
+fn prefix_increment_returns_global_set_result() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+let counter = 0;
+
+export function bump(): number {
+  return ++counter;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = named_function_item(&ctx, module, "bump")?;
+    let body = function_body(&ctx, function)?;
+    // The returned expression is the GlobalSet itself (new value).
+    let returned = body
+        .stmts
+        .iter()
+        .find_map(|stmt| match stmt {
+            Stmt::Return(Some(expr)) => Some(*expr),
+            _ => None,
+        })
+        .ok_or_else(|| "expected a return statement".to_owned())?;
+    let returned_kind = &body.exprs[returned.0 as usize].kind;
+    ensure!(
+        matches!(returned_kind, ExprKind::GlobalSet { .. }),
+        "prefix increment should return the GlobalSet (new value), got {returned_kind:?}",
+    );
+    Ok(())
+}
+
+#[test]
+fn postfix_increment_returns_old_value_temp() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+let counter = 0;
+
+export function bumpAfter(): number {
+  return counter++;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = named_function_item(&ctx, module, "bump_after")?;
+    let body = function_body(&ctx, function)?;
+    // The returned expression is a local temp holding the pre-increment value,
+    // while a GlobalSet statement performs the store.
+    let returned = body
+        .stmts
+        .iter()
+        .find_map(|stmt| match stmt {
+            Stmt::Return(Some(expr)) => Some(*expr),
+            _ => None,
+        })
+        .ok_or_else(|| "expected a return statement".to_owned())?;
+    let returned_kind = &body.exprs[returned.0 as usize].kind;
+    ensure!(
+        matches!(returned_kind, ExprKind::Local(_)),
+        "postfix increment should return the old-value temp local, got {returned_kind:?}",
+    );
+    ensure!(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::GlobalSet { .. })),
+        "postfix increment should still store through GlobalSet",
+    );
+    Ok(())
+}
+
+#[test]
+fn compound_assignment_reads_current_value_through_global_get() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+let total = 0;
+
+export function add(amount: number): number {
+  total += amount;
+  return total;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = named_function_item(&ctx, module, "add")?;
+    let body = function_body(&ctx, function)?;
+    // `total += amount` desugars to GlobalSet(total, GlobalGet(total) + amount).
+    let has_set_of_binop_over_get = body.exprs.iter().any(|expr| {
+        let ExprKind::GlobalSet { value, .. } = &expr.kind else {
+            return false;
+        };
+        let ExprKind::BinOp { op: BinOp::Add, lhs, .. } = &body.exprs[value.0 as usize].kind else {
+            return false;
+        };
+        matches!(body.exprs[lhs.0 as usize].kind, ExprKind::GlobalGet { .. })
+    });
+    ensure!(
+        has_set_of_binop_over_get,
+        "`+=` should desugar to GlobalSet over GlobalGet + rhs",
+    );
+    Ok(())
+}
+
+#[test]
+fn var_binding_is_treated_like_let() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+var flag = false;
+
+export function toggle(): boolean {
+  flag = !flag;
+  return flag;
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(
+        crate_has_mutable_global(&ctx),
+        "mutated module var should lift like let",
+    );
+    ensure!(
+        crate_has(&ctx, |kind| matches!(kind, ExprKind::GlobalSet { .. })),
+        "assignment to a lifted var should lower to GlobalSet",
+    );
+    Ok(())
+}
+
+#[test]
+fn non_mutated_module_let_keeps_inline_path() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+let greeting = 'hello';
+
+export function greet(): string {
+  return greeting;
+}
+"#),
+        &mut ctx,
+    )?;
+    ensure!(
+        !crate_has_mutable_global(&ctx),
+        "non-mutated module let must not lift to a mutable global",
+    );
+    ensure!(
+        !crate_has(&ctx, |kind| matches!(
+            kind,
+            ExprKind::GlobalGet { .. } | ExprKind::GlobalSet { .. }
+        )),
+        "non-mutated module let reads must keep the existing inline path",
+    );
+    Ok(())
+}
+
+#[test]
+fn function_local_binding_shadows_module_global() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+let counter = 0;
+
+export function bump(): number {
+  counter += 1;
+  return counter;
+}
+
+export function shadowed(): number {
+  let counter = 10;
+  counter += 1;
+  return counter;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = ctx.krate.modules.last().ok_or("missing module")?;
+    let shadowed = named_function_item(&ctx, module, "shadowed")?;
+    let body = function_body(&ctx, shadowed)?;
+    ensure!(
+        !body.exprs.iter().any(|expr| matches!(
+            expr.kind,
+            ExprKind::GlobalGet { .. } | ExprKind::GlobalSet { .. }
+        )),
+        "a same-named function local must shadow the module global",
+    );
+    Ok(())
+}
+
+#[test]
+fn non_literal_initializer_is_a_named_blocker() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let errors = lowering_errors(
+        ts!(r#"
+function seed(): number {
+  return 41;
+}
+
+let counter = seed();
+
+export function bump(): number {
+  counter = counter + 1;
+  return counter;
+}
+"#),
+        &mut ctx,
+    )?;
+    assert_unsupported_ts(
+        &errors,
+        "module-level mutable binding initializer must be a literal for now",
+    )
+}
+
+#[test]
+fn non_primitive_type_is_a_named_blocker() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let errors = lowering_errors(
+        ts!(r#"
+let holder: unknown = 0;
+
+export function stash(value: unknown): void {
+  holder = value;
+}
+"#),
+        &mut ctx,
+    )?;
+    assert_unsupported_ts(
+        &errors,
+        "module-level mutable bindings support primitive types for now",
+    )
+}
+
+#[test]
+fn narrowing_facts_do_not_leak_across_sibling_tests() -> Result<(), String> {
+    // Regression: an observed-type narrowing recorded in one test body
+    // (`array1 = /c/.exec(...)` observing `Optional<SmeltMatch>`) leaked into a
+    // sibling test that declares its own `array1`, turning its indexed write
+    // target into a non-assignable optional projection (`OptionalIndex`).
+    let mut ctx = HirCtx::new();
+    lower_path_ok(
+        ts!(r#"
+import { describe, expect, it } from 'vitest';
+
+describe('narrowing scope', () => {
+  it('records a match narrowing', () => {
+    let array1: any = [1, 2, 3];
+    array1 = /c/.exec('abcde');
+    expect(array1).toBe(array1);
+  });
+
+  it('declares its own array and writes by index', () => {
+    let array1: any[] = [];
+    array1 = ['a', 'b', 'c'];
+    array1[1] = array1;
+    expect(array1).toBe(array1);
+  });
+});
+"#),
+        "src/narrowing-scope.spec.ts",
+        &mut ctx,
+    )?;
+    // No assignment target in any body may be an optional projection.
+    for body in &ctx.krate.bodies {
+        for stmt in &body.stmts {
+            if let Stmt::Assign { target, .. } = stmt {
+                let kind = &body.exprs[target.0 as usize].kind;
+                ensure!(
+                    !matches!(
+                        kind,
+                        ExprKind::OptionalIndex { .. } | ExprKind::OptionalField { .. }
+                    ),
+                    "assignment target must not be an optional projection, got {kind:?}",
+                );
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/smelt-frontend-ts/src/tests/part02_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part02_tests.rs
@@ -69,7 +69,19 @@ describe("outer", () => {
     let mut ctx = HirCtx::new();
     let module_id = lower_path_ok(source, "src/setup-expression.test.ts", &mut ctx)?;
     let module = module(&ctx, module_id)?;
-    ensure_eq!(module.items.len(), 2);
+    // `clock` is a module-level `let` mutated inside `fakeDate`, so it lifts to
+    // a mutable-global item alongside the function item and the test item. The
+    // replayed setup reads and writes the same global (its declaration is not
+    // re-declared as a shadowing local), so the test observes `fakeDate`'s
+    // write.
+    ensure_eq!(module.items.len(), 3);
+    ensure!(
+        ctx.krate
+            .items
+            .iter()
+            .any(|item| matches!(item, Item::MutableGlobal(_))),
+        "mutated module let should lift to a mutable global",
+    );
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
     Ok(())
 }
@@ -1231,8 +1243,15 @@ let defaultOptions: DefaultOptions = {};
 
 #[test]
 fn lowers_module_mutable_default_options_accessors() -> Result<(), String> {
+    // `defaultOptions` is a module-level `let` mutated inside a function, so it
+    // classifies as a mutable global; its object initializer is outside the V1
+    // literal constraint, producing the named frontend blocker. Before the
+    // mutable-global lift this shape HIR-lowered but the function-body write
+    // had no assignable place, so MIR lowering always aborted with the generic
+    // "only local, field, and index expressions can be assigned" — the named
+    // blocker surfaces the same gap earlier and more precisely.
     let mut ctx = HirCtx::new();
-    let module_id = lower_ok(
+    let errors = lowering_errors(
         ts!(r#"
 interface LocalizedOptions {
   locale?: string;
@@ -1251,9 +1270,10 @@ function setDefaultOptions(newOptions: DefaultOptions): void {
 "#),
         &mut ctx,
     )?;
-    let _module = module(&ctx, module_id)?;
-    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
-    Ok(())
+    assert_unsupported_ts(
+        &errors,
+        "module-level mutable binding initializer must be a literal for now",
+    )
 }
 
 #[test]

--- a/crates/smelt-hir/src/expr/kinds.rs
+++ b/crates/smelt-hir/src/expr/kinds.rs
@@ -27,6 +27,27 @@ pub enum ExprKind {
     Literal(Literal),
     Local(LocalId),
     Item(ItemId),
+    /// Read of a module-level mutable global binding.
+    ///
+    /// `item` references an [`crate::Item::MutableGlobal`]; the expression is
+    /// typed as that binding's declared type. Reads of a lifted module `let`
+    /// lower to this instead of being const-inlined.
+    GlobalGet {
+        /// The mutable-global item being read.
+        item: ItemId,
+    },
+    /// Store to a module-level mutable global binding.
+    ///
+    /// Evaluates `value`, stores it into the global referenced by `item`, and
+    /// evaluates to the stored value so that `++`/`--` and compound assignments
+    /// compose as expressions. `item` references an
+    /// [`crate::Item::MutableGlobal`].
+    GlobalSet {
+        /// The mutable-global item being written.
+        item: ItemId,
+        /// The value expression to store.
+        value: ExprId,
+    },
     Call {
         callee: ExprId,
         args: Vec<ExprId>,

--- a/crates/smelt-hir/src/expr/map.rs
+++ b/crates/smelt-hir/src/expr/map.rs
@@ -61,6 +61,7 @@ impl ExprKind {
             kind @ (Self::Literal(_)
             | Self::Local(_)
             | Self::Item(_)
+            | Self::GlobalGet { .. }
             | Self::Closure(_)
             | Self::NumericRandom
             | Self::DateNow
@@ -118,6 +119,10 @@ impl ExprKind {
             Self::OptionalCoalesce { optional, fallback } => Self::OptionalCoalesce {
                 optional: f(optional)?,
                 fallback: f(fallback)?,
+            },
+            Self::GlobalSet { item, value } => Self::GlobalSet {
+                item,
+                value: f(value)?,
             },
             Self::TypeAssert { value } => Self::TypeAssert { value: f(value)? },
             Self::Len { operand } => Self::Len {

--- a/crates/smelt-hir/src/format/call.rs
+++ b/crates/smelt-hir/src/format/call.rs
@@ -15,6 +15,10 @@ pub(super) fn expr_text(krate: &Crate, expr: &Expr) -> String {
         ExprKind::Literal(literal) => literal_text(literal),
         ExprKind::Local(local) => local_ref(*local),
         ExprKind::Item(item) => item_ref(krate, *item),
+        ExprKind::GlobalGet { item } => format!("global_get {}", item_ref(krate, *item)),
+        ExprKind::GlobalSet { item, value } => {
+            format!("global_set {} = {}", item_ref(krate, *item), expr_ref(*value))
+        }
         ExprKind::Call { .. }
         | ExprKind::ClosureCall { .. }
         | ExprKind::ClosureCallSpread { .. }

--- a/crates/smelt-hir/src/format/types.rs
+++ b/crates/smelt-hir/src/format/types.rs
@@ -17,6 +17,7 @@ pub(super) fn item_ref(krate: &Crate, item: ItemId) -> String {
         Item::Interface(interface) => krate.symbols.get(interface.name),
         Item::TypeAlias(alias) => krate.symbols.get(alias.name),
         Item::Const(item) => krate.symbols.get(item.name),
+        Item::MutableGlobal(item) => krate.symbols.get(item.name),
     }
     .unwrap_or("<unknown>");
 
@@ -46,6 +47,10 @@ pub(super) fn item_text(krate: &Crate, item: ItemId) -> String {
         Item::Const(const_item) => {
             let name = krate.symbols.get(const_item.name).unwrap_or("<unknown>");
             format!("const {name}: {}", type_ref(krate, const_item.ty))
+        }
+        Item::MutableGlobal(global_item) => {
+            let name = krate.symbols.get(global_item.name).unwrap_or("<unknown>");
+            format!("global mut {name}: {}", type_ref(krate, global_item.ty))
         }
     }
 }

--- a/crates/smelt-hir/src/item.rs
+++ b/crates/smelt-hir/src/item.rs
@@ -20,6 +20,8 @@ pub enum Item {
     TypeAlias(TypeAlias),
     /// A constant item.
     Const(ConstItem),
+    /// A module-level mutable binding lifted to a global.
+    MutableGlobal(MutableGlobalItem),
 }
 
 /// Visibility modifier for items.
@@ -303,6 +305,32 @@ pub struct ParamSig {
     /// The type of the parameter.
     pub ty: TypeId,
     /// Source location of the parameter.
+    pub span: Span,
+}
+
+/// A module-level mutable binding lifted to a "mutable global".
+///
+/// Created by the TypeScript frontend's classification pass for a module-level
+/// `let`/`var` binding that is mutated somewhere in the crate (direct
+/// reassignment, `++`/`--`, or a compound assignment). Reads of the binding
+/// lower to [`crate::ExprKind::GlobalGet`] and writes to
+/// [`crate::ExprKind::GlobalSet`], both referencing this item's
+/// [`crate::ItemId`]. MIR lowering collects these items into `Mir::globals`,
+/// and codegen emits one thread-local cell per global. Non-mutated module
+/// bindings keep the existing inline/const-item path and never become a
+/// `MutableGlobalItem`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MutableGlobalItem {
+    /// The name of the binding.
+    pub name: Symbol,
+    /// The lowered type of the binding (always a primitive in V1: Float, Int,
+    /// Bool, or String).
+    pub ty: TypeId,
+    /// The literal initializer captured from the binding declaration.
+    pub init: Literal,
+    /// The visibility of the binding (exported bindings are `Public`).
+    pub visibility: Visibility,
+    /// Source location of the binding declaration.
     pub span: Span,
 }
 

--- a/crates/smelt-hir/src/lib.rs
+++ b/crates/smelt-hir/src/lib.rs
@@ -78,8 +78,8 @@ pub use ids::{
 };
 pub use item::{
     Class, ClassKind, ConstItem, Descriptor, DescriptorValueField, Field, Function, FunctionOwner,
-    Interface, InterfaceHeritage, Item, MethodSig, Param, ParamSig, StaticField, TypeAlias,
-    TypeParamDef, Visibility,
+    Interface, InterfaceHeritage, Item, MethodSig, MutableGlobalItem, Param, ParamSig, StaticField,
+    TypeAlias, TypeParamDef, Visibility,
 };
 pub use krate::{
     CLASS_INDEX_STORE_FIELD, CONSOLE_ERROR_WRITE_SYMBOL, CONSOLE_LOG_SYMBOL, CONSOLE_WRITE_SYMBOL,

--- a/crates/smelt-mir/src/format.rs
+++ b/crates/smelt-mir/src/format.rs
@@ -1147,6 +1147,10 @@ fn rvalue_text(value: &Rvalue) -> String {
             format!("json_parse {}", operand_text(text))
         }
         Rvalue::HttpGetText { url } => format!("http_get_text {}", operand_text(url)),
+        Rvalue::GlobalGet { global } => format!("global_get #{global}"),
+        Rvalue::GlobalSet { global, value: stored } => {
+            format!("global_set #{global} = {}", operand_text(stored))
+        }
         Rvalue::DateNow => "date_now".to_owned(),
         Rvalue::DateSetNow { timestamp } => format!("date_set_now {}", operand_text(timestamp)),
         Rvalue::DateResetNow => "date_reset_now".to_owned(),

--- a/crates/smelt-mir/src/lower/closures.rs
+++ b/crates/smelt-mir/src/lower/closures.rs
@@ -129,6 +129,7 @@ impl LoweringCtx<'_> {
         let shared = LoweringShared {
             krate: self.krate,
             item_functions: self.item_functions,
+            global_ids: self.global_ids,
             loop_index_ty: self.loop_index_ty,
             loop_bool_ty: self.loop_bool_ty,
             closure_base: closure_index

--- a/crates/smelt-mir/src/lower/context.rs
+++ b/crates/smelt-mir/src/lower/context.rs
@@ -28,6 +28,8 @@ pub(super) struct LoweringCtx<'hir> {
     pub(super) krate: &'hir smelt_hir::Crate,
     /// Mapping of HIR item IDs to MIR function IDs.
     pub(super) item_functions: &'hir HashMap<smelt_hir::ItemId, FuncId>,
+    /// Mapping of mutable-global HIR item IDs to their `Mir::globals` index.
+    pub(super) global_ids: &'hir HashMap<smelt_hir::ItemId, u32>,
     /// The HIR body being lowered.
     pub(super) body: &'hir Body,
     /// The MIR function being constructed.
@@ -82,6 +84,8 @@ pub(super) struct LoweringShared<'hir> {
     pub(super) krate: &'hir smelt_hir::Crate,
     /// Mapping of HIR item IDs to MIR function IDs.
     pub(super) item_functions: &'hir HashMap<smelt_hir::ItemId, FuncId>,
+    /// Mapping of mutable-global HIR item IDs to their `Mir::globals` index.
+    pub(super) global_ids: &'hir HashMap<smelt_hir::ItemId, u32>,
     /// Numeric type used for generated index-based loop counters.
     pub(super) loop_index_ty: TypeId,
     /// Boolean type used for generated loop conditions.
@@ -238,6 +242,7 @@ impl<'hir> LoweringCtx<'hir> {
         Self {
             krate: shared.krate,
             item_functions: shared.item_functions,
+            global_ids: shared.global_ids,
             body,
             function,
             closures: Vec::new(),

--- a/crates/smelt-mir/src/lower/expr.rs
+++ b/crates/smelt-mir/src/lower/expr.rs
@@ -75,6 +75,22 @@ impl LoweringCtx<'_> {
                     Some(expr.span),
                 ));
             }
+            ExprKind::GlobalGet { item } => {
+                let global = self.global_index(*item, expr.span)?;
+                self.assign_temp(expr.ty, expr.span, Rvalue::GlobalGet { global })?
+            }
+            ExprKind::GlobalSet { item, value } => {
+                let global = self.global_index(*item, expr.span)?;
+                let value_operand = self.lower_expr(*value)?;
+                self.assign_temp(
+                    expr.ty,
+                    expr.span,
+                    Rvalue::GlobalSet {
+                        global,
+                        value: value_operand,
+                    },
+                )?
+            }
             ExprKind::BinOp { op, lhs, rhs } => {
                 let lhs_operand = self.lower_expr(*lhs)?;
                 let rhs_operand = self.lower_expr(*rhs)?;
@@ -2005,6 +2021,16 @@ impl LoweringCtx<'_> {
 
         self.exprs.insert(expr_id, operand.clone());
         Ok(operand)
+    }
+
+    /// Resolve a mutable-global HIR item to its `Mir::globals` index.
+    fn global_index(&self, item: smelt_hir::ItemId, span: Span) -> Result<u32, LowerError> {
+        self.global_ids.get(&item).copied().ok_or_else(|| {
+            self.error(
+                "mutable-global reference does not resolve to a lowered global",
+                Some(span),
+            )
+        })
     }
 
     /// Lowers a callee expression to a MIR callee.

--- a/crates/smelt-mir/src/lower/mod.rs
+++ b/crates/smelt-mir/src/lower/mod.rs
@@ -168,14 +168,19 @@ pub fn lower_hir(krate: &smelt_hir::Crate) -> Result<Mir, Vec<LowerError>> {
     let mut errors = Vec::new();
 
     let item_functions = assign_function_ids(krate)?;
+    let global_ids = lower_globals(krate, &mut mir);
+    let tables = LoweringTables {
+        item_functions: &item_functions,
+        global_ids: &global_ids,
+    };
     lower_type_tables(krate, &mut mir, &item_functions);
-    lower_item_functions(krate, &mut mir, &item_functions, helpers, &mut errors);
+    lower_item_functions(krate, &mut mir, &tables, helpers, &mut errors);
 
     if !errors.is_empty() {
         return Err(errors);
     }
 
-    lower_module_bodies(krate, &mut mir, &item_functions, helpers, &mut errors);
+    lower_module_bodies(krate, &mut mir, &tables, helpers, &mut errors);
 
     if errors.is_empty() {
         run_finalization_passes(&mut mir);
@@ -213,6 +218,51 @@ fn assign_function_ids(
     Ok(item_functions)
 }
 
+/// Item-resolution tables shared by every body lowering.
+///
+/// Bundles the function-id map from [`assign_function_ids`] with the
+/// mutable-global index map from [`lower_globals`] so body lowering entry
+/// points take one resolution frame instead of parallel table arguments.
+struct LoweringTables<'hir> {
+    /// Mapping of HIR function items to their assigned MIR function ids.
+    item_functions: &'hir FunctionIds,
+    /// Mapping of mutable-global HIR items to their `Mir::globals` index.
+    global_ids: &'hir HashMap<smelt_hir::ItemId, u32>,
+}
+
+/// Populate [`Mir::globals`] from every HIR mutable-global item.
+///
+/// Scans crate items in order; each [`smelt_hir::Item::MutableGlobal`] becomes
+/// one [`crate::MirGlobal`] with its literal initializer lowered to a
+/// [`Constant`]. Returns a map from the global's HIR [`smelt_hir::ItemId`] to
+/// its dense index in `Mir::globals`, which `GlobalGet`/`GlobalSet` lowering
+/// uses to resolve references.
+fn lower_globals(
+    krate: &smelt_hir::Crate,
+    mir: &mut Mir,
+) -> HashMap<smelt_hir::ItemId, u32> {
+    let mut global_ids = HashMap::new();
+    for (idx, item) in krate.items.iter().enumerate() {
+        let smelt_hir::Item::MutableGlobal(global) = item else {
+            continue;
+        };
+        let Ok(item_index) = u32_from_usize(idx, "HIR item index does not fit in u32") else {
+            continue;
+        };
+        let Ok(global_index) = u32_from_usize(mir.globals.len(), "MIR global index does not fit in u32")
+        else {
+            continue;
+        };
+        mir.globals.push(crate::MirGlobal {
+            name: global.name,
+            ty: global.ty,
+            init: lower_literal(&global.init),
+        });
+        global_ids.insert(smelt_hir::ItemId(item_index), global_index);
+    }
+    global_ids
+}
+
 /// Build the MIR class and interface tables from HIR items.
 ///
 /// Class descriptors, methods, and constructors are resolved to their already
@@ -228,7 +278,9 @@ fn lower_type_tables(krate: &smelt_hir::Crate, mir: &mut Mir, item_functions: &F
             }
             smelt_hir::Item::Function(_)
             | smelt_hir::Item::TypeAlias(_)
-            | smelt_hir::Item::Const(_) => {}
+            | smelt_hir::Item::Const(_)
+            // Mutable globals are collected separately by `lower_globals`.
+            | smelt_hir::Item::MutableGlobal(_) => {}
         }
     }
 }
@@ -337,7 +389,7 @@ fn lower_interface_table_entry(
 fn lower_item_functions(
     krate: &smelt_hir::Crate,
     mir: &mut Mir,
-    item_functions: &FunctionIds,
+    tables: &LoweringTables<'_>,
     helpers: HelperTypes,
     errors: &mut Vec<LowerError>,
 ) {
@@ -371,12 +423,13 @@ fn lower_item_functions(
         } else {
             function.return_ty
         };
-        let Some(function_id) = item_functions.get(&item_id).copied() else {
+        let Some(function_id) = tables.item_functions.get(&item_id).copied() else {
             continue;
         };
         let shared = LoweringShared {
             krate,
-            item_functions,
+            item_functions: tables.item_functions,
+            global_ids: tables.global_ids,
             loop_index_ty: helpers.loop_index_ty,
             loop_bool_ty: helpers.loop_bool_ty,
             closure_base: mir.closures.len(),
@@ -410,7 +463,7 @@ fn lower_item_functions(
 fn lower_module_bodies(
     krate: &smelt_hir::Crate,
     mir: &mut Mir,
-    item_functions: &FunctionIds,
+    tables: &LoweringTables<'_>,
     helpers: HelperTypes,
     errors: &mut Vec<LowerError>,
 ) {
@@ -436,7 +489,8 @@ fn lower_module_bodies(
         let function_id = mir.next_function_id();
         let shared = LoweringShared {
             krate,
-            item_functions,
+            item_functions: tables.item_functions,
+            global_ids: tables.global_ids,
             loop_index_ty: helpers.loop_index_ty,
             loop_bool_ty: helpers.loop_bool_ty,
             closure_base: mir.closures.len(),

--- a/crates/smelt-mir/src/lower/place.rs
+++ b/crates/smelt-mir/src/lower/place.rs
@@ -98,6 +98,10 @@ impl LoweringCtx<'_> {
             | ExprKind::UnknownCast { .. }
             | ExprKind::Literal(_)
             | ExprKind::Item(_)
+            // Global reads/writes are values, not assignable places: a write to
+            // a mutable global lowers to `Rvalue::GlobalSet`, never through here.
+            | ExprKind::GlobalGet { .. }
+            | ExprKind::GlobalSet { .. }
             | ExprKind::Call { .. }
             | ExprKind::ClosureCall { .. }
             | ExprKind::ClosureCallSpread { .. }

--- a/crates/smelt-mir/src/opt/mod.rs
+++ b/crates/smelt-mir/src/opt/mod.rs
@@ -687,6 +687,8 @@ fn rewrite_rvalue(
         Rvalue::HttpGetText { url } => rewrite_operand_except(url, aliases, dest),
         Rvalue::DateNow => false,
         Rvalue::DateResetNow => false,
+        Rvalue::GlobalGet { .. } => false,
+        Rvalue::GlobalSet { value: stored, .. } => rewrite_operand_except(stored, aliases, dest),
         Rvalue::DateSetNow { timestamp } => rewrite_operand_except(timestamp, aliases, dest),
         Rvalue::DateTimezoneOffset | Rvalue::DateResetTimezoneOffset => false,
         Rvalue::DateSetTimezoneOffset { offset } => rewrite_operand_except(offset, aliases, dest),

--- a/crates/smelt-mir/src/types.rs
+++ b/crates/smelt-mir/src/types.rs
@@ -42,12 +42,33 @@ pub struct Mir {
     pub interfaces: Vec<MirInterface>,
     /// All closure bodies in the crate.
     pub closures: Vec<MirClosure>,
+    /// Module-level mutable globals lifted from source `let`/`var` bindings.
+    ///
+    /// Populated during HIR lowering from every [`smelt_hir::Item::MutableGlobal`]
+    /// in the crate. `Rvalue::GlobalGet`/`Rvalue::GlobalSet` reference entries by
+    /// index, and codegen emits one thread-local cell per entry.
+    pub globals: Vec<MirGlobal>,
     /// Type interner for interned types.
     pub types: smelt_hir::TypeInterner,
     /// Symbol interner for interned identifiers.
     pub symbols: smelt_hir::SymbolInterner,
     /// Original source spellings for symbols that were normalized internally.
     pub names: smelt_hir::OriginalNameTable,
+}
+
+/// A module-level mutable global lowered from a source `let`/`var` binding.
+///
+/// Carries the binding's name, primitive type, and literal initializer. Codegen
+/// mangles a per-program thread-local cell name from `name` and the global's
+/// index so cross-module bindings that share a source name stay distinct.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MirGlobal {
+    /// The binding's name symbol.
+    pub name: Symbol,
+    /// The binding's primitive type (Float, Int, Bool, or String in V1).
+    pub ty: TypeId,
+    /// The binding's literal initializer.
+    pub init: Constant,
 }
 
 impl Mir {
@@ -63,6 +84,7 @@ impl Mir {
             classes: Vec::new(),
             interfaces: Vec::new(),
             closures: Vec::new(),
+            globals: Vec::new(),
             types,
             symbols,
             names,
@@ -1455,6 +1477,18 @@ pub enum Rvalue {
     HttpGetText {
         /// URL to request.
         url: Operand,
+    },
+    /// Read a module-level mutable global by index into `Mir::globals`.
+    GlobalGet {
+        /// Index into `Mir::globals`.
+        global: u32,
+    },
+    /// Store into a module-level mutable global; evaluates to the stored value.
+    GlobalSet {
+        /// Index into `Mir::globals`.
+        global: u32,
+        /// The value to store.
+        value: Operand,
     },
     /// Read the current timestamp in milliseconds.
     DateNow,

--- a/crates/smelt-mir/src/validate/operands.rs
+++ b/crates/smelt-mir/src/validate/operands.rs
@@ -581,6 +581,10 @@ impl Rvalue {
             }
             Self::DateNow => {}
             Self::DateResetNow => {}
+            Self::GlobalGet { .. } => {}
+            Self::GlobalSet { value, .. } => {
+                visit(value);
+            }
             Self::DateSetNow { timestamp } => {
                 visit(timestamp);
             }
@@ -1278,6 +1282,10 @@ impl Rvalue {
             }
             Self::DateNow => {}
             Self::DateResetNow => {}
+            Self::GlobalGet { .. } => {}
+            Self::GlobalSet { value, .. } => {
+                visit(value);
+            }
             Self::DateSetNow { timestamp } => {
                 visit(timestamp);
             }

--- a/crates/smelt-transpiler/src/stubs.rs
+++ b/crates/smelt-transpiler/src/stubs.rs
@@ -182,7 +182,7 @@ fn typescript_declaration(krate: &Crate, module_id: ModuleId) -> String {
                     ),
                 );
             }
-            Item::Function(_) | Item::Const(_) => {}
+            Item::Function(_) | Item::Const(_) | Item::MutableGlobal(_) => {}
         }
     }
     out
@@ -232,7 +232,11 @@ fn python_declaration(krate: &Crate, module_id: ModuleId) -> String {
                     }
                 }
             }
-            Item::Function(_) | Item::Interface(_) | Item::TypeAlias(_) | Item::Const(_) => {}
+            Item::Function(_)
+            | Item::Interface(_)
+            | Item::TypeAlias(_)
+            | Item::Const(_)
+            | Item::MutableGlobal(_) => {}
         }
     }
     out


### PR DESCRIPTION
## Summary

Implements the designed module-level mutable state model — the `uniqueId.ts` gate (`let idCounter = 0; ++idCounter`):

- Module `let`/`var` bindings mutated in hoisted item bodies lift to `Item::MutableGlobal`; reads lower to `GlobalGet`, writes desugar through `GlobalSet` (which evaluates to the stored value, so `++`/`+=`/postfix-old-value all compose). No new MIR `Place` variant — globals never enter place lowering.
- Codegen emits `thread_local!` cells (`Cell` for Copy primitives, `RefCell<String>` for strings) named `SMELT_GLOBAL_<NAME>_<index>`, gated on a non-empty `Mir.globals` table, with per-test-thread semantics documented (each `#[test]` observes fresh module state, mirroring vitest per-file module isolation).
- v1 constraints enforced as named blockers (literal initializers; primitive types) — no `SmeltUnknown` anywhere; local shadowing takes priority over the global.
- Scope-rule refinement vs the original design, forced by its own byte-identical requirement: "mutated anywhere" is read as *mutated in hoisted item bodies*; module-body-statement mutations keep today's path exactly (the broad reading regressed 4 pre-existing green tests; for valid ES modules the two readings agree cross-module).

Fixed en route via the first-abort loop: per-test scoping of narrowing facts, `delete list[i]` no-op deferral, list-extend and string-contains erased coercions.

## State of the es-toolkit build

Advances past `uniqueId.ts`. Does not yet emit: the new first abort is the `globalThis.File = …` monkey-patching specs (a documented project non-goal), then optional-chained methods on modeled Map receivers. Details in `blocker-logs/estk-module-globals.md`.

## Verification

- `cargo test --workspace --exclude smelt-gui`: 1755 passed, 0 failed (new frontend + codegen suites for lift shapes, prefix/postfix, `var`, inline-path regression, shadowing, both blockers, cell emission/gating).
- clippy (pedantic, lib) clean on all six touched crates.
- E2E uniqueId-mirror fixture green end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_