### PR TITLE
fix(frontend-ts): optional-chained method calls on modeled receivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ blocker-logs/*.md
 !blocker-logs/estk-mir-gates.md
 # estk-module-globals.md documents module-level mutable state (thread-local mutable globals)
 !blocker-logs/estk-module-globals.md
+# estk-optional-receivers.md documents the optional-chained modeled-receiver desugar and probe families
+!blocker-logs/estk-optional-receivers.md
 
 # Generated docs site output
 _site/

--- a/blocker-logs/estk-optional-receivers.md
+++ b/blocker-logs/estk-optional-receivers.md
@@ -1,0 +1,132 @@
+# Optional-chained method calls on modeled stdlib receivers
+
+## Summary
+
+`recv?.method(args)` where `recv: T | undefined` (or `T | null`) and `T` is a
+modeled stdlib receiver (`Map`, `Set`, ...) previously failed to lower: the
+optional-chained collection method fell through the stdlib dispatch to the
+generic static-member path, which mis-typed `stack?.has(x)` as an erased field
+read (`stack.get("has")`) returning `SmeltUnknown`. This blocked es-toolkit
+`src/compat/predicate/isMatchWith.ts` (`stack?.has` / `stack?.set` /
+`stack?.delete` on a `Map<any, any> | undefined`) and every spec importing it.
+
+The fix desugars the optional-chained modeled-receiver call generally, in the
+same stdlib dispatch that already handles the non-optional receiver:
+
+```
+recv?.method(args)   ==>   recv-present ? Some(<modeled op on narrowed recv>)
+                                        : undefined
+```
+
+so the result type is `R | undefined` through the existing optional machinery,
+and the operation itself is the *same* modeled HIR node the non-optional
+receiver produces (`DictContainsKey`, `DictGet`, `DictSet`, `DictRemoveKey`,
+`SetContains`, `SetAdd`, `SetRemove`, projections). No `SmeltUnknown` is
+introduced.
+
+## Implementation
+
+`crates/smelt-frontend-ts/src/lowering/stdlib/collections.rs`
+
+* `dispatch_collection_method` now recognizes an `Optional(inner)` receiver
+  whose inner type is a modeled `Map`/`Set`. It lowers the receiver once, builds
+  the modeled operation on a **narrowed** receiver, and wraps the result.
+* `narrowed_optional_receiver` builds a `TypeAssert` typed as the inner receiver
+  type. The Rust emitter already unwraps an `Optional(inner)` operand assigned
+  into an `inner` slot (`.clone().expect("optional value was absent after
+  narrowing")`) — the exact narrowing the ordinary `if (recv) { recv.method() }`
+  guard produces — so the modeled-op codegen is reused verbatim.
+* `wrap_optional_receiver_method` builds `Conditional { cond: !recv.is_none(),
+  then: <op>, else: undefined }`, with the result type flattened through
+  `optional_chain_result_type` so a method that already returns `Optional`
+  (e.g. `Map.get`) does not double-wrap. The receiver is shared by the presence
+  test and the narrowed access; MIR memoizes each HIR expression, so the
+  receiver is evaluated exactly once and its temporary dominates both uses
+  (single-eval, matching JS `?.` semantics).
+* The per-method builders (`map_has_call`, `map_get_call`, `map_mutation_call`,
+  `set_contains_call`, `set_mutation_call`, `set_projection_call`, and the new
+  shared `map_projection_with_receiver`) now take the pre-lowered receiver, so a
+  single code path serves both the plain and the optional-chained spellings.
+
+### Semantics note (Set/value-collection mutation)
+
+For `Map` (runtime `SmeltRecord`, `Rc<RefCell<..>>`-shared) the narrowed clone
+shares storage, so `stack?.set(k,v)` / `stack?.delete(k)` mutate the underlying
+map — correct, and the es-toolkit shape. For a value-semantic `Set`
+(`HashSet`), the narrowed access is an owned clone, so a mutation through an
+optional receiver is not observed by the caller. This is **pre-existing**
+behavior: the ordinary non-optional narrowing path (`if (s !== undefined) {
+s.add(x) }`) already re-clones the owned `Option<HashSet>` on each narrowed
+access and loses the write the same way. Optional `Set` reads (`s?.has(x)`)
+lower correctly, and the desugar is consistent with the established narrowing
+semantics. es-toolkit does not rely on optional `Set` mutation propagation.
+
+## Tests
+
+* Codegen regression tests (`crates/smelt-codegen-rust/src/tests/part_5_tests.rs`):
+  * `emits_optional_chained_map_methods_as_guarded_modeled_ops`
+  * `emits_optional_chained_set_has_as_guarded_modeled_op`
+* End-to-end fixture verified with `smelt build` + generated `cargo test`
+  (3 tests green): optional Map `has/set/get/delete` propagate through the
+  reference-shared receiver; Map methods on an absent receiver return
+  `undefined`; Set `has` reads through present/absent receivers.
+
+## Whole-crate probe (es-toolkit)
+
+Iterating the first-abort loop on a private copy of the es-toolkit checkout
+(`isBlob.spec.ts` / `isFile.spec.ts` added to that copy's `exclude` list only —
+the `globalThis.File/Blob` monkey-patch family a sibling agent owns), the build
+advanced past isMatchWith and cleared these further families (fixed generally):
+
+1. **Host-global monkey-patch (deferred / non-goal).**
+   `src/predicate/isBuffer.spec.ts` does `delete global.Buffer` /
+   `global.Buffer = ...`. Same family as the `globalThis.File` monkey-patch;
+   excluded in the probe copy only.
+2. **Array predicate callback truthiness** (`list_query.rs`, `types.rs`).
+   `arr.findIndex/filter/find/some/every(cb)` where `cb` returns a non-`boolean`
+   (e.g. an erased `unknown` predicate) previously errored ("array predicate
+   callback must return boolean"). Now the single callback result is coerced to
+   a JS truthiness test via the new `value_truthy_text` helper, matching source
+   semantics.
+3. **Optional field on a statically-absent receiver** (`call_runtime.rs`).
+   `window?.document` (a DOM host global the non-DOM profile models as `()`)
+   errored in optional-field codegen. An optional field read on a `None`/unit
+   receiver now folds to the destination's absent default (`undefined`),
+   short-circuiting the chain as JS does.
+4. **`Array.prototype.pop` destination coercion** (`list_mutation.rs`).
+   `arr.pop()` whose destination optional-inner differs from the list item type
+   (e.g. a union item type) errored. The popped value is now coerced to the
+   destination through the standard coercion seam; the two exact-match fast
+   paths are preserved.
+5. **Surplus positional call arguments** (`call.rs`).
+   A call passing more positional arguments than a fixed-arity (non-rest)
+   callee declares errored ("call argument has no target parameter").
+   JavaScript ignores surplus positional arguments; the operands are already
+   evaluated into temporaries before the call, so the extra arguments are simply
+   not forwarded. `tsc` only admits this shape for erased/`any` callees, so a
+   genuine over-application is still rejected upstream.
+
+### Genuine wall (deferred, architectural)
+
+The probe then aborts at:
+
+> `match codegen requires all non-terminating arms to share one join block`
+
+A `switch`/`match` whose non-terminating arms fall through to *different* join
+blocks (divergent post-arm control flow) is not representable by the current
+match emitter (`control_flow_match.rs::match_join`), which requires a single
+shared join block. Reworking match/switch arm emission to support divergent
+join targets is a structural MIR/codegen change beyond the optional-receiver
+scope and is deferred. The probe copy did **not** reach `dist-smelt` emission,
+so no generated-crate diagnostics/test report was produced this pass.
+
+## Validation
+
+* `cargo check --workspace` clean.
+* `cargo clippy -p smelt-frontend-ts -p smelt-codegen-rust --lib -W
+  clippy::pedantic` clean.
+* `cargo test --workspace --exclude smelt-gui`: all green (no regressions;
+  518 / 186 / 857 / ... passing across crates).
+* `dump-hir` on `isMatchWith.ts` succeeds.
+* No net increase in `SmeltUnknown`: the optional-receiver desugar replaces an
+  erased `SmeltUnknown` mis-lowering with concrete modeled ops.

--- a/crates/smelt-codegen-rust/src/emitter/call.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call.rs
@@ -665,66 +665,74 @@ impl FunctionEmitter<'_> {
                 }
                 let free_function_type_params =
                     self.callee_free_function_type_params(function);
-                let mut rendered_args = args
-                    .iter()
-                    .enumerate()
-                    .map(|(index, arg)| {
-                        let param = function.params.get(index).copied();
-                        let local_ty = param
-                            .map(|target_param| {
-                                self.function_local_decl(function, target_param)
-                                    .map(|local| local.ty)
-                            })
-                            .transpose()?;
-                        let target_ty = emitted_params
-                            .as_ref()
-                            .and_then(|params| params.get(index).copied())
-                            .or(local_ty)
-                            .ok_or_else(|| {
-                                EmitError::new("call argument has no target parameter")
-                            })?;
-                        // A concrete argument bound to one of the callee's own
-                        // generic type parameters (`identity(3)` against
-                        // `x: T`) is passed through at its own type so Rust
-                        // monomorphizes `identity::<f64>`; erasing it against the
-                        // bare `T` target would mismatch the generic parameter.
-                        if matches!(
-                            self.mir.types.get(target_ty),
-                            Some(Type::TypeParam { name })
-                                if free_function_type_params.contains(name)
-                        ) {
-                            return self.callee_generic_argument_text(
-                                arg,
-                                function,
-                                target_ty,
-                                &free_function_type_params,
-                            );
-                        }
-                        if matches!(self.mir.types.get(target_ty), Some(Type::Function(_)))
-                            && param.is_some_and(|target_param| {
-                                !self
-                                    .function_parameter_requires_owned_in(function, target_param)
-                                    .unwrap_or(false)
-                            })
-                        {
-                            return self.borrowed_function_argument_text(arg, target_ty);
-                        }
-                        if param.is_some_and(|target_param| {
-                            self.parameter_needs_mutable_reference_in(function, target_param)
-                        }) {
-                            return self.mutable_reference_argument_text(arg, target_ty);
-                        }
-                        if matches!(
-                            self.mir.types.get(self.operand_ty(arg)?),
-                            Some(Type::Function(_))
-                        ) && !self.type_accepts_erased_function(target_ty)
-                        {
-                            self.default_value(target_ty)
-                        } else {
-                            self.value_at_type(arg, target_ty)
-                        }
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
+                let mut rendered_args = Vec::new();
+                for (index, arg) in args.iter().enumerate() {
+                    let param = function.params.get(index).copied();
+                    let local_ty = param
+                        .map(|target_param| {
+                            self.function_local_decl(function, target_param)
+                                .map(|local| local.ty)
+                        })
+                        .transpose()?;
+                    let target_ty = emitted_params
+                        .as_ref()
+                        .and_then(|params| params.get(index).copied())
+                        .or(local_ty);
+                    let Some(target_ty) = target_ty else {
+                        // Extra trailing argument beyond the callee's fixed arity
+                        // (no rest parameter absorbs it). JavaScript silently
+                        // ignores surplus positional arguments; the operand has
+                        // already been evaluated into a temporary before the call,
+                        // so its side effects are preserved and it is simply not
+                        // forwarded. `tsc` only admits this shape when the callee
+                        // is erased/`any`-typed, so a genuine over-application is
+                        // already rejected upstream.
+                        continue;
+                    };
+                    // A concrete argument bound to one of the callee's own
+                    // generic type parameters (`identity(3)` against
+                    // `x: T`) is passed through at its own type so Rust
+                    // monomorphizes `identity::<f64>`; erasing it against the
+                    // bare `T` target would mismatch the generic parameter.
+                    if matches!(
+                        self.mir.types.get(target_ty),
+                        Some(Type::TypeParam { name })
+                            if free_function_type_params.contains(name)
+                    ) {
+                        rendered_args.push(self.callee_generic_argument_text(
+                            arg,
+                            function,
+                            target_ty,
+                            &free_function_type_params,
+                        )?);
+                        continue;
+                    }
+                    if matches!(self.mir.types.get(target_ty), Some(Type::Function(_)))
+                        && param.is_some_and(|target_param| {
+                            !self
+                                .function_parameter_requires_owned_in(function, target_param)
+                                .unwrap_or(false)
+                        })
+                    {
+                        rendered_args.push(self.borrowed_function_argument_text(arg, target_ty)?);
+                        continue;
+                    }
+                    if param.is_some_and(|target_param| {
+                        self.parameter_needs_mutable_reference_in(function, target_param)
+                    }) {
+                        rendered_args.push(self.mutable_reference_argument_text(arg, target_ty)?);
+                        continue;
+                    }
+                    if matches!(
+                        self.mir.types.get(self.operand_ty(arg)?),
+                        Some(Type::Function(_))
+                    ) && !self.type_accepts_erased_function(target_ty)
+                    {
+                        rendered_args.push(self.default_value(target_ty)?);
+                    } else {
+                        rendered_args.push(self.value_at_type(arg, target_ty)?);
+                    }
+                }
                 for (index, param) in function.params.iter().enumerate().skip(args.len()) {
                     let local = self.function_local_decl(function, *param)?;
                     let target_ty = emitted_params

--- a/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
@@ -2204,6 +2204,14 @@ impl FunctionEmitter<'_> {
         dest_ty: TypeId,
     ) -> Result<String, EmitError> {
         let (receiver_text, inner_ty, is_optional) = self.optional_receiver_parts(receiver)?;
+        // An optional field read on a statically-absent receiver (`None`/unit, as
+        // for a host global the non-DOM profile does not model, e.g.
+        // `window?.document`) always short-circuits to `undefined`. The receiver
+        // carries no value to read, so fold to the destination's absent default
+        // instead of attempting a field access on a unit type.
+        if matches!(self.mir.types.get(inner_ty), Some(Type::None)) {
+            return self.default_value(dest_ty);
+        }
         let field_ty = self.field_access_type(inner_ty, field)?;
         if is_optional {
             let value = self.field_access_text("_smelt_value", inner_ty, field)?;

--- a/crates/smelt-codegen-rust/src/emitter/list_mutation.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_mutation.rs
@@ -356,25 +356,32 @@ impl FunctionEmitter<'_> {
         let Some(Type::List(item_ty)) = self.mir.types.get(list_ty) else {
             return Err(EmitError::new("list pop receiver must be a list"));
         };
-        let returns_optional = match self.mir.types.get(dest_ty) {
-            Some(Type::Optional(inner)) if *inner == *item_ty => true,
-            _ if dest_ty == *item_ty => false,
-            _ => {
-                return Err(EmitError::new(
-                    "list pop destination must be item or optional item",
-                ));
-            }
-        };
+        let item_ty = *item_ty;
         let (Operand::Copy(Place::Local(local)) | Operand::Move(Place::Local(local))) = list else {
             return Err(EmitError::new(
                 "list pop receiver must be a mutable local for now",
             ));
         };
         let list_text = self.local_mut_value_text(*local)?;
-        if returns_optional {
-            Ok(format!("{list_text}.pop()"))
-        } else {
-            Ok(format!("{list_text}.pop().expect(\"pop from empty list\")"))
+        // `Array.prototype.pop` yields `item | undefined`. The two exact-match
+        // fast paths keep the historical output; any other destination (e.g. a
+        // widened/narrowed optional whose inner differs from the list item type,
+        // as when the item type is a union) coerces the popped value to the
+        // destination through the standard coercion seam instead of aborting.
+        match self.mir.types.get(dest_ty) {
+            Some(Type::Optional(inner)) if *inner == item_ty => Ok(format!("{list_text}.pop()")),
+            _ if dest_ty == item_ty => {
+                Ok(format!("{list_text}.pop().expect(\"pop from empty list\")"))
+            }
+            Some(Type::Optional(_)) => {
+                let pop_ty = self.type_id(Type::Optional(item_ty))?;
+                self.value_at_type_text(&format!("{list_text}.pop()"), pop_ty, dest_ty)
+            }
+            _ => self.value_at_type_text(
+                &format!("{list_text}.pop().expect(\"pop from empty list\")"),
+                item_ty,
+                dest_ty,
+            ),
         }
     }
 

--- a/crates/smelt-codegen-rust/src/emitter/list_query.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_query.rs
@@ -144,11 +144,6 @@ impl FunctionEmitter<'_> {
         else {
             return Ok("Default::default()".to_owned());
         };
-        if self.mir.types.get(function_ty.return_ty) != Some(&Type::Bool) {
-            return Err(EmitError::new(
-                "array predicate callback must return boolean",
-            ));
-        }
         let closure_text = match self.closure_operand_text_for_declared_type(callback) {
             Ok(closure_text) => closure_text,
             Err(_) => self.operand_text(callback)?,
@@ -156,7 +151,19 @@ impl FunctionEmitter<'_> {
         let list_iteration =
             self.list_callback_iteration_parts(list, list_ty, element_ty, callback, function_ty)?;
         let call_args = list_iteration.call_args;
-        let call_text = format!("(smelt_callback)({})", call_args.join(", "));
+        // JavaScript array predicates (`filter`/`find`/`findIndex`/`some`/`every`)
+        // coerce the callback result with the usual truthiness rules rather than
+        // requiring a `boolean`. When the declared return type is not already
+        // `bool` (e.g. an erased `unknown` predicate, `x => x.length`, or
+        // `x => x && cond`), route the single call through `value_truthy_text` so
+        // the predicate observes the same truthiness the source does; a `bool`
+        // return passes through unchanged.
+        let raw_call_text = format!("(smelt_callback)({})", call_args.join(", "));
+        let call_text = if self.mir.types.get(function_ty.return_ty) == Some(&Type::Bool) {
+            raw_call_text
+        } else {
+            self.value_truthy_text(&raw_call_text, function_ty.return_ty)?
+        };
         let prefix = format!(
             "let mut smelt_callback = {closure_text}; {prefix}",
             prefix = list_iteration.prefix

--- a/crates/smelt-codegen-rust/src/emitter/types.rs
+++ b/crates/smelt-codegen-rust/src/emitter/types.rs
@@ -284,6 +284,48 @@ impl FunctionEmitter<'_> {
         self.primitive_cast_text(smelt_hir::PrimitiveCastOp::ToBool, operand, bool_ty)
     }
 
+    /// Convert an already-rendered value expression to a Rust boolean using
+    /// JavaScript/Python truthiness rules.
+    ///
+    /// This is the text-based counterpart to the `ToBool` arm of
+    /// [`Self::primitive_cast_text`]: callers that hold a rendered expression
+    /// (rather than an [`Operand`]) — such as an array predicate callback result —
+    /// coerce it here. `value_text` is evaluated exactly once. Objects, arrays,
+    /// functions, class instances, and other reference values are always truthy;
+    /// primitives follow their per-type emptiness/zero rules; optionals defer to
+    /// [`Self::optional_truthy_text`].
+    pub(super) fn value_truthy_text(
+        &self,
+        value_text: &str,
+        ty: TypeId,
+    ) -> Result<String, EmitError> {
+        match self.mir.types.get(ty) {
+            Some(Type::Bool) => Ok(value_text.to_owned()),
+            Some(Type::Int) => Ok(format!("({value_text}) != 0")),
+            Some(Type::Float) => Ok(format!(
+                "{{ let smelt_number = ({value_text}); smelt_number != 0.0 && !smelt_number.is_nan() }}"
+            )),
+            Some(Type::String) => Ok(format!("!({value_text}).is_empty()")),
+            Some(Type::Unknown | Type::Union(_) | Type::TypeParam { .. } | Type::Never) => {
+                Ok(format!(
+                    "match ({value_text}) {{ SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != 0.0 && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true }}"
+                ))
+            }
+            Some(Type::Optional(inner)) => self.optional_truthy_text(value_text, *inner),
+            Some(Type::None) => Ok(format!("{{ let _ = ({value_text}); false }}")),
+            Some(
+                Type::Class { .. }
+                | Type::Function(_)
+                | Type::List(_)
+                | Type::Tuple(_)
+                | Type::Dict(_, _)
+                | Type::Set(_)
+                | Type::Future(_),
+            ) => Ok(format!("{{ let _ = ({value_text}); true }}")),
+            None => Err(EmitError::new("predicate result type is unknown")),
+        }
+    }
+
     /// Converts a string trim operation to Rust text.
     /// Returns whether a type is supported by the current JSON serializer path.
     pub(super) fn is_json_serializable_type(&self, ty: TypeId) -> bool {

--- a/crates/smelt-codegen-rust/src/tests/part_5_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_5_tests.rs
@@ -417,6 +417,81 @@ mapping.clear();
 }
 
 #[test]
+fn emits_optional_chained_map_methods_as_guarded_modeled_ops() {
+    // `recv?.has/get/set/delete(...)` on an optional Map receiver desugars to the
+    // same modeled dict operation the non-optional receiver produces, guarded by
+    // a presence test and narrowed via the `optional value was absent` unwrap.
+    // It must NOT fall through to a generic `.get("has")` field access.
+    let source = source_for(
+        r#"
+export function probe(stack: Map<string, number> | undefined, key: string): boolean | undefined {
+  return stack?.has(key);
+}
+export function fetch(stack: Map<string, number> | undefined, key: string): number | undefined {
+  return stack?.get(key);
+}
+export function store(stack: Map<string, number> | undefined, key: string): void {
+  stack?.set(key, 1);
+}
+export function drop(stack: Map<string, number> | undefined, key: string): boolean | undefined {
+  return stack?.delete(key);
+}
+"#,
+    );
+
+    assert!(
+        source.contains(".is_none()"),
+        "optional receiver presence test should emit is_none\n{source}"
+    );
+    assert!(
+        source.contains(".expect(\"optional value was absent after narrowing\")"),
+        "narrowed receiver should unwrap the optional in the present branch\n{source}"
+    );
+    assert!(
+        source.contains(".contains_key(&"),
+        "optional Map.has should lower to a modeled contains_key\n{source}"
+    );
+    assert!(
+        source.contains(".insert("),
+        "optional Map.set should lower to a modeled insert\n{source}"
+    );
+    assert!(
+        source.contains(".remove(&"),
+        "optional Map.delete should lower to a modeled remove\n{source}"
+    );
+    assert!(
+        !source.contains(".get(\"has\")"),
+        "optional Map.has must not misroute to an erased field access\n{source}"
+    );
+}
+
+#[test]
+fn emits_optional_chained_set_has_as_guarded_modeled_op() {
+    // `recv?.has(value)` on an optional Set receiver desugars to a guarded
+    // modeled `contains` check rather than a generic erased field access.
+    let source = source_for(
+        r#"
+export function probe(seen: Set<string> | undefined, value: string): boolean | undefined {
+  return seen?.has(value);
+}
+"#,
+    );
+
+    assert!(
+        source.contains(".is_none()"),
+        "optional receiver presence test should emit is_none\n{source}"
+    );
+    assert!(
+        source.contains(".contains(&"),
+        "optional Set.has should lower to a modeled contains check\n{source}"
+    );
+    assert!(
+        !source.contains(".get(\"has\")"),
+        "optional Set.has must not misroute to an erased field access\n{source}"
+    );
+}
+
+#[test]
 fn emits_string_split_method() {
     let source = source_for(
         r#"

--- a/crates/smelt-frontend-ts/src/lowering/stdlib/collections.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/collections.rs
@@ -53,7 +53,21 @@ impl ModuleBuilder<'_> {
         }
         let receiver = self.expression(&member.object, body)?;
         let receiver_ty = self.type_param_constraint_or_self(Self::expr_ty(body, receiver));
-        let receiver_kind = match self.ctx.krate.types.get(receiver_ty) {
+        // A `recv?.method(args)` call whose receiver is `T | undefined` for a
+        // modeled receiver `T` (Map/Set) desugars to the same modeled operation
+        // guarded by a presence test: the op runs on the narrowed receiver when
+        // present and yields `undefined` otherwise. Detect the optional shape
+        // here so the same per-method lowering serves both the plain and the
+        // optional-chained receiver instead of the optional case falling through
+        // to a generic (mis-typed) field access.
+        let optional_inner =
+            if let Some(Type::Optional(inner)) = self.ctx.krate.types.get(receiver_ty) {
+                Some(self.type_param_constraint_or_self(*inner))
+            } else {
+                None
+            };
+        let effective_ty = optional_inner.unwrap_or(receiver_ty);
+        let receiver_kind = match self.ctx.krate.types.get(effective_ty) {
             Some(Type::Dict(_, _)) => smelt_stdlib::TypeScriptReceiverKind::Map,
             Some(Type::Set(_)) => smelt_stdlib::TypeScriptReceiverKind::Set,
             _ => return Ok(None),
@@ -61,16 +75,102 @@ impl ModuleBuilder<'_> {
         let Some(rule) = smelt_stdlib::typescript_method_rule(receiver_kind, member_name) else {
             return Ok(None);
         };
-        match rule {
-            RuleId::TsMapHas => self.map_has_call(call, body),
-            RuleId::TsMapGet => self.map_get_call(call, body),
-            RuleId::TsMapMutation => self.map_mutation_call(call, body),
-            RuleId::TsMapProjection => self.map_projection_call(call, body),
-            RuleId::TsSetHas => self.set_contains_call(call, body),
-            RuleId::TsSetMutation => self.set_mutation_call(call, body),
-            RuleId::TsSetProjection => self.set_projection_call(call, body),
-            _ => Ok(None),
+        // The operation is built on the narrowed receiver (typed `T`, unwrapped
+        // by codegen) when the source receiver was optional, and directly on the
+        // receiver otherwise.
+        let op_receiver = if optional_inner.is_some() {
+            self.narrowed_optional_receiver(receiver, effective_ty, member.span, body)
+        } else {
+            receiver
+        };
+        let op = match rule {
+            RuleId::TsMapHas => self.map_has_call(call, op_receiver, body)?,
+            RuleId::TsMapGet => self.map_get_call(call, op_receiver, body)?,
+            RuleId::TsMapMutation => self.map_mutation_call(call, op_receiver, body)?,
+            RuleId::TsMapProjection => self.map_projection_with_receiver(call, op_receiver, body)?,
+            RuleId::TsSetHas => self.set_contains_call(call, op_receiver, body)?,
+            RuleId::TsSetMutation => self.set_mutation_call(call, op_receiver, body)?,
+            RuleId::TsSetProjection => self.set_projection_call(call, op_receiver, body)?,
+            _ => return Ok(None),
+        };
+        let Some(op) = op else {
+            return Ok(None);
+        };
+        if optional_inner.is_some() {
+            Ok(Some(
+                self.wrap_optional_receiver_method(receiver, op, call.span, body),
+            ))
+        } else {
+            Ok(Some(op))
         }
+    }
+
+    /// Narrow an optional modeled receiver to its inner type for a guarded op.
+    ///
+    /// Builds an [`ExprKind::TypeAssert`] typed as the receiver's inner type. The
+    /// Rust emitter recognizes an `Optional(inner)` operand assigned into an
+    /// `inner`-typed slot and unwraps it (`.clone().expect(...)`), matching the
+    /// narrowing the ordinary `if (recv) { recv.method() }` guard produces. The
+    /// assertion is only ever evaluated inside the present branch of the
+    /// conditional built by [`Self::wrap_optional_receiver_method`], so the
+    /// unwrap cannot observe an absent receiver.
+    fn narrowed_optional_receiver(
+        &self,
+        receiver: smelt_hir::ExprId,
+        inner_ty: smelt_hir::TypeId,
+        span: oxc::span::Span,
+        body: &mut Body,
+    ) -> smelt_hir::ExprId {
+        body.push_expr(Expr {
+            kind: ExprKind::TypeAssert { value: receiver },
+            ty: inner_ty,
+            span: self.span(span.start, span.end),
+        })
+    }
+
+    /// Wrap a modeled receiver operation as an optional-chained method result.
+    ///
+    /// Given the original optional receiver and the modeled operation `op` built
+    /// on its narrowed form, produces `recv present ? Some(op) : undefined`. The
+    /// result type flattens through [`Self::optional_chain_result_type`] so an op
+    /// that already returns `Optional` (e.g. `Map.get`) does not double-wrap. The
+    /// receiver expression is shared by the presence test and the narrowed
+    /// access; MIR memoizes each HIR expression, so the receiver is evaluated
+    /// exactly once and its temporary dominates both uses.
+    fn wrap_optional_receiver_method(
+        &mut self,
+        receiver: smelt_hir::ExprId,
+        op: smelt_hir::ExprId,
+        span: oxc::span::Span,
+        body: &mut Body,
+    ) -> smelt_hir::ExprId {
+        let op_ty = Self::expr_ty(body, op);
+        let result_ty = self.optional_chain_result_type(op_ty);
+        let bool_ty = self.ctx.krate.types.intern(Type::Bool);
+        let is_absent = body.push_expr(Expr {
+            kind: ExprKind::UnknownIs {
+                value: receiver,
+                kind: smelt_hir::UnknownKind::Null,
+            },
+            ty: bool_ty,
+            span: self.span(span.start, span.end),
+        });
+        let present = self.unary_bool_expr(smelt_hir::UnaryOp::Not, is_absent, span, body);
+        let none_ty = self.ctx.krate.types.intern(Type::None);
+        let absent = body.push_expr(Expr {
+            kind: ExprKind::Literal(smelt_hir::Literal::None),
+            ty: none_ty,
+            span: self.span(span.start, span.end),
+        });
+        body.push_expr(Expr {
+            kind: ExprKind::Conditional {
+                cond: present,
+                then_expr: op,
+                else_expr: absent,
+            },
+            ty: result_ty,
+            span: self.span(span.start, span.end),
+        })
     }
 
     /// Return whether a member name belongs to a registry-backed collection method family.
@@ -82,9 +182,14 @@ impl ModuleBuilder<'_> {
     }
 
     /// Lower direct TypeScript `Set.prototype.has`.
+    ///
+    /// `receiver` is the pre-lowered set receiver supplied by
+    /// [`Self::dispatch_collection_method`]; for an optional-chained receiver it
+    /// is the narrowed (`T`-typed) form so the same op serves both spellings.
     pub(in crate::lowering) fn set_contains_call(
         &mut self,
         call: &oxc::ast::ast::CallExpression<'_>,
+        receiver: smelt_hir::ExprId,
         body: &mut Body,
     ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
         let Expression::StaticMemberExpression(member) = &call.callee else {
@@ -99,7 +204,7 @@ impl ModuleBuilder<'_> {
                 "Set.has requires exactly one argument",
             ));
         };
-        let set = self.expression(&member.object, body)?;
+        let set = receiver;
         let set_ty = Self::expr_ty(body, set);
         let Some(Type::Set(set_element_ty)) = self.ctx.krate.types.get(set_ty) else {
             return Ok(None);
@@ -121,9 +226,12 @@ impl ModuleBuilder<'_> {
     }
 
     /// Lower direct TypeScript `Set` mutation methods.
+    ///
+    /// `receiver` is the pre-lowered set receiver (narrowed for optional chains).
     pub(in crate::lowering) fn set_mutation_call(
         &mut self,
         call: &oxc::ast::ast::CallExpression<'_>,
+        receiver: smelt_hir::ExprId,
         body: &mut Body,
     ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
         let Expression::StaticMemberExpression(member) = &call.callee else {
@@ -133,7 +241,7 @@ impl ModuleBuilder<'_> {
         if !matches!(method, "add" | "delete" | "clear") {
             return Ok(None);
         }
-        let set = self.expression(&member.object, body)?;
+        let set = receiver;
         let set_ty = Self::expr_ty(body, set);
         let Some(Type::Set(set_element_ty)) = self.ctx.krate.types.get(set_ty) else {
             return Ok(None);
@@ -204,9 +312,12 @@ impl ModuleBuilder<'_> {
     }
 
     /// Lower direct TypeScript `Map.prototype.has`.
+    ///
+    /// `receiver` is the pre-lowered map receiver (narrowed for optional chains).
     pub(in crate::lowering) fn map_has_call(
         &mut self,
         call: &oxc::ast::ast::CallExpression<'_>,
+        receiver: smelt_hir::ExprId,
         body: &mut Body,
     ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
         let Expression::StaticMemberExpression(member) = &call.callee else {
@@ -221,7 +332,7 @@ impl ModuleBuilder<'_> {
                 "Map.has requires exactly one key argument",
             ));
         };
-        let dict = self.expression(&member.object, body)?;
+        let dict = receiver;
         let dict_ty = Self::expr_ty(body, dict);
         let Some(Type::Dict(dict_key_ty, _)) = self.ctx.krate.types.get(dict_ty) else {
             return Ok(None);
@@ -243,9 +354,12 @@ impl ModuleBuilder<'_> {
     }
 
     /// Lower direct TypeScript `Map.prototype.get`.
+    ///
+    /// `receiver` is the pre-lowered map receiver (narrowed for optional chains).
     pub(in crate::lowering) fn map_get_call(
         &mut self,
         call: &oxc::ast::ast::CallExpression<'_>,
+        receiver: smelt_hir::ExprId,
         body: &mut Body,
     ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
         let Expression::StaticMemberExpression(member) = &call.callee else {
@@ -254,7 +368,7 @@ impl ModuleBuilder<'_> {
         if member.property.name != "get" {
             return Ok(None);
         }
-        let dict = self.expression(&member.object, body)?;
+        let dict = receiver;
         let dict_ty = Self::expr_ty(body, dict);
         let Some(Type::Dict(dict_key_ty, dict_value_ty)) = self.ctx.krate.types.get(dict_ty) else {
             return Ok(None);
@@ -287,9 +401,12 @@ impl ModuleBuilder<'_> {
     }
 
     /// Lower direct TypeScript `Map` mutation methods.
+    ///
+    /// `receiver` is the pre-lowered map receiver (narrowed for optional chains).
     pub(in crate::lowering) fn map_mutation_call(
         &mut self,
         call: &oxc::ast::ast::CallExpression<'_>,
+        receiver: smelt_hir::ExprId,
         body: &mut Body,
     ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
         let Expression::StaticMemberExpression(member) = &call.callee else {
@@ -299,7 +416,7 @@ impl ModuleBuilder<'_> {
         if !matches!(method, "set" | "delete" | "clear") {
             return Ok(None);
         }
-        let dict = self.expression(&member.object, body)?;
+        let dict = receiver;
         let dict_ty = Self::expr_ty(body, dict);
         let Some(Type::Dict(dict_key_ty, dict_value_ty)) = self.ctx.krate.types.get(dict_ty) else {
             return Ok(None);
@@ -427,13 +544,37 @@ impl ModuleBuilder<'_> {
         if let [dict_argument] = call.arguments.as_slice() {
             return self.static_dict_projection_utility_call(call, body, op, dict_argument);
         }
+        let dict = self.expression(&member.object, body)?;
+        self.map_projection_with_receiver(call, dict, body)
+    }
+
+    /// Lower a `Map` projection method on a pre-lowered receiver.
+    ///
+    /// Shared by [`Self::map_projection_call`] (receiver form) and
+    /// [`Self::dispatch_collection_method`], which passes the narrowed receiver
+    /// for optional-chained `recv?.keys()/values()/entries()` calls.
+    pub(in crate::lowering) fn map_projection_with_receiver(
+        &mut self,
+        call: &oxc::ast::ast::CallExpression<'_>,
+        receiver: smelt_hir::ExprId,
+        body: &mut Body,
+    ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return Ok(None);
+        };
+        let op = match member.property.name.as_str() {
+            "keys" => DictProjectionOp::Keys,
+            "values" => DictProjectionOp::Values,
+            "entries" => DictProjectionOp::Entries,
+            _ => return Ok(None),
+        };
         if !call.arguments.is_empty() {
             return Err(SmeltError::unsupported(
                 self.span(call.span.start, call.span.end),
                 "Map keys/values/entries require no arguments",
             ));
         }
-        let dict = self.expression(&member.object, body)?;
+        let dict = receiver;
         let dict_ty = Self::expr_ty(body, dict);
         let Some(Type::Dict(dict_key_ty, dict_value_ty)) = self.ctx.krate.types.get(dict_ty) else {
             return Ok(None);
@@ -551,9 +692,12 @@ impl ModuleBuilder<'_> {
     }
 
     /// Lower direct TypeScript `Set` projection methods.
+    ///
+    /// `receiver` is the pre-lowered set receiver (narrowed for optional chains).
     pub(in crate::lowering) fn set_projection_call(
         &mut self,
         call: &oxc::ast::ast::CallExpression<'_>,
+        receiver: smelt_hir::ExprId,
         body: &mut Body,
     ) -> Result<Option<smelt_hir::ExprId>, SmeltError> {
         let Expression::StaticMemberExpression(member) = &call.callee else {
@@ -570,7 +714,7 @@ impl ModuleBuilder<'_> {
                 "Set keys/values/entries require no arguments",
             ));
         }
-        let set = self.expression(&member.object, body)?;
+        let set = receiver;
         let set_ty = Self::expr_ty(body, set);
         let Some(Type::Set(set_item_ty)) = self.ctx.krate.types.get(set_ty) else {
             return Ok(None);


### PR DESCRIPTION
## Summary

Fixes a correctness bug: `recv?.method(args)` where `recv: T | undefined`/`T | null` and `T` is a modeled receiver (Map/Set) was silently mis-lowering to an erased `SmeltUnknown` field read (`stack.get("has")`) instead of the modeled operation — blocking es-toolkit `isMatchWith` and dependents.

- `dispatch_collection_method` detects an `Optional(inner)` modeled receiver and produces `present ? Some(<modeled op on narrowed recv>) : undefined`, reusing the same modeled HIR ops the non-optional receiver produces (`DictContainsKey`/`DictGet`/`DictSet`/`SetContains`/…). No new `SmeltUnknown`; result flows through the existing Optional machinery.
- Per-method builders refactored to take a pre-lowered receiver so one path serves plain and optional-chained spellings.

Four further codegen families fixed via the probe loop: array-predicate-callback truthiness coercion, optional-field-on-absent-receiver fold, `Array.prototype.pop` destination coercion, surplus positional call arguments dropped (JS semantics).

## Verification

- `cargo test --workspace --exclude smelt-gui` green, no regressions; clippy (pedantic, lib) clean on touched crates; new codegen regression tests.
- E2E fixture (`smelt build` + generated `cargo test`, 3 tests) green.
- Documented deferral: a `switch`/`match` with divergent post-arm join blocks (structural match-emitter limitation) is the next wall; the probe copy did not reach dist-smelt emission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_