### PR TITLE
feat(estk): general match join-block emitter + first whole-crate transpile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,10 @@ blocker-logs/*.md
 !blocker-logs/estk-optional-receivers.md
 # estk-host-override-slots.md documents bounded globalThis host-constructor reassignment
 !blocker-logs/estk-host-override-slots.md
+# estk-match-emitter.md documents the match/switch join-block emitter fix + first whole-crate transpile
+!blocker-logs/estk-match-emitter.md
+# estk-first-transpile-diagnostics.md is the generated-crate diagnostics report for the first whole-crate transpile
+!blocker-logs/estk-first-transpile-diagnostics.md
 
 # Generated docs site output
 _site/

--- a/blocker-logs/estk-first-transpile-diagnostics.md
+++ b/blocker-logs/estk-first-transpile-diagnostics.md
@@ -1,0 +1,562 @@
+# Rust Diagnostics
+
+- Cargo manifest: `/tmp/claude-0/-home-user-smelt/992beec0-8d53-5927-bcf1-98aff0398478/scratchpad/es-toolkit/dist-smelt/Cargo.toml`
+- Cargo check: `failed`
+- Errors: `525`
+- Warnings: `387`
+
+## Summary By Code
+
+1. **error** `E0308` - 394 diagnostics
+2. **warning** `unused_mut` - 244 diagnostics
+3. **warning** `unused_assignments` - 57 diagnostics
+4. **warning** `unreachable_code` - 44 diagnostics
+5. **warning** `unused_parens` - 41 diagnostics
+6. **error** `no-code` - 26 diagnostics
+7. **error** `E0599` - 20 diagnostics
+8. **error** `E0277` - 19 diagnostics
+9. **error** `E0004` - 16 diagnostics
+10. **error** `E0596` - 12 diagnostics
+11. **error** `E0609` - 10 diagnostics
+12. **error** `E0425` - 7 diagnostics
+13. **error** `E0631` - 5 diagnostics
+14. **error** `E0282` - 4 diagnostics
+15. **error** `E0382` - 3 diagnostics
+16. **error** `E0057` - 2 diagnostics
+17. **error** `E0658` - 2 diagnostics
+18. **error** `E0107` - 1 diagnostic
+19. **error** `E0271` - 1 diagnostic
+20. **error** `E0381` - 1 diagnostic
+21. **error** `E0600` - 1 diagnostic
+22. **error** `E0689` - 1 diagnostic
+23. **warning** `non_camel_case_types` - 1 diagnostic
+
+## Groups
+
+1. **error** `E0308` - 389 occurrences
+   - Message: mismatched types
+   - Examples:
+     - `src/allKeyed.rs:65`
+     - `src/allKeyed.rs:65`
+     - `src/allKeyed.rs:65`
+     - `src/allKeyed.rs:65`
+     - `src/allKeyed.rs:65`
+2. **warning** `unused_mut` - 244 occurrences
+   - Message: variable does not need to be mutable
+   - Examples:
+     - `src/assignInWith.rs:7`
+     - `src/assignValue.rs:7`
+     - `src/assignWith.rs:7`
+     - `src/cartesianProduct.rs:10`
+     - `src/clone.rs:91`
+3. **warning** `unreachable_code` - 44 occurrences
+   - Message: unreachable statement
+   - Examples:
+     - `src/bind.rs:60`
+     - `src/bindKey.rs:61`
+     - `src/cloneDeepWith_1.rs:576`
+     - `src/clone_1.rs:387`
+     - `src/every.rs:122`
+4. **warning** `unused_parens` - 17 occurrences
+   - Message: unnecessary parentheses around method argument
+   - Examples:
+     - `src/chunk.rs:14`
+     - `src/curryRight.rs:200`
+     - `src/decimalAdjust.rs:62`
+     - `src/dropRight_1.rs:11`
+     - `src/drop_1.rs:8`
+5. **error** `E0004` - 16 occurrences
+   - Message: non-exhaustive patterns: `Some(SmeltUnknown::Undefined)` not covered
+   - Examples:
+     - `src/ary.rs:15`
+     - `src/cloneWith.rs:13`
+     - `src/curry.rs:22`
+     - `src/curryRight.rs:22`
+     - `src/defaults.rs:43`
+6. **warning** `unused_parens` - 13 occurrences
+   - Message: unnecessary parentheses around function argument
+   - Examples:
+     - `src/debounce.rs:96`
+     - `src/debounce.rs:109`
+     - `src/debounce.rs:133`
+     - `src/dropWhile_1.rs:11`
+     - `src/dropWhile_1.rs:16`
+7. **error** `no-code` - 12 occurrences
+   - Message: expected pattern, found `*`
+   - Examples:
+     - `src/filterAsync_spec.rs:316`
+     - `src/filterAsync_spec.rs:381`
+     - `src/flatMapAsync_spec.rs:387`
+     - `src/flatMapAsync_spec.rs:452`
+     - `src/forEachAsync_spec.rs:232`
+8. **warning** `unused_assignments` - 11 occurrences
+   - Message: value assigned to `keys` is never read
+   - Examples:
+     - `src/filter.rs:73`
+     - `src/pick_1.rs:65`
+     - `src/pick_1.rs:61`
+     - `src/pick_1.rs:73`
+     - `src/pick_1.rs:78`
+9. **warning** `unused_assignments` - 11 occurrences
+   - Message: value assigned to `resolved_path` is never read
+   - Examples:
+     - `src/has.rs:83`
+     - `src/has.rs:80`
+     - `src/has.rs:42`
+     - `src/hasIn.rs:123`
+     - `src/hasIn.rs:120`
+10. **warning** `unused_assignments` - 8 occurrences
+   - Message: value assigned to `i_2` is never read
+   - Examples:
+     - `src/mergeWith_1.rs:26504`
+     - `src/mergeWith_1.rs:22758`
+     - `src/mergeWith_1.rs:19007`
+     - `src/mergeWith_1.rs:15261`
+     - `src/mergeWith_1.rs:11504`
+11. **warning** `unused_parens` - 8 occurrences
+   - Message: unnecessary parentheses around type
+   - Examples:
+     - `src/main.rs:3461`
+     - `src/main.rs:3515`
+     - `src/main.rs:3527`
+     - `src/main.rs:3538`
+     - `src/main.rs:3694`
+12. **error** `no-code` - 6 occurrences
+   - Message: expected identifier, found `(`
+   - Examples:
+     - `src/cond.rs:25`
+     - `src/cond.rs:26`
+     - `src/cond.rs:42`
+     - `src/cond.rs:42`
+     - `src/cond.rs:44`
+13. **error** `E0599` - 6 occurrences
+   - Message: `SmeltUnknown` is not an iterator
+   - Examples:
+     - `src/isEqualWith.rs:47`
+     - `src/isEqualWith.rs:56`
+     - `src/isEqualWith.rs:67`
+     - `src/isEqualWith.rs:80`
+     - `src/isEqualWith.rs:89`
+14. **error** `E0609` - 5 occurrences
+   - Message: no field `apply` on type `DebouncedFunction<SmeltErasedFunction>`
+   - Examples:
+     - `src/debounce.rs:114`
+     - `src/debounce.rs:138`
+     - `src/debounce.rs:146`
+     - `src/throttle.rs:73`
+     - `src/throttle.rs:95`
+15. **error** `no-code` - 4 occurrences
+   - Message: cast cannot be followed by a method call
+   - Examples:
+     - `src/clone_1.rs:283`
+     - `src/clone_1.rs:283`
+     - `src/clone_spec.rs:347`
+     - `src/clone_spec.rs:347`
+16. **error** `E0282` - 4 occurrences
+   - Message: type annotations needed
+   - Examples:
+     - `src/omitBy_1.rs:59`
+     - `src/omit_1.rs:144`
+     - `src/omit_1.rs:200`
+     - `src/pickBy_1.rs:72`
+17. **error** `E0308` - 4 occurrences
+   - Message: arguments to this function are incorrect
+   - Examples:
+     - `src/isSubset.rs:7`
+     - `src/without_1.rs:7`
+     - `src/xor_1.rs:7`
+     - `src/xor_1.rs:7`
+18. **error** `E0425` - 4 occurrences
+   - Message: cannot find value `smelt_capture_self` in this scope
+   - Examples:
+     - `src/main.rs:5082`
+     - `src/main.rs:5084`
+     - `src/main.rs:5085`
+     - `src/main.rs:5089`
+19. **error** `no-code` - 3 occurrences
+   - Message: `<` is interpreted as a start of generic arguments for `f64`, not a comparison
+   - Examples:
+     - `src/initial_spec.rs:81`
+     - `src/initial_spec.rs:91`
+     - `src/last_spec.rs:77`
+20. **error** `E0596` - 3 occurrences
+   - Message: cannot borrow `*mapper` as mutable, as it is behind a `&` reference
+   - Examples:
+     - `src/unionBy_1.rs:9`
+     - `src/xorBy_1.rs:12`
+     - `src/xorBy_1.rs:14`
+21. **error** `E0631` - 3 occurrences
+   - Message: type mismatch in closure arguments
+   - Examples:
+     - `src/matchesProperty.rs:27`
+     - `src/matchesProperty.rs:65`
+     - `src/matchesProperty.rs:100`
+22. **error** `E0277` - 2 occurrences
+   - Message: can't compare `std::option::Option<SmeltUnknown>` with `{float}`
+   - Examples:
+     - `src/repeat.rs:31`
+     - `src/repeat.rs:36`
+23. **error** `E0277` - 2 occurrences
+   - Message: the trait bound `SmeltUnknown: AsRef<str>` is not satisfied
+   - Examples:
+     - `src/escape_1.rs:8`
+     - `src/unescape_1.rs:8`
+24. **error** `E0277` - 2 occurrences
+   - Message: the trait bound `dyn Future<Output = Result<SmeltUnknown, Box<dyn StdError>>>: Default` is not satisfied
+   - Examples:
+     - `src/allKeyed.rs:65`
+     - `src/allKeyed.rs:65`
+25. **error** `E0382` - 2 occurrences
+   - Message: use of moved value: `predicate_1`
+   - Examples:
+     - `src/filter.rs:62`
+     - `src/partition.rs:59`
+26. **error** `E0425` - 2 occurrences
+   - Message: cannot find function `smelt_capture_` in this scope
+   - Examples:
+     - `src/debounce_1.rs:117`
+     - `src/debounce_1.rs:129`
+27. **error** `E0596` - 2 occurrences
+   - Message: cannot borrow `*are_elements_equal` as mutable, as it is behind a `&` reference
+   - Examples:
+     - `src/xorWith_1.rs:12`
+     - `src/xorWith_1.rs:14`
+28. **error** `E0596` - 2 occurrences
+   - Message: cannot borrow `self.__data__` as mutable, as it is behind a `&` reference
+   - Examples:
+     - `src/main.rs:5169`
+     - `src/main.rs:5177`
+29. **error** `E0596` - 2 occurrences
+   - Message: cannot borrow `self.semaphore` as mutable, as it is behind a `&` reference
+   - Examples:
+     - `src/main.rs:5146`
+     - `src/main.rs:5152`
+30. **error** `E0596` - 2 occurrences
+   - Message: cannot borrow data in an `Rc` as mutable
+   - Examples:
+     - `src/after.rs:33`
+     - `src/before.rs:78`
+31. **error** `E0599` - 2 occurrences
+   - Message: no method named `len` found for tuple `(SmeltUnknown, SmeltUnknown)` in the current scope
+   - Examples:
+     - `src/dropWhile.rs:61`
+     - `src/findIndex.rs:101`
+32. **error** `E0599` - 2 occurrences
+   - Message: no method named `len` found for tuple `(std::string::String, SmeltUnknown)` in the current scope
+   - Examples:
+     - `src/dropRightWhile.rs:63`
+     - `src/findLastIndex.rs:115`
+33. **error** `E0599` - 2 occurrences
+   - Message: no method named `same_js_key` found for enum `SmeltUnion359` in the current scope
+   - Examples:
+     - `src/decimalAdjust.rs:56`
+     - `src/decimalAdjust.rs:135`
+34. **error** `E0609` - 2 occurrences
+   - Message: no field `length` on type `SmeltList<SmeltUnknown>`
+   - Examples:
+     - `src/unzipWith_1.rs:19`
+     - `src/unzipWith_1.rs:22`
+35. **error** `E0609` - 2 occurrences
+   - Message: no field `result` on type `&SmeltMatch`
+   - Examples:
+     - `src/truncate.rs:170`
+     - `src/truncate.rs:249`
+36. **error** `E0631` - 2 occurrences
+   - Message: type mismatch in function arguments
+   - Examples:
+     - `src/trimEnd_1.rs:33`
+     - `src/trimStart_1.rs:31`
+37. **error** `E0658` - 2 occurrences
+   - Message: use of unstable library feature `fn_traits`
+   - Examples:
+     - `src/attempt_1.rs:14`
+     - `src/unzipWith_1.rs:45`
+38. **warning** `unused_assignments` - 2 occurrences
+   - Message: value assigned to `end` is never read
+   - Examples:
+     - `src/slice.rs:54`
+     - `src/slice.rs:48`
+39. **warning** `unused_assignments` - 2 occurrences
+   - Message: value assigned to `i` is never read
+   - Examples:
+     - `src/some.rs:130`
+     - `src/sumBy_1.rs:50`
+40. **warning** `unused_assignments` - 2 occurrences
+   - Message: value assigned to `mapped` is never read
+   - Examples:
+     - `src/flatMap.rs:28`
+     - `src/flatMap.rs:21`
+41. **warning** `unused_assignments` - 2 occurrences
+   - Message: value assigned to `new_error` is never read
+   - Examples:
+     - `src/clone.rs:195`
+     - `src/clone.rs:111`
+42. **warning** `unused_assignments` - 2 occurrences
+   - Message: value assigned to `new_object` is never read
+   - Examples:
+     - `src/clone.rs:228`
+     - `src/clone.rs:144`
+43. **warning** `unused_assignments` - 2 occurrences
+   - Message: value assigned to `result` is never read
+   - Examples:
+     - `src/filter.rs:69`
+     - `src/sumBy_1.rs:49`
+44. **warning** `unused_assignments` - 2 occurrences
+   - Message: value assigned to `start_index` is never read
+   - Examples:
+     - `src/reduce.rs:54`
+     - `src/reduceRight.rs:56`
+45. **warning** `unused_parens` - 2 occurrences
+   - Message: unnecessary parentheses around `match` scrutinee expression
+   - Examples:
+     - `src/findIndex.rs:81`
+     - `src/findLastIndex.rs:106`
+46. **error** `no-code` - 1 occurrence
+   - Message: lifetime may not live long enough
+   - Examples:
+     - `src/cloneDeepWith_1.rs:7`
+47. **error** `E0057` - 1 occurrence
+   - Message: this function takes 0 arguments but 1 argument was supplied
+   - Examples:
+     - `src/once_1.rs:21`
+48. **error** `E0057` - 1 occurrence
+   - Message: this function takes 1 argument but 0 arguments were supplied
+   - Examples:
+     - `src/once_1.rs:29`
+49. **error** `E0107` - 1 occurrence
+   - Message: missing generics for struct `ImmutableCache`
+   - Examples:
+     - `src/main.rs:5194`
+50. **error** `E0271` - 1 occurrence
+   - Message: expected `{closure@flatten_1.rs:20:5}` to return `SmeltUnknown`, but it returns `()`
+   - Examples:
+     - `src/flatten_1.rs:20`
+51. **error** `E0277` - 1 occurrence
+   - Message: `A` doesn't implement `std::fmt::Display`
+   - Examples:
+     - `src/main.rs:5268`
+52. **error** `E0277` - 1 occurrence
+   - Message: `SmeltJsMap<SmeltUnknown, std::string::String>` doesn't implement `Debug`
+   - Examples:
+     - `src/main.rs:4281`
+53. **error** `E0277` - 1 occurrence
+   - Message: `SmeltJsMap<T, std::string::String>` doesn't implement `Debug`
+   - Examples:
+     - `src/main.rs:4293`
+54. **error** `E0277` - 1 occurrence
+   - Message: a value of type `SmeltJsMap<T, std::string::String>` cannot be built from an iterator over elements of type `(SmeltUnknown, std::string::String)`
+   - Examples:
+     - `src/main.rs:5190`
+55. **error** `E0277` - 1 occurrence
+   - Message: can't compare `f64` with `std::option::Option<SmeltUnion359>`
+   - Examples:
+     - `src/rangeRight_1.rs:66`
+56. **error** `E0277` - 1 occurrence
+   - Message: can't compare `f64` with `std::option::Option<SmeltUnknown>`
+   - Examples:
+     - `src/range.rs:65`
+57. **error** `E0277` - 1 occurrence
+   - Message: the trait bound `SmeltRecord<std::string::String, SmeltUnknown>: serde::Deserialize<'de>` is not satisfied
+   - Examples:
+     - `src/isJSON.rs:16`
+58. **error** `E0277` - 1 occurrence
+   - Message: the trait bound `SmeltUnion359: Eq` is not satisfied
+   - Examples:
+     - `src/pullAt.rs:87`
+59. **error** `E0277` - 1 occurrence
+   - Message: the trait bound `SmeltUnion359: Hash` is not satisfied
+   - Examples:
+     - `src/pullAt.rs:87`
+60. **error** `E0277` - 1 occurrence
+   - Message: the trait bound `T: Eq` is not satisfied
+   - Examples:
+     - `src/uniq_1.rs:8`
+61. **error** `E0277` - 1 occurrence
+   - Message: the trait bound `T: Hash` is not satisfied
+   - Examples:
+     - `src/uniq_1.rs:8`
+62. **error** `E0277` - 1 occurrence
+   - Message: the trait bound `f64: Eq` is not satisfied
+   - Examples:
+     - `src/pullAt_1.rs:27`
+63. **error** `E0277` - 1 occurrence
+   - Message: the trait bound `f64: Hash` is not satisfied
+   - Examples:
+     - `src/pullAt_1.rs:27`
+64. **error** `E0308` - 1 occurrence
+   - Message: `match` arms have incompatible types
+   - Examples:
+     - `src/delay.rs:14`
+65. **error** `E0381` - 1 occurrence
+   - Message: used binding `i_1` isn't initialized
+   - Examples:
+     - `src/some.rs:138`
+66. **error** `E0382` - 1 occurrence
+   - Message: use of moved value: `_smelt_tmp_11`
+   - Examples:
+     - `src/unionBy.rs:34`
+67. **error** `E0425` - 1 occurrence
+   - Message: cannot find value `smelt_callback` in this scope
+   - Examples:
+     - `src/template.rs:408`
+68. **error** `E0596` - 1 occurrence
+   - Message: cannot borrow `*are_items_equal` as mutable, as it is behind a `&` reference
+   - Examples:
+     - `src/isSubsetWith.rs:10`
+69. **error** `E0599` - 1 occurrence
+   - Message: no method named `clear` found for struct `SmeltJsMap<K, V>` in the current scope
+   - Examples:
+     - `src/main.rs:5181`
+70. **error** `E0599` - 1 occurrence
+   - Message: no method named `into_smelt_unknown` found for struct `Rc<dyn Fn(SmeltUnknown) -> SmeltUnknown>` in the current scope
+   - Examples:
+     - `src/isMatchWith.rs:61`
+71. **error** `E0599` - 1 occurrence
+   - Message: no method named `into_smelt_unknown` found for struct `Rc<{closure@src/toolkit.rs:12:43: 12:72}>` in the current scope
+   - Examples:
+     - `src/toolkit.rs:16`
+72. **error** `E0599` - 1 occurrence
+   - Message: no method named `unwrap_or_else` found for unit type `()` in the current scope
+   - Examples:
+     - `src/flow_1.rs:75`
+73. **error** `E0599` - 1 occurrence
+   - Message: the method `contains_key` exists for struct `SmeltJsMap<T, std::string::String>`, but its trait bounds were not satisfied
+   - Examples:
+     - `src/main.rs:5202`
+74. **error** `E0599` - 1 occurrence
+   - Message: the method `get` exists for struct `SmeltJsMap<T, std::string::String>`, but its trait bounds were not satisfied
+   - Examples:
+     - `src/main.rs:5198`
+75. **error** `E0599` - 1 occurrence
+   - Message: the method `insert` exists for struct `SmeltJsMap<T, std::string::String>`, but its trait bounds were not satisfied
+   - Examples:
+     - `src/main.rs:5206`
+76. **error** `E0599` - 1 occurrence
+   - Message: the method `remove` exists for struct `SmeltJsMap<T, std::string::String>`, but its trait bounds were not satisfied
+   - Examples:
+     - `src/main.rs:5210`
+77. **error** `E0600` - 1 occurrence
+   - Message: cannot apply unary operator `-` to type `std::option::Option<f64>`
+   - Examples:
+     - `src/takeRight_1.rs:41`
+78. **error** `E0609` - 1 occurrence
+   - Message: no field `name` on type `HttpError`
+   - Examples:
+     - `src/main.rs:5276`
+79. **error** `E0689` - 1 occurrence
+   - Message: can't call method `max` on ambiguous numeric type `{float}`
+   - Examples:
+     - `src/invoke.rs:19`
+80. **warning** `non_camel_case_types` - 1 occurrence
+   - Message: type `__smelt_anon_class_2461` should have an upper camel case name
+   - Examples:
+     - `src/main.rs:4454`
+81. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `cache_constructor` is never read
+   - Examples:
+     - `src/memoize_1.rs:140`
+82. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `customizer_fn` is never read
+   - Examples:
+     - `src/setWith.rs:11`
+83. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `i_1` is never read
+   - Examples:
+     - `src/filter.rs:81`
+84. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `key_1` is never read
+   - Examples:
+     - `src/some.rs:166`
+85. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `length_1` is never read
+   - Examples:
+     - `src/filter.rs:80`
+86. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `path` is never read
+   - Examples:
+     - `src/result.rs:38`
+87. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `predicate_1` is never read
+   - Examples:
+     - `src/filter.rs:63`
+88. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `result_1` is never read
+   - Examples:
+     - `src/filter.rs:77`
+89. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `result_length` is never read
+   - Examples:
+     - `src/pullAllWith.rs:57`
+90. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `set_low` is never read
+   - Examples:
+     - `src/sortedIndexBy.rs:99`
+91. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `start` is never read
+   - Examples:
+     - `src/slice.rs:53`
+92. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `value_1` is never read
+   - Examples:
+     - `src/some.rs:168`
+93. **warning** `unused_assignments` - 1 occurrence
+   - Message: value assigned to `value` is never read
+   - Examples:
+     - `src/pullAllBy.rs:68`
+94. **warning** `unused_parens` - 1 occurrence
+   - Message: unnecessary parentheses around `return` value
+   - Examples:
+     - `src/now.rs:9`
+
+## Cargo Stderr
+
+```text
+Updating crates.io index
+     Locking 69 packages to latest Rust 1.96.1 compatible versions
+      Adding fancy-regex v0.14.0 (available: v0.18.0)
+      Adding rand v0.9.4 (available: v0.10.2)
+ Downloading crates ...
+  Downloaded zerocopy v0.8.53
+   Compiling proc-macro2 v1.0.106
+   Compiling quote v1.0.46
+   Compiling unicode-ident v1.0.24
+   Compiling libc v0.2.186
+   Compiling zerocopy v0.8.53
+   Compiling getrandom v0.3.4
+    Checking memchr v2.8.3
+   Compiling autocfg v1.5.1
+   Compiling num-traits v0.2.19
+    Checking cfg-if v1.0.4
+   Compiling serde_core v1.0.228
+   Compiling syn v2.0.118
+    Checking aho-corasick v1.1.4
+    Checking regex-syntax v0.8.11
+   Compiling zmij v1.0.21
+    Checking siphasher v1.0.3
+    Checking phf_shared v0.12.1
+    Checking rand_core v0.9.5
+    Checking regex-automata v0.4.14
+    Checking tinyvec_macros v0.1.1
+   Compiling serde_json v1.0.150
+    Checking iana-time-zone v0.1.65
+    Checking ppv-lite86 v0.2.21
+   Compiling chrono-tz v0.10.4
+   Compiling serde v1.0.228
+    Checking bit-vec v0.8.0
+    Checking bit-set v0.8.0
+    Checking rand_chacha v0.9.0
+    Checking chrono v0.4.45
+   Compiling serde_derive v1.0.228
+   Compiling tokio-macros v2.7.0
+    Checking tinyvec v1.11.0
+    Checking phf v0.12.1
+    Checking itoa v1.0.18
+    Checking pin-project-lite v0.2.17
+    Checking tokio v1.52.3
+    Checking unicode-normalization v0.1.25
+    Checking regex v1.12.4
+    Checking fancy-regex v0.14.0
+    Checking rand v0.9.4
+    Checking es_toolkit_probe v0.1.0 (/tmp/claude-0/-home-user-smelt/992beec0-8d53-5927-bcf1-98aff0398478/scratchpad/es-toolkit/dist-smelt)
+error: could not compile `es_toolkit_probe` (bin "es_toolkit_probe") due to 525 previous errors; 387 warnings emitted
+```

--- a/blocker-logs/estk-match-emitter.md
+++ b/blocker-logs/estk-match-emitter.md
@@ -1,0 +1,136 @@
+# es-toolkit match/switch join-block emitter + first whole-crate transpile
+
+This entry documents the Rust-emission blocker that gated es-toolkit's first
+whole-crate transpile, the general fix, and the small emitter families cleared
+afterward until `smelt build` at the es-toolkit root emitted `dist-smelt`.
+
+## Primary blocker: match codegen join block
+
+`smelt build` HIR- and MIR-lowered the whole crate but aborted in Rust emission
+with:
+
+```
+EmitError { message: "match codegen requires all non-terminating arms to share one join block" }
+```
+
+### Root cause
+
+A source `switch`/`match` lowers to a MIR `Terminator::Match` whose arms are
+separate basic blocks (`crates/smelt-mir/src/lower/stmt.rs::lower_match`). Every
+arm that does not otherwise diverge ends with `Goto(join)` where `join` is a
+single continuation block created up front.
+
+The emitter (`crates/smelt-codegen-rust/src/emitter/control_flow_match.rs`)
+assumed each arm target's **direct** terminator was that `Goto(join)`. It scanned
+the arm targets, collected their direct `Goto` targets, and required them all to
+be equal so the join could be hoisted and emitted **once** after the `match`.
+
+That assumption breaks whenever an arm body contains its own control flow. The
+triggering function was `trimEnd` (`src/string/trimEnd.ts`):
+
+```ts
+switch (typeof chars) {
+  case 'string': { if (chars.length !== 1) throw ...; while (...) endIndex--; break; }
+  case 'object': { while (...) endIndex--; }
+}
+return str.substring(0, endIndex);
+```
+
+The `'string'` arm target ends in a `Switch` (the conditional throw), and the
+`'object'` arm target ends in `Goto(<loop-header>)`. Neither directly `Goto`s the
+real join (`return str.substring(...)`); they reach it only transitively through
+their loops/branches. The synthesized default `Goto`s the join directly. So the
+scan saw conflicting direct targets (`<loop-header>` vs `<join>`) and aborted,
+even though all arm regions genuinely converge on one continuation.
+
+### General fix
+
+Emit each arm as a self-contained region that carries its own control-flow tail,
+rather than assuming one hoistable join:
+
+- `match_join` now returns `Some(join)` **only** when every arm target's direct
+  terminator is either a `Goto` to one shared block or a diverging terminator
+  (`Return`/`Throw`/`Unreachable`). If any arm ends in a `Switch`/`Call`/`Await`/
+  `Match`, or two arms `Goto` different blocks, it returns `None` (previously it
+  raised the hard error).
+- When a single clean join exists, behavior is unchanged: arms drop their
+  trailing `Goto` and the join is emitted once after the `match` (preserves
+  existing tests / output).
+- When there is no hoistable join, each arm (and the default) is emitted via the
+  existing `emit_block`, which already lowers nested loops, branches, and
+  returns and follows each arm's tail to its own continuation. The shared
+  continuation is duplicated into every arm that reaches it — the same treatment
+  arms ending in a non-`Goto` terminator already received.
+
+This reuses the emitter's existing structured-control-flow machinery instead of
+adding a bespoke join solver, and needs no MIR changes.
+
+Regression tests (`crates/smelt-codegen-rust/src/tests/part_6_tests.rs`):
+`emits_switch_with_heterogeneous_arm_successors` and
+`emits_switch_arm_with_loop_and_conditional_throw` (the `trimEnd` shape). Both
+previously aborted emission. End-to-end: a clean string-scrutinee variant was
+transpiled, compiled, and executed, returning the JS-correct results
+(`pick("loop",3)=6`, `pick("double",5)=10`, `pick("other",7)=7`).
+
+## Subsequent families cleared (first-abort loop)
+
+Each fix below was the next `smelt build` abort after the previous; all are
+general emitter fixes, not per-file special cases.
+
+1. **`array sort comparator must return a number`** — `sortKeys`
+   (`src/object/sortKeys.ts`) passes an optional `(a, b) => number` comparator to
+   `.sort()`. That optional callback is lowered through a synthesized wrapper
+   closure whose call of the erased/optional inner callback yields `SmeltUnknown`,
+   so the wrapper's declared return type erases to `unknown`. The frontend
+   already admits this erased return and documents that "the emitter coerces the
+   comparison result numerically", but the emitter still hard-required `Float`.
+   Fix (`emitter/list_mutation.rs::list_sort_comparator_text`): a `number` return
+   compares directly; an erased return (`unknown`/union/`never`/leaked
+   non-scoped type parameter, all of which render as `SmeltUnknown`) is coerced
+   through the existing `SmeltIntoF64` boundary adapter. This is a genuine dynamic
+   boundary (the callback may be absent at runtime), not `SmeltUnknown`-to-compile.
+
+2. **`set remove item must match the set element type`** — deleting a concrete
+   value from a `Set<unknown>` (e.g. `Set<unknown>.delete(1)` in an `isEqualWith`
+   spec). `set_add_text` already coerced inserted items to the element type via
+   `value_at_type`, but `set_remove_text` used strict type equality plus a raw
+   operand render. Fix (`emitter/set.rs::set_remove_text`): coerce the removed
+   item to the set element type, mirroring add, so the lookup key erases to
+   `SmeltUnknown` to match the stored keys. The now-unused
+   `validate_set_item_operands` helper was removed.
+
+3. **`dict set / dict remove / collection clear receiver must be a mutable local
+   for now`** — a `Map`-backed class stores its map in a field and mutates it via
+   `this.<field>.set/delete/clear(...)`, so the receiver operand is a `Field`
+   place, not a bare `Local`. Fix (`emitter/map.rs`, `emitter/list_mutation.rs`):
+   accept any place-rooted receiver and render its assignable lvalue via
+   `assignment_place_text` (which returns `self.<field>` for class fields), so the
+   mutation targets the stored collection in place instead of a temporary copy.
+
+After these, `smelt build` at the es-toolkit root completed and emitted
+`dist-smelt` (745 generated source files) — es-toolkit's first whole-crate
+transpile.
+
+## Whole-crate transpile status
+
+`dist-smelt` **emits** but does **not** yet compile clean. `rust-diagnostics`
+over the generated crate (see `estk-first-transpile-diagnostics.md`) reports
+525 errors / 387 warnings, dominated by `E0308` mismatched types (394). Because
+the crate does not compile clean, the `rust-test-report` prize step was not run
+(it requires a compiling crate). The remaining generated-Rust diagnostics are a
+separate, large body of work beyond this emitter blocker.
+
+## Observations noted, not fixed (out of scope for this blocker)
+
+- **`typeof`-switch scrutinee folding**: in `trimEnd`, `switch (typeof chars)`
+  lowers with a constant scrutinee (`match "object" { ... }`) and folds
+  `chars.includes(...)` inside the `'object'` arm to `false`. This is a
+  `typeof`-switch narrowing/fold issue in the frontend, independent of the match
+  emitter; it still emits valid (if runtime-incorrect) Rust.
+- **switch-inside-loop loop recognition**: `block_exits_to_loop`
+  (`emitter/control_flow.rs`) has no `Terminator::Match` arm (`_ => Ok(false)`),
+  so a `for`/`while` whose body ends in a `Match` is not recognized as a loop and
+  degenerates to a single-pass guard, and a match arm that should `continue`/
+  `break` the surrounding loop does not. es-toolkit's first-abort loop did not
+  reach this (it aborts earlier on the diagnostics families above), so it is
+  documented here as the next control-flow item rather than fixed.

--- a/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
@@ -1341,26 +1341,6 @@ impl FunctionEmitter<'_> {
         Ok(left_ty)
     }
 
-    /// Validates a set receiver and item operand, returning the set type.
-    /// Validates a set receiver and item operand, returning the set type.
-    pub(super) fn validate_set_item_operands(
-        &self,
-        set: &Operand,
-        item: &Operand,
-        context: &str,
-    ) -> Result<TypeId, EmitError> {
-        let set_ty = self.operand_ty(set)?;
-        let Some(Type::Set(item_ty)) = self.mir.types.get(set_ty) else {
-            return Err(EmitError::new(format!("{context} receiver must be a set")));
-        };
-        if self.operand_ty(item)? != *item_ty {
-            return Err(EmitError::new(format!(
-                "{context} item must match the set element type"
-            )));
-        }
-        Ok(set_ty)
-    }
-
     /// Converts a set insertion operation to Rust text.
     /// Converts a blocking HTTP GET operation to Rust text.
     pub(super) fn http_get_text(&self, url: &Operand) -> Result<String, EmitError> {

--- a/crates/smelt-codegen-rust/src/emitter/control_flow_match.rs
+++ b/crates/smelt-codegen-rust/src/emitter/control_flow_match.rs
@@ -4,6 +4,24 @@ use super::*;
 
 impl FunctionEmitter<'_> {
     /// Emits a match expression.
+    ///
+    /// Two strategies handle the arm bodies:
+    ///
+    /// * When every arm target's *direct* terminator is either a `Goto` to one
+    ///   shared block or a diverging terminator (`Return`/`Throw`/`Unreachable`),
+    ///   the arms are straight-line and truly converge on a single continuation.
+    ///   That continuation (the "join") is emitted once after the `match`, and
+    ///   each arm drops its trailing `Goto` to it (see [`Self::emit_block_as_match_arm`]).
+    ///
+    /// * Otherwise the arms have heterogeneous successors: some diverge, some
+    ///   fall through, and some reach the shared continuation only transitively
+    ///   through nested loops or branches whose own blocks end in a `Switch` or a
+    ///   `Goto` back into the arm body. There is no single block to hoist, so each
+    ///   arm is emitted as a self-contained region via [`Self::emit_block`], which
+    ///   already lowers nested loops, branches, and returns and follows each arm's
+    ///   control-flow tail to its own continuation. The shared continuation is
+    ///   duplicated into every arm that reaches it, mirroring how arms ending in a
+    ///   non-`Goto` terminator already emit their tail inline.
     pub(super) fn emit_match(
         &self,
         scrutinee: &Operand,
@@ -13,6 +31,7 @@ impl FunctionEmitter<'_> {
     ) -> Result<(), EmitError> {
         let scrutinee_text = self.match_scrutinee_text(scrutinee)?;
         let scrutinee_ty = self.operand_ty(scrutinee)?;
+        let hoisted_join = self.match_join(arms, default)?;
         out.push_str(&format!("    match {scrutinee_text} {{\n"));
         let match_declared = self.declared_locals_snapshot();
         for arm in arms {
@@ -20,27 +39,46 @@ impl FunctionEmitter<'_> {
                 "        {} => {{\n",
                 self.match_label_text_for_scrutinee(&arm.label, scrutinee_ty)
             ));
-            self.emit_block_as_match_arm(self.block(arm.target)?, out)?;
+            self.emit_match_arm(self.block(arm.target)?, hoisted_join, out)?;
             out.push_str("        }\n");
             self.restore_declared_locals(match_declared.clone());
         }
         if let Some(default_block) = default {
             out.push_str("        _ => {\n");
-            self.emit_block_as_match_arm(self.block(default_block)?, out)?;
+            self.emit_match_arm(self.block(default_block)?, hoisted_join, out)?;
             out.push_str("        }\n");
             self.restore_declared_locals(match_declared);
         } else {
             out.push_str("        _ => {}\n");
         }
         out.push_str("    }\n");
-        if let Some(join) = self.match_join(arms, default)? {
+        if let Some(join) = hoisted_join {
             self.emit_block(self.block(join)?, out)?;
         }
         Ok(())
     }
 
-    /// Emits a match arm body.
-    /// Emits a match arm body.
+    /// Emits a single arm body, dispatching on whether a shared join was hoisted.
+    ///
+    /// With a hoisted join the arm drops its trailing `Goto` to it; without one
+    /// the arm emits its full control-flow tail inline.
+    fn emit_match_arm(
+        &self,
+        block: &BasicBlock,
+        hoisted_join: Option<smelt_mir::BlockId>,
+        out: &mut String,
+    ) -> Result<(), EmitError> {
+        if hoisted_join.is_some() {
+            self.emit_block_as_match_arm(block, out)
+        } else {
+            self.emit_block(block, out)
+        }
+    }
+
+    /// Emits a match arm body whose trailing `Goto` to the shared join is dropped.
+    ///
+    /// Only used on the hoisted-join path, where the join block is emitted once
+    /// after the whole `match` and every arm falls straight through to it.
     pub(super) fn emit_block_as_match_arm(
         &self,
         block: &BasicBlock,
@@ -56,8 +94,14 @@ impl FunctionEmitter<'_> {
         }
     }
 
-    /// Finds the join block where all match arms converge.
-    /// Finds the join block where all match arms converge.
+    /// Finds a single join block that every arm falls straight through to.
+    ///
+    /// Returns `Some(join)` only when every arm target's direct terminator is a
+    /// `Goto` to the same block or a diverging terminator; the shared block can
+    /// then be hoisted out of the `match`. Returns `None` when the arms have
+    /// heterogeneous successors (an arm ends in a `Switch`/`Call`/`Await`/`Match`,
+    /// or two arms `Goto` different blocks), because in that case there is no
+    /// single block to hoist and each arm must carry its own control-flow tail.
     pub(super) fn match_join(
         &self,
         arms: &[smelt_mir::MatchArm],
@@ -66,15 +110,20 @@ impl FunctionEmitter<'_> {
         let mut join = None;
         for target in arms.iter().map(|arm| arm.target).chain(default) {
             let block = self.block(target)?;
-            if let Some(Terminator::Goto(join_target)) = block.terminator {
-                if join
-                    .replace(join_target)
-                    .is_some_and(|seen| seen != join_target)
-                {
-                    return Err(EmitError::new(
-                        "match codegen requires all non-terminating arms to share one join block",
-                    ));
+            match &block.terminator {
+                Some(Terminator::Goto(join_target)) => {
+                    if join
+                        .replace(*join_target)
+                        .is_some_and(|seen| seen != *join_target)
+                    {
+                        return Ok(None);
+                    }
                 }
+                // A diverging arm imposes no join constraint.
+                Some(Terminator::Return(_) | Terminator::Throw(_) | Terminator::Unreachable) => {}
+                // An arm ending in a branch/loop/call reaches its continuation
+                // only transitively, so no single block can be hoisted.
+                _ => return Ok(None),
             }
         }
         Ok(join)

--- a/crates/smelt-codegen-rust/src/emitter/list_mutation.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_mutation.rs
@@ -463,13 +463,15 @@ impl FunctionEmitter<'_> {
                 "{collection_name} clear destination must be None"
             )));
         }
-        let (Operand::Copy(Place::Local(local)) | Operand::Move(Place::Local(local))) = collection
-        else {
+        // Accept a place-rooted receiver (a class field holding the collection,
+        // e.g. `this.__data.clear()`) as well as a plain local, rendering the
+        // assignable lvalue so the clear mutates the stored collection in place.
+        let (Operand::Copy(collection_place) | Operand::Move(collection_place)) = collection else {
             return Err(EmitError::new(format!(
-                "{collection_name} clear receiver must be a mutable local for now"
+                "{collection_name} clear receiver must be a place operand"
             )));
         };
-        let collection_text = self.local_mut_value_text(*local)?;
+        let collection_text = self.assignment_place_text(collection_place)?;
         Ok(format!("{{ {collection_text}.clear(); () }}"))
     }
 
@@ -641,6 +643,19 @@ impl FunctionEmitter<'_> {
     /// and invoked per comparison; its numeric result maps to `Ordering` with
     /// JavaScript semantics (negative -> `Less`, positive -> `Greater`, zero and
     /// `NaN` -> `Equal`).
+    ///
+    /// A named or optional comparator (`array.sort(compareFn)` where `compareFn`
+    /// is `((a, b) => number) | undefined`) is lowered through a synthesized
+    /// wrapper closure whose call of the erased/optional inner callback yields a
+    /// `SmeltUnknown` result, so the wrapper's declared return type is erased to
+    /// `unknown` even though the source comparator is typed `=> number`. The
+    /// frontend deliberately admits that erased return (see the `array sort`
+    /// comparator check in `stdlib::list_sort_call`) and relies on this emitter
+    /// to coerce the comparison result numerically. A `SmeltUnknown` here is a
+    /// genuine dynamic boundary (the callback may be absent at runtime), so the
+    /// result is coerced through the `SmeltIntoF64` boundary adapter rather than
+    /// routed as an ordinary typed value; a concrete `number` return skips the
+    /// adapter and compares directly.
     fn list_sort_comparator_text(
         &self,
         comparator: &Operand,
@@ -658,9 +673,16 @@ impl FunctionEmitter<'_> {
         else {
             return Err(EmitError::new("array sort comparator must be a closure"));
         };
-        if self.mir.types.get(function_ty.return_ty) != Some(&Type::Float) {
-            return Err(EmitError::new("array sort comparator must return a number"));
-        }
+        // A `number` return compares directly; an erased return (`unknown`,
+        // concrete union, `never`, or a leaked non-scoped type parameter, all of
+        // which render as `SmeltUnknown`) is coerced through `SmeltIntoF64`.
+        let coerce_result = match self.mir.types.get(function_ty.return_ty) {
+            Some(Type::Float) => false,
+            Some(Type::Unknown | Type::Union(_) | Type::Never | Type::TypeParam { .. }) => true,
+            _ => {
+                return Err(EmitError::new("array sort comparator must return a number"));
+            }
+        };
         let left_param_ty = function_ty.params.first().copied().unwrap_or(element_ty);
         let right_param_ty = function_ty.params.get(1).copied().unwrap_or(left_param_ty);
         let left_arg = self.value_at_type_text("left.clone()", element_ty, left_param_ty)?;
@@ -669,8 +691,9 @@ impl FunctionEmitter<'_> {
             Ok(closure_text) => closure_text,
             Err(_) => self.operand_text(comparator)?,
         };
+        let ordering_coercion = if coerce_result { ".smelt_into_f64()" } else { "" };
         Ok(format!(
-            "{{ let mut smelt_comparator = {closure_text}; {list_text}.sort_by(|left, right| {{ let ordering = (smelt_comparator)({left_arg}, {right_arg}); if ordering < 0.0 {{ std::cmp::Ordering::Less }} else if ordering > 0.0 {{ std::cmp::Ordering::Greater }} else {{ std::cmp::Ordering::Equal }} }}); {result_text} }}"
+            "{{ let mut smelt_comparator = {closure_text}; {list_text}.sort_by(|left, right| {{ let ordering = (smelt_comparator)({left_arg}, {right_arg}){ordering_coercion}; if ordering < 0.0 {{ std::cmp::Ordering::Less }} else if ordering > 0.0 {{ std::cmp::Ordering::Greater }} else {{ std::cmp::Ordering::Equal }} }}); {result_text} }}"
         ))
     }
 

--- a/crates/smelt-codegen-rust/src/emitter/map.rs
+++ b/crates/smelt-codegen-rust/src/emitter/map.rs
@@ -234,12 +234,16 @@ impl FunctionEmitter<'_> {
                 "dict set destination must match the receiver dict type",
             ));
         }
-        let (Operand::Copy(Place::Local(local)) | Operand::Move(Place::Local(local))) = dict else {
+        // The receiver may be a plain local or a place rooted in one (a class
+        // field holding a `Map`, e.g. `this.__data.set(k, v)`). Render the
+        // assignable lvalue for the place so the insertion mutates the stored
+        // dict in place rather than a temporary copy.
+        let (Operand::Copy(dict_place) | Operand::Move(dict_place)) = dict else {
             return Err(EmitError::new(
-                "dict set receiver must be a mutable local for now",
+                "dict set receiver must be a place operand",
             ));
         };
-        let dict_text = self.local_mut_value_text(*local)?;
+        let dict_text = self.assignment_place_text(dict_place)?;
         let key_text = self.dict_key_operand_text(key, *key_ty)?;
         let value_text = self.value_at_type(value, *value_ty)?;
         Ok(format!(
@@ -340,14 +344,17 @@ impl FunctionEmitter<'_> {
         if !matches!(self.mir.types.get(dest_ty), Some(Type::Bool)) {
             return Err(EmitError::new("dict remove destination must be bool"));
         }
-        let (Operand::Copy(Place::Local(local)) | Operand::Move(Place::Local(local))) = dict else {
+        // Accept a place-rooted receiver (a class field holding a `Map`, e.g.
+        // `this.__data.delete(k)`) as well as a plain local, rendering the
+        // assignable lvalue so the removal mutates the stored dict in place.
+        let (Operand::Copy(dict_place) | Operand::Move(dict_place)) = dict else {
             return Err(EmitError::new(
-                "dict remove receiver must be a mutable local for now",
+                "dict remove receiver must be a place operand",
             ));
         };
         Ok(format!(
             "{}.remove(&{}).is_some()",
-            self.local_mut_value_text(*local)?,
+            self.assignment_place_text(dict_place)?,
             self.dict_key_operand_text(key, *key_ty)?
         ))
     }

--- a/crates/smelt-codegen-rust/src/emitter/set.rs
+++ b/crates/smelt-codegen-rust/src/emitter/set.rs
@@ -173,14 +173,21 @@ impl FunctionEmitter<'_> {
         item: &Operand,
         dest_ty: TypeId,
     ) -> Result<String, EmitError> {
-        self.validate_set_item_operands(set, item, "set remove")?;
+        let set_ty = self.operand_ty(set)?;
+        let Some(Type::Set(item_ty)) = self.mir.types.get(set_ty) else {
+            return Err(EmitError::new("set remove receiver must be a set"));
+        };
         let (Operand::Copy(Place::Local(local)) | Operand::Move(Place::Local(local))) = set else {
             return Err(EmitError::new(
                 "set remove receiver must be a mutable local for now",
             ));
         };
         let set_text = self.local_mut_value_text(*local)?;
-        let item_text = self.operand_text(item)?;
+        // Coerce the removed item to the set's element type so removing a
+        // concrete value (e.g. a `number`) from an erased `Set<unknown>` erases
+        // the key the same way `set_add_text` erases inserted items; the set
+        // stores `SmeltUnknown`, so the lookup key must be erased to match.
+        let item_text = self.value_at_type(item, *item_ty)?;
         match op {
             smelt_hir::SetRemoveOp::Delete => {
                 if !matches!(self.mir.types.get(dest_ty), Some(Type::Bool)) {

--- a/crates/smelt-codegen-rust/src/tests/part_6_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_6_tests.rs
@@ -417,6 +417,87 @@ console.log(result);
 }
 
 #[test]
+fn emits_switch_with_heterogeneous_arm_successors() {
+    // A switch whose arms have different control-flow tails: one case loops and
+    // then falls through, one case returns early, and the default falls through.
+    // The arm blocks therefore reach the shared continuation only transitively
+    // (through the loop) or not at all (the early return), so no single join
+    // block can be hoisted. This previously aborted emission with "match codegen
+    // requires all non-terminating arms to share one join block"; the emitter now
+    // gives each arm its own control-flow tail.
+    let source = source_for(
+        "function pick(kind: string, n: number): number {
+  let total = 0;
+  switch (kind) {
+    case \"loop\": {
+      while (n > 0) {
+        total += n;
+        n--;
+      }
+      break;
+    }
+    case \"double\":
+      return n * 2;
+    default:
+      total = n;
+  }
+  return total;
+}
+const result = pick(\"loop\", 3);
+console.log(result);
+",
+    );
+
+    assert!(source.contains("match kind.as_str() {"), "{source}");
+    assert!(source.contains("\"loop\" => {"), "{source}");
+    assert!(source.contains("\"double\" => {"), "{source}");
+    // The early-return arm diverges inline.
+    assert!(source.contains("return"), "{source}");
+    // The loop arm's own control-flow tail is emitted inside the arm.
+    assert!(source.contains("while"), "{source}");
+}
+
+#[test]
+fn emits_switch_arm_with_loop_and_conditional_throw() {
+    // Mirrors es-toolkit's `trimEnd`: a `typeof` switch whose first arm branches
+    // (a conditional throw) and then runs a loop before rejoining, while a later
+    // arm is itself a loop. The arm regions converge on the trailing `return`
+    // only transitively, which is exactly the heterogeneous-successor shape that
+    // the join-block emitter must handle without a single hoisted join.
+    let source = source_for(
+        "function trimEnd(str: string, chars: string | string[]): string {
+  let endIndex = str.length;
+  switch (typeof chars) {
+    case \"string\": {
+      if (chars.length !== 1) {
+        throw new Error(\"bad\");
+      }
+      while (endIndex > 0 && str[endIndex - 1] === chars) {
+        endIndex--;
+      }
+      break;
+    }
+    case \"object\": {
+      while (endIndex > 0 && chars.includes(str[endIndex - 1])) {
+        endIndex--;
+      }
+    }
+  }
+  return str.substring(0, endIndex);
+}
+const result = trimEnd(\"aaa\", \"a\");
+console.log(result);
+",
+    );
+
+    // Emission succeeds (no EmitError) and the trailing continuation is emitted
+    // as each arm's own tail rather than one hoisted join.
+    assert!(source.contains("=> {"), "{source}");
+    assert!(source.contains("while"), "{source}");
+    assert!(source.contains("return Err(std::io::Error::new("), "{source}");
+}
+
+#[test]
 fn emits_uncaught_throw_as_result() {
     let source = source_for(
         "function fail(): void {


### PR DESCRIPTION
## Summary

Generalizes the Rust match/switch emitter so `switch` arms with heterogeneous successors emit correctly — the emission-stage abort that gated the whole-crate transpile.

- **Root cause**: `match_join` in `control_flow_match.rs` required every non-diverging arm to *directly* `Goto` one shared join block, so it could hoist the continuation once. That broke whenever an arm body has its own control flow (e.g. `trimEnd`'s `case 'string'` ends in a conditional-throw `Switch`, `case 'object'` ends in `Goto(<loop-header>)` — both reach the real join only transitively).
- **Fix**: hoist a single continuation only when every arm target directly `Goto`s one shared block or diverges (`Return`/`Throw`/`Unreachable`); otherwise return `None` and emit each arm through the existing `emit_block`, which already lowers nested loops/branches/returns and follows each arm's own tail. No MIR changes, no per-file special-casing.

Three further families from the first-abort loop: synthesized optional-comparator wrappers coerce their erased return through the `SmeltIntoF64` boundary adapter; `set_remove` coerces the removed item to the element type (mirrors add); dict-set/remove/clear accept a place-rooted receiver (`this.<field>.set(...)`).

## Milestone

`smelt build` at the es-toolkit root now **emits `dist-smelt` (745 files) — the first whole-crate transpile.** The generated crate does not yet compile clean: 525 errors / 387 warnings, dominated by `E0308` mismatched types (394). `rust-test-report` correctly skipped until it compiles. Grouped diagnostics committed at `blocker-logs/estk-first-transpile-diagnostics.md` — the worklist for the new phase.

## Verification

- `cargo test --workspace --exclude smelt-gui` green (33 targets; codegen 522, incl. 2 new match regression tests); clippy (pedantic, lib) adds no new warnings.
- End-to-end: a string-scrutinee switch variant compiled and ran with JS-correct results.
- Documented out-of-scope: `typeof`-switch scrutinee const-folding; `block_exits_to_loop` lacking a `Terminator::Match` arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_