### PR TITLE
fix(codegen): non-exhaustive optional-truthy match, callback reborrow, tuple .length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ blocker-logs/*.md
 !blocker-logs/estk-match-emitter.md
 # estk-first-transpile-diagnostics.md is the generated-crate diagnostics report for the first whole-crate transpile
 !blocker-logs/estk-first-transpile-diagnostics.md
+# estk-codegen-misc.md documents the E0004/E0596/E0599 generated-Rust codegen fixes
+!blocker-logs/estk-codegen-misc.md
 
 # Generated docs site output
 _site/

--- a/blocker-logs/estk-codegen-misc.md
+++ b/blocker-logs/estk-codegen-misc.md
@@ -1,0 +1,111 @@
+# es-toolkit codegen misc error classes
+
+Fixing three semantically-distinct generated-Rust compile-error classes in the
+es-toolkit whole-crate transpile (`<es-toolkit>/dist-smelt`). Diagnosed with
+`smelt rust-diagnostics`. The sibling agent owns the large `E0308` class, which
+was not touched here.
+
+## Totals
+
+- Whole-crate errors: **548 → 524** (−24).
+- `E0308` stable at 396 (394 at the original baseline; +2 is newly-revealed
+  code unblocked by the `E0004` fix, not a regression introduced here — it is
+  the sibling's lane).
+
+## Fixed (per class, root cause)
+
+### E0004 — non-exhaustive patterns: `16 → 0`
+
+Message: `non-exhaustive patterns: Some(SmeltUnknown::Undefined) not covered`
+(e.g. `ary.rs:15`, `cloneWith.rs`, `curry.rs`, `defaults.rs`, ...).
+
+Root cause: `optional_truthy_text` in `emitter/types.rs` builds the JS-truthiness
+`match` for an `Option<SmeltUnknown>` value. Its falsy arm was
+`Some(SmeltUnknown::Null) => false`, omitting the dedicated `Undefined` variant,
+so the `match` was non-exhaustive. The non-optional coercion path
+(`extract_value_text`, `Some(Type::Bool)`) already grouped `Null | Undefined`;
+the optional path had drifted.
+
+Fix (one site): falsy arm is now
+`Some(SmeltUnknown::Null) | Some(SmeltUnknown::Undefined) => false`.
+Regression test: `optional_unknown_truthiness_covers_undefined`.
+
+### E0596 — cannot borrow behind `&` reference: `12 → 6`
+
+Message: `cannot borrow *mapper as mutable, as it is behind a & reference`
+(`unionBy_1.rs`, `xorBy_1.rs`, `xorWith_1.rs`, `isSubsetWith.rs`).
+
+Root cause: `function_shape_adapter_text` in `emitter/core.rs` builds a wrapper
+closure when a borrowed callback parameter is forwarded to a helper expecting a
+different callback arity. When the source is a function parameter it reborrowed
+it as `&mut *mapper`. Callback parameters are always bound as immutable
+`&dyn Fn` (see `param_type_text`; `parameter_needs_mutable_reference` never
+applies to function types), so a `&mut` reborrow through that shared reference
+cannot compile. The fresh `move` wrapper closure supplies whatever `FnMut` shape
+the callee needs on its own.
+
+Fix (one site): reborrow immutably with `&*mapper`.
+Regression test: `callback_parameter_adapter_reborrows_immutably`.
+
+### E0599 — method not found (tuple `.length`): `20 → 16` (4 fixed)
+
+Message: `no method named len found for tuple (SmeltUnknown, SmeltUnknown)` /
+`(String, SmeltUnknown)` (`dropWhile.rs`, `findIndex.rs`, `dropRightWhile.rs`,
+`findLastIndex.rs`).
+
+Root cause: `len_text` in `emitter/numeric.rs` lowers a `.length` read
+(`Rvalue::Len`). When TypeScript narrows a value to a fixed tuple (e.g. the
+`[key, value]` matches-property shorthand) and reads `.length`, the fallback arm
+emitted `{receiver}.len()`, but Rust tuples have no `.len()` method.
+
+Fix (one arm): a `Type::Tuple(items)` receiver now emits the compile-time arity
+constant (`items.len()`), matching JavaScript's fixed tuple `.length`.
+Regression test: `tuple_length_emits_constant_arity`.
+
+## Deferred (with reason)
+
+- **E0599 remaining (16):**
+  - `SmeltUnknown is not an iterator` (6, `isEqualWith.rs`): entangled with the
+    known `isEqualWith` inlining blocker (see `Smelt.toml`); single complex file,
+    also carries the `E0282` cluster.
+  - `SmeltJsMap<T, String>` method/trait-bound failures (9, `main.rs`): the map
+    key type parameter is unbounded; needs `Hash`/`Eq` bound propagation on the
+    generated map, adjacent to the trait-bound work below.
+  - `into_smelt_unknown` on `Rc<dyn Fn>` (2), `unwrap_or_else` on `()` (1):
+    isolated shape issues.
+- **E0277 (19):** heterogeneous.
+  - `T/f64/SmeltUnion359: Hash + Eq` (uniq, pullAt): JS `Set`/dedup over
+    arbitrary values (incl. `f64`, unbounded generics, unions) cannot key a Rust
+    `HashSet`/`HashMap`. This is a runtime-container redesign (SameValueZero
+    semantics), not a localized emitter fix.
+  - `can't compare Option<SmeltUnknown>/f64` (repeat, range, rangeRight):
+    comparison-operator numeric coercion — deliberately left alone to avoid
+    colliding with the sibling's `E0308` coercion paths.
+  - `SmeltUnknown: AsRef<str>` (escape/unescape): `String.replace` with a
+    function replacer must coerce the closure's `SmeltUnknown` return to a
+    string; localized but non-trivial.
+  - Misc `Debug`/`Deserialize`/`Default`/`Display` derive gaps: one-offs.
+- **E0596 remaining (6):** class-field mutation through `&self`
+  (`self.__data__`, `self.semaphore`) and `Rc`-interior mutation
+  (`after.rs`, `before.rs`) — distinct class/`Rc` root causes.
+- **E0609 (10):** `no field apply on DebouncedFunction<...>` (debounce/throttle)
+  and similar — entangled with returned-object-literal struct modeling
+  (adjacent to `E0308` struct-shape work).
+- **E0425 (7):** closure-capture name bugs — `smelt_capture_self` in async class
+  methods (4), a double `smelt_capture_` prefix in nested-closure assignment
+  targets (2, `debounce_1.rs`), and one `smelt_callback` scope issue. Entangled
+  with async-method self-capture and nested-closure capture aliasing.
+
+## Validation
+
+- `cargo check --workspace`: clean.
+- `cargo clippy -p smelt-codegen-rust --lib -W clippy::pedantic`: no new
+  warnings in touched files (the 2 remaining pedantic warnings are pre-existing
+  in `list_mutation.rs`).
+- `cargo test --workspace --exclude smelt-gui`: all pass, incl. 3 new tests.
+- es-toolkit `dist-smelt` regenerated with the release binary after each change.
+
+## SmeltUnknown
+
+No new `SmeltUnknown` conversions introduced; all three fixes narrow or correct
+existing generated forms.

--- a/crates/smelt-codegen-rust/src/emitter/core.rs
+++ b/crates/smelt-codegen-rust/src/emitter/core.rs
@@ -3515,8 +3515,13 @@ impl<'mir> FunctionEmitter<'mir> {
         let (Operand::Copy(place) | Operand::Move(place)) = operand else {
             return Ok(None);
         };
+        // A borrowed callback parameter is bound as an immutable `&dyn Fn`
+        // (see `param_type_text`), so the adapter reborrows it immutably. A
+        // `&mut *` reborrow through the shared reference would fail to compile
+        // (E0596); the fresh `move` wrapper closure below supplies whatever
+        // `FnMut` shape the target expects on its own.
         let function_text = if self.is_function_parameter_place(place)? {
-            format!("&mut *{}", self.place_text(place)?)
+            format!("&*{}", self.place_text(place)?)
         } else {
             self.place_text(place)?
         };

--- a/crates/smelt-codegen-rust/src/emitter/numeric.rs
+++ b/crates/smelt-codegen-rust/src/emitter/numeric.rs
@@ -80,6 +80,10 @@ impl FunctionEmitter<'_> {
                     "match &{receiver_text} {{ SmeltUnknown::String(value) => value.chars().count(), SmeltUnknown::Array(value) => value.len(), SmeltUnknown::Object(value) => match smelt_get_object_field(value, \"length\") {{ SmeltUnknown::Number(value) => value as usize, _ => 0 }}, _ => 0 }}"
                 )
             }
+            // A fixed-arity tuple (e.g. a `[key, value]` narrowing) has no Rust
+            // `.len()` method; its JavaScript `.length` is the compile-time
+            // arity, so emit that constant rather than a method call.
+            Some(Type::Tuple(items)) => format!("{}", items.len()),
             _ => format!("{receiver_text}.len()"),
         };
         Ok(format!("{len_expr} as {cast}"))

--- a/crates/smelt-codegen-rust/src/emitter/types.rs
+++ b/crates/smelt-codegen-rust/src/emitter/types.rs
@@ -257,7 +257,7 @@ impl FunctionEmitter<'_> {
             )),
             Some(Type::Unknown | Type::Union(_) | Type::TypeParam { .. } | Type::Never) => {
                 Ok(format!(
-                    "match {operand_text}.clone() {{ None => false, Some(SmeltUnknown::Null) => false, Some(SmeltUnknown::Bool(value)) => value, Some(SmeltUnknown::Number(value)) => value != 0.0 && !value.is_nan(), Some(SmeltUnknown::String(value)) => !value.is_empty(), Some(SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_)) => true }}"
+                    "match {operand_text}.clone() {{ None => false, Some(SmeltUnknown::Null) | Some(SmeltUnknown::Undefined) => false, Some(SmeltUnknown::Bool(value)) => value, Some(SmeltUnknown::Number(value)) => value != 0.0 && !value.is_nan(), Some(SmeltUnknown::String(value)) => !value.is_empty(), Some(SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_)) => true }}"
                 ))
             }
             Some(Type::Optional(inner)) => {

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -6557,3 +6557,78 @@ function tag(rows: string[][], suffix: string): string[][] {
         "the member-assignment blocker must be gone\n{source}"
     );
 }
+
+#[test]
+fn optional_unknown_truthiness_covers_undefined() {
+    // An optional `unknown` used in a boolean position coerces through
+    // `optional_truthy_text`. The generated `match` must treat both
+    // `Some(Null)` and `Some(Undefined)` as falsy; omitting the `Undefined`
+    // arm produced a non-exhaustive match (E0004) because `SmeltUnknown` has a
+    // dedicated `Undefined` variant.
+    let source = source_for(
+        r#"
+export function firstTruthy(guard?: unknown): boolean {
+  if (guard) {
+    return true;
+  }
+  return false;
+}
+"#,
+    );
+
+    assert!(
+        source.contains("Some(SmeltUnknown::Null) | Some(SmeltUnknown::Undefined) => false"),
+        "optional-unknown truthiness must cover the Undefined variant\n{source}"
+    );
+}
+
+#[test]
+fn callback_parameter_adapter_reborrows_immutably() {
+    // Forwarding a borrowed callback parameter to a helper that expects a
+    // different callback arity builds a wrapper closure. The wrapper reborrows
+    // the parameter, which is bound as an immutable `&dyn Fn`; a `&mut *`
+    // reborrow through that shared reference fails to compile (E0596), so the
+    // adapter must reborrow immutably with `&*`.
+    let source = source_for(
+        r#"
+function uniqBy<T>(arr: T[], mapper: (item: T, index: number, arr: T[]) => unknown): T[] {
+  return arr;
+}
+export function unionBy<T>(arr1: T[], arr2: T[], mapper: (item: T) => unknown): T[] {
+  return uniqBy([...arr1, ...arr2], mapper);
+}
+"#,
+    );
+
+    assert!(
+        source.contains("&*mapper"),
+        "the callback adapter should reborrow the parameter immutably\n{source}"
+    );
+    assert!(
+        !source.contains("&mut *mapper"),
+        "the callback adapter must not mutably reborrow an immutable `&dyn Fn`\n{source}"
+    );
+}
+
+#[test]
+fn tuple_length_emits_constant_arity() {
+    // A fixed-arity tuple has no Rust `.len()` method (E0599). Its JavaScript
+    // `.length` is a compile-time constant, so the length rvalue must emit the
+    // arity literal rather than a method call on the tuple.
+    let source = source_for(
+        r#"
+export function pairLength(pair: [string, number]): number {
+  return pair.length;
+}
+"#,
+    );
+
+    assert!(
+        source.contains("2 as f64"),
+        "a tuple's `.length` should emit its constant arity\n{source}"
+    );
+    assert!(
+        !source.contains("pair.len()"),
+        "a tuple must not call the list `.len()` method\n{source}"
+    );
+}


### PR DESCRIPTION
## Summary

Three systematic generated-Rust codegen error classes in the es-toolkit whole-crate transpile. Whole-crate errors 548 → 524; E0308 (sibling lane) unchanged, no regressions.

- **E0004 non-exhaustive patterns: 16 → 0.** `optional_truthy_text` built the JS-truthiness `match` for `Option<SmeltUnknown>` with a falsy arm of `Some(SmeltUnknown::Null) => false`, omitting the dedicated `Undefined` variant — now `Some(Null) | Some(Undefined) => false`.
- **E0596 cannot borrow: 12 → 6.** `function_shape_adapter_text` reborrowed a forwarded callback param as `&mut *mapper`, but callback params bind as immutable `&dyn Fn`; changed to `&*` (the fresh `move` wrapper supplies the FnMut shape).
- **E0599 method not found: 20 → 16.** `len_text` fell through to `.len()` for a `.length` read on a fixed-arity tuple; added a `Type::Tuple` arm emitting the arity constant.

3 codegen regression tests added.

## Verification

- `cargo check --workspace` clean; clippy (pedantic, lib) no new warnings; `cargo test --workspace --exclude smelt-gui` green.
- dist-smelt regenerated after each change to confirm counts.
- Deferrals documented in `blocker-logs/estk-codegen-misc.md` (E0277 Hash/Eq container redesign; remaining E0599/E0596/E0609/E0425 deeper root causes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_