### PR TITLE
fix(codegen): es-toolkit E0425 nested-capture and E0631 optional-union .length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ blocker-logs/*.md
 !blocker-logs/estk-codegen-e0308.md
 # remeda-regression.md documents the remeda no-regression investigation (baseline vs current binary)
 !blocker-logs/remeda-regression.md
+# estk-codegen-tail.md documents the non-coercion structural/trait/name tail fixes
+!blocker-logs/estk-codegen-tail.md
 
 # Generated docs site output
 _site/

--- a/blocker-logs/estk-codegen-tail.md
+++ b/blocker-logs/estk-codegen-tail.md
@@ -1,0 +1,129 @@
+# es-toolkit generated-Rust codegen tail (non-coercion structural/trait/name/borrow)
+
+Scope: the non-E0308 structural/trait/name/borrow tail of the whole-crate
+es-toolkit build (`<es-toolkit>/dist-smelt`, 745 files). The dominant E0308
+mismatched-types / coercion / callback / mutable-ref paths are explicitly out of
+scope (owned by a sibling agent for a remeda regression). All measurements use
+`smelt rust-diagnostics` on the release binary; dist-smelt regenerated before
+each measurement.
+
+Totals: **296 -> 292 errors** (warnings unchanged at ~440). No new error classes
+introduced; no non-target class regressed.
+
+## Fixed root causes
+
+### 1. E0425 nested-closure double-capture of a shared cell (7 -> 5)
+
+Sites: `src/debounce_1.rs:117,129` (`cannot find value smelt_capture_`).
+
+Root cause (`emitter/list_query.rs`, closure emission): when a closure nested
+inside an escaping shared-capture closure re-captures the same binding, the
+source binding's rendered name is already `(*smelt_capture_x.borrow_mut())`. Two
+spots mishandled that already-rendered form:
+
+* The nested closure's target-local name was wrapped a second time
+  (`format!("(*smelt_capture_{alias}.borrow_mut())")`), producing the invalid
+  `(*smelt_capture_(*smelt_capture_timeout_id.borrow_mut()).borrow_mut())` which
+  fails to resolve (E0425).
+* The capture-clone prelude bailed out entirely (`return None`) for an
+  already-rendered source name, so the nested closure never cloned the enclosing
+  `Rc` cell — which, once the double-wrap was removed, would have surfaced as a
+  moved-cell borrow error.
+
+Fix: added `shared_capture_cell_name()` to recover the bare `smelt_capture_x`
+cell from an already-rendered access. The target-name path now reuses the
+already-rendered form verbatim; the prelude path clones the recovered `Rc` cell
+(`let smelt_capture_x = smelt_capture_x.clone();`). General across any depth of
+nested shared-capture closures.
+
+Regression test: `nested_closure_reuses_enclosing_shared_capture_cell`
+(part_1_tests.rs) — asserts the double-wrap substring never appears, the nested
+`Rc` clone is emitted, and the assignment targets the single-wrapped cell.
+
+### 2. E0631 optional-union `.length` mapper mismatch (5 -> 3)
+
+Sites: `src/trimEnd_1.rs:33`, `src/trimStart_1.rs:31`
+(`type mismatch in function arguments`).
+
+Root cause (`emitter/numeric.rs`, length emission): for `.length` on an optional
+whose inner type is a *concrete* union / type-parameter / erased class (e.g.
+`string | string[]` -> `Option<SmeltUnion1093>`), the emitter used
+`map_or(0, SmeltUnknown::len)`. `SmeltUnknown::len` has a `&SmeltUnknown`
+receiver, but `.as_ref()` yields `&SmeltUnionN`, so the mapper signature
+mismatches (E0631).
+
+Fix: keep `SmeltUnknown::len` only when the inner type is literally
+`Type::Unknown`. For a concrete union / type-param / erased-class inner, emit a
+mapper that erases the borrowed value (`value.clone().into_smelt_unknown()`) and
+inspects it (string char count / array len / length-bearing object), mirroring
+the existing non-optional dynamic-length case. JS `.length` on such a value is a
+genuinely dynamic property whose meaning depends on the runtime variant, so this
+is a legitimate dynamic boundary (documented inline). The two sites did not
+compile before, so this adds `into_smelt_unknown` erasure only at real
+`.length`-on-dynamic-union boundaries, not to ordinary data flow.
+
+Regression test: `optional_union_length_inspects_dynamically` (part_1_tests.rs).
+
+## Deferred (root cause identified; fix is architectural or out-of-lane)
+
+### E0425 async-`this` capture `smelt_capture_self` (4, `src/main.rs`, class `Semaphore::acquire`)
+
+`emit_method` (core.rs) emits the method body via `emit_block` directly, skipping
+`emit_shared_parameter_preludes`, so `smelt_capture_self` is never bound. But
+merely emitting the prelude does not fix it: the method receiver is `&mut self`,
+and the body's `new Promise(resolve => this.deferredTasks.push(resolve))` pushes
+an **escaping** closure that captures `this` into a field. `&mut self` cannot be
+moved into an `Rc<RefCell<>>` and shared with a closure that outlives the method
+frame — emitting the prelude would only trade E0425 for borrow/lifetime errors.
+The honest fix is interior-mutability class modeling (methods over
+`Rc<RefCell<Self>>` or per-field shared cells so escaping closures can share
+`this` by reference like JS). This is the same architectural root as the
+sibling-tracked E0596 `self.semaphore` / `self.__data__` self-borrow cluster, so
+it wants a coordinated class-model change, not a local patch.
+
+### E0277 JS Set / dedup requires `Eq + Hash` (7: uniq_1, pullAt, pullAt_1)
+
+`new Set(arr)` / `uniq` lowers via `list.iter().cloned().collect::<HashSet<_>>()`
+(`emitter/list.rs::list_to_set_text`), which needs `T: Eq + Hash`. That fails for
+`f64` (not `Eq`/`Hash`), for concrete unions (`SmeltUnion359`), and for unbounded
+generic `T`. Adding `Eq + Hash` bounds is not a general fix: `f64`/float-bearing
+instantiations can never satisfy them, and JS `Set` uses SameValueZero (NaN,
++0/-0, object identity) semantics that a Rust `HashSet` does not model. The
+honest fix is a runtime JS-Set container that dedups by a hashable projection of
+the erased JS value (`into_smelt_unknown` key) while storing the original `T`,
+rewiring `Type::Set` codegen away from `HashSet` crate-wide. That is a
+cross-cutting runtime + emitter change with broad regression surface across all
+Set usage, out of proportion to a scoped tail fix; deferred with this design.
+
+### E0609 / other E0277 / E0282 / E0631 / E0382 (heterogeneous semantic-modeling gaps or sibling-owned)
+
+* E0609 `DebouncedFunction.apply` (5) — modeling `Function.prototype.apply` as a
+  field access on a generated debounced-function struct; needs callable-object
+  modeling.
+* E0609 `SmeltMatch.result` (2, truncate) and `SmeltList.length` (2, unzipWith,
+  inside a mistyped callback) — regex-match modeling and a callback-return
+  type-inference tangle, respectively.
+* E0609 `HttpError.name` (1) — missing generated error field.
+* E0631 `matchesProperty` (3) — closure emitted with param `SmeltUnknown` where
+  the target expects `Option<SmeltUnknown>`; this is closure/callback-argument
+  coercion, in the sibling's lane.
+* E0382 filter/partition/uniqBy/unionBy (4) — a value moved into `Some(x)` twice
+  because a sub-expression is emitted once as a dead temp and once inline;
+  copy-propagation / move-on-last-use, in the sibling's lane.
+* E0277 escape/unescape `AsRef<str>` (2) — compound bug: the module-level
+  `htmlEscapes` const is lowered to `SmeltUnknown::Null` inside the regex
+  replacer, and the replacer closure returns `SmeltUnknown` instead of a
+  `String`; needs module-const capture + replacer-return work.
+* E0282 omit/omitBy/pickBy (7) — `Default::default().into_iter()` emitted with no
+  inferable element type from an unmodeled key-enumeration builtin.
+
+## Validation
+
+* `cargo check --workspace`: clean.
+* `cargo clippy -p smelt-codegen-rust --lib`: no new warnings from this change
+  (2 remaining are pre-existing in call.rs / list_mutation.rs).
+* `cargo test --workspace --exclude smelt-gui`: all green (includes the two new
+  regression tests).
+* Diagnostics: 296 -> 292; E0425 7 -> 5, E0631 5 -> 3; no class regressed.
+
+Baseline: `blocker-logs/estk-baseline.md`; after: `blocker-logs/estk-after2.md`.

--- a/crates/smelt-codegen-rust/src/emitter/list_query.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list_query.rs
@@ -992,7 +992,14 @@ impl FunctionEmitter<'_> {
                     {
                         emitter.borrowed_callback_names.insert(alias_name.clone());
                     }
-                    let capture_name = if self.closure_capture_needs_shared_access(closure, capture)
+                    let capture_name = if alias_name.starts_with("(*smelt_capture_") {
+                        // The source binding is itself captured from an
+                        // enclosing shared closure and already renders as
+                        // `(*smelt_capture_x.borrow_mut())`. Reuse that rendered
+                        // form; wrapping it again would emit the invalid
+                        // `(*smelt_capture_(*smelt_capture_x.borrow_mut())...)`.
+                        alias_name
+                    } else if self.closure_capture_needs_shared_access(closure, capture)
                         || self.local_uses_shared_capture_storage(capture.source_local)
                     {
                         format!("(*smelt_capture_{alias_name}.borrow_mut())")
@@ -1170,8 +1177,17 @@ impl FunctionEmitter<'_> {
                     .get(&capture.source_local)
                     .cloned()
                     .unwrap_or_else(|| source_name.clone());
-                if source_name.starts_with("(*smelt_capture_") {
-                    return None;
+                if let Some(cell_ref) = shared_capture_cell_name(&source_name) {
+                    // The source binding already renders through shared storage
+                    // (it was captured from an enclosing shared closure). The
+                    // nested closure body references the same `smelt_capture_x`
+                    // cell directly, so clone the `Rc` into this closure's
+                    // header; otherwise `move` steals the enclosing closure's
+                    // cell and later uses of it fail to borrow-check.
+                    let cell = cell_ref.to_owned();
+                    return cloned_captures
+                        .insert(cell.clone())
+                        .then(|| format!("let {cell} = {cell}.clone();"));
                 }
                 cloned_captures.insert(name.clone()).then(|| {
                     if self.closure_capture_needs_shared_access(closure, capture)
@@ -1694,6 +1710,20 @@ impl FunctionEmitter<'_> {
     }
 
     // Sorted-list helpers continue in `list_ordering.rs`.
+}
+
+/// Extracts the bare shared-capture cell identifier from an already-rendered
+/// shared-capture access.
+///
+/// Shared captures render as `(*smelt_capture_x.borrow())` (read) or
+/// `(*smelt_capture_x.borrow_mut())` (write); this returns the underlying cell
+/// binding `smelt_capture_x` so a nested closure can clone the `Rc` cell
+/// itself. Returns `None` when `text` is not a shared-capture access.
+fn shared_capture_cell_name(text: &str) -> Option<&str> {
+    let inner = text.strip_prefix("(*")?;
+    inner
+        .strip_suffix(".borrow_mut())")
+        .or_else(|| inner.strip_suffix(".borrow())"))
 }
 
 /// Rewrites emitted closure text so shared captures use their `RefCell` storage.

--- a/crates/smelt-codegen-rust/src/emitter/numeric.rs
+++ b/crates/smelt-codegen-rust/src/emitter/numeric.rs
@@ -68,12 +68,27 @@ impl FunctionEmitter<'_> {
                 format!("{receiver_text}.as_ref().map_or(0, Vec::len)")
             }
             Some(Type::Optional(inner))
-                if matches!(
-                    self.mir.types.get(*inner),
-                    Some(Type::Unknown | Type::Union(_) | Type::TypeParam { .. })
-                ) || self.is_erased_class_type(*inner) =>
+                if matches!(self.mir.types.get(*inner), Some(Type::Unknown)) =>
             {
                 format!("{receiver_text}.as_ref().map_or(0, SmeltUnknown::len)")
+            }
+            Some(Type::Optional(inner))
+                if matches!(
+                    self.mir.types.get(*inner),
+                    Some(Type::Union(_) | Type::TypeParam { .. })
+                ) || self.is_erased_class_type(*inner) =>
+            {
+                // The unwrapped value is a concrete union, type parameter, or
+                // erased class rather than a `SmeltUnknown`, so `SmeltUnknown::len`
+                // cannot be used as the `map_or` mapper (its `&SmeltUnknown`
+                // receiver mismatches the concrete borrow, E0631). JS `.length`
+                // is a dynamic property whose meaning depends on the runtime
+                // variant (string char count vs array length vs a length-bearing
+                // object), so erase the borrowed value at this genuinely dynamic
+                // boundary and inspect it, mirroring the non-optional case below.
+                format!(
+                    "{receiver_text}.as_ref().map_or(0, |value| match value.clone().into_smelt_unknown() {{ SmeltUnknown::String(value) => value.chars().count(), SmeltUnknown::Array(value) => value.len(), SmeltUnknown::Object(value) => match smelt_get_object_field(&value, \"length\") {{ SmeltUnknown::Number(value) => value as usize, _ => 0 }}, _ => 0 }})"
+                )
             }
             Some(Type::Unknown | Type::Union(_) | Type::TypeParam { .. }) => {
                 format!(

--- a/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
@@ -1108,3 +1108,95 @@ export function rebindCb(cb: (value: unknown) => unknown): unknown {
         "rebound callback parameter stayed a borrowed &dyn Fn: {source}"
     );
 }
+
+/// A closure nested inside another shared-capture closure must reuse the
+/// already-rendered `smelt_capture_x` cell instead of wrapping it again.
+///
+/// When an escaping outer closure mutates a captured binding, the binding lives
+/// in an `Rc<RefCell<T>>` cell and every use renders as
+/// `(*smelt_capture_x.borrow_mut())`. A closure nested inside that outer closure
+/// re-captures the same binding; its source name is therefore already the
+/// rendered `(*smelt_capture_x.borrow_mut())` form. The nested closure must (a)
+/// reuse that rendered form verbatim rather than emitting the invalid double
+/// wrap `(*smelt_capture_(*smelt_capture_x.borrow_mut())...)` (which fails to
+/// parse / resolve, E0425), and (b) still clone the `Rc` cell into its own
+/// header so the outer closure can keep using the cell after the nested closure
+/// moves its clone.
+#[test]
+fn nested_closure_reuses_enclosing_shared_capture_cell() {
+    let source = source_for(
+        r"
+export function makeTimers(onEnd: () => void): { schedule: () => void; cancel: () => void } {
+  let timeoutId: number | null = null;
+  const schedule = () => {
+    const cb = () => {
+      timeoutId = null;
+      onEnd();
+    };
+    timeoutId = 1;
+  };
+  const cancel = () => {
+    timeoutId = null;
+  };
+  return { schedule, cancel };
+}
+",
+    );
+
+    // The invalid double-wrapped capture name must never appear.
+    assert!(
+        !source.contains("smelt_capture_(*smelt_capture_"),
+        "nested capture re-wrapped an already-rendered shared cell: {source}"
+    );
+    // The nested closure clones the enclosing `Rc` cell into its own header
+    // (the source `timeoutId` is emitted as the snake-cased `timeout_id`).
+    assert!(
+        source.contains("let smelt_capture_timeout_id = smelt_capture_timeout_id.clone();"),
+        "nested closure did not clone the enclosing shared capture cell: {source}"
+    );
+    // The nested assignment writes straight through the single-wrapped cell.
+    assert!(
+        source.contains("(*smelt_capture_timeout_id.borrow_mut()) = None"),
+        "nested assignment did not target the single-wrapped shared cell: {source}"
+    );
+}
+
+/// `.length` on an optional whose unwrapped value is a concrete union must
+/// inspect the value dynamically rather than call `SmeltUnknown::len`.
+///
+/// A `string | string[]` parameter lowers to a concrete union, so an optional
+/// of it is `Option<SmeltUnionN>`, not `Option<SmeltUnknown>`. Emitting
+/// `map_or(0, SmeltUnknown::len)` there gives the mapper a `&SmeltUnknown`
+/// receiver that mismatches the concrete `&SmeltUnionN` borrow (E0631). JS
+/// `.length` is a dynamic property whose meaning depends on the runtime variant,
+/// so the mapper must erase the borrowed value and inspect it.
+#[test]
+fn optional_union_length_inspects_dynamically() {
+    let source = source_for(
+        r"
+export function measure(str: string, chars?: string | string[]): number {
+  if (chars === undefined) {
+    return str.length;
+  }
+  switch (typeof chars) {
+    case 'string': {
+      return chars.length;
+    }
+    default: {
+      return 0;
+    }
+  }
+}
+",
+    );
+
+    assert!(
+        !source.contains("map_or(0, SmeltUnknown::len)"),
+        "optional union `.length` used the SmeltUnknown::len mapper: {source}"
+    );
+    assert!(
+        source.contains("into_smelt_unknown()")
+            && source.contains("SmeltUnknown::String(value) => value.chars().count()"),
+        "optional union `.length` did not inspect the erased value: {source}"
+    );
+}


### PR DESCRIPTION
## Summary

Two systematic generated-Rust codegen fixes in the es-toolkit whole-crate build tail (non-coercion classes). Errors 296 → 292; no class regressed.

- **E0425 nested-closure double-capture (7 → 5).** A closure nested inside an escaping shared-capture closure re-wrapped an already-rendered `(*smelt_capture_x.borrow_mut())` name a second time (producing unresolvable `smelt_capture_(*smelt_capture_x...)`) and skipped cloning the enclosing `Rc`. Added `shared_capture_cell_name()` to recover the bare cell; target-name path reuses the rendered form, prelude clones the `Rc`.
- **E0631 optional-union `.length` (5 → 3).** `.length` on `Option<concrete-union>` used the `SmeltUnknown::len` mapper whose `&SmeltUnknown` receiver mismatched the `&SmeltUnionN` borrow. Now keeps `SmeltUnknown::len` only for literal `Type::Unknown`; concrete union/type-param/erased-class inners erase at the `.length` boundary (documented dynamic boundary).

2 regression tests added.

## Verification

- `cargo test --workspace --exclude smelt-gui` green (33 targets) rebased on main; clippy (pedantic, lib) no new warnings.

## Deferred (documented, with identified root cause + design in `blocker-logs/estk-codegen-tail.md`)

Notably these converge on two architectural items worth their own design pass: **`Rc<RefCell<Self>>` class modeling** (async-`this` E0425 + self-borrow E0596), and a **runtime JS-Set container** keyed by an erased projection (E0277 uniq/dedup, SameValueZero semantics). Plus heterogeneous singletons (E0382 dup-subexpr/move-on-last-use, E0609 debounced-fn/regex-match fields, E0282 untyped defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_