### PR TITLE
feat(codegen-rust): JS-semantics SmeltJsSet container + tail E0277 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,8 @@ blocker-logs/*.md
 # reference-classes-diagnostics.md is the es-toolkit rust-diagnostics report after the feature
 !blocker-logs/reference-classes-diagnostics.md
 !blocker-logs/estk-e0308-round2.md
+# estk-jsset-and-tail.md documents the SmeltJsSet container and tail E0277/E0631 fixes
+!blocker-logs/estk-jsset-and-tail.md
 
 # Generated docs site output
 _site/

--- a/blocker-logs/estk-jsset-and-tail.md
+++ b/blocker-logs/estk-jsset-and-tail.md
@@ -1,0 +1,160 @@
+# es-toolkit: SmeltJsSet container + tail E0277/E0631 fixes
+
+Whole-crate es-toolkit probe (pinned `e008a2818cd8`), diagnostics via
+`smelt rust-diagnostics` with the release binary built from this branch.
+
+## Headline totals (es-toolkit whole-crate)
+
+| metric | before | after | delta |
+| --- | --- | --- | --- |
+| total errors | 296 | 256 | **-40** |
+
+Per-class movement (this lane and its cascades):
+
+| code | before | after | delta | owner/notes |
+| --- | --- | --- | --- | --- |
+| E0277 | 19 | 9 | **-10** | my lane |
+| E0631 | 5 | 3 | -2 | my lane |
+| E0308 | 187 | 168 | -19 | sibling's class; reduced as a cascade of the Set representation fix |
+| E0425 | 7 | 1 | -6 | cascade of the Set fix |
+| E0596 | 6 | 4 | -2 | cascade |
+| E0599 | 16 | 16 | 0 | deferred (see below) |
+| E0609 | 10 | 10 | 0 | deferred |
+| E0282 | 7 | 7 | 0 | untouched |
+| E0382 | 4 | 4 | 0 | untouched |
+
+Direct in-lane elimination (E0277 + E0631) is **-12**; the Set representation
+fix additionally drove -19 E0308 / -6 E0425 / -2 E0596 cascades, for **-40
+combined**. The remaining in-lane clusters (E0599 generic `SmeltJsMap`,
+E0609 struct-field gaps) are entangled with other subsystems and are deferred
+with reasons below rather than converted into sibling-lane errors.
+
+## SmeltJsSet design
+
+`Type::Set` previously emitted `HashSet<T>` when the element type was judged
+"key-safe" and a bare `Vec<T>` otherwise. Both were wrong:
+
+- `HashSet<T>` demands `T: Eq + Hash`, impossible for `f64`, generated unions
+  (`SmeltUnion*`), and generic type parameters — the source of the headline
+  E0277s in `uniq`, `pullAt`, and the `[...new Set(list)]` dedup pattern. It is
+  also semantically wrong: JS `Set` uses SameValueZero (objects/functions by
+  reference identity, `NaN` equal to itself), not Rust structural `Eq`.
+- The `Vec<T>` fallback compiled but did not dedup and used `==` membership
+  (so `NaN` was never found, `+0`/`-0` diverged, objects compared structurally).
+- `list_to_set_text` ignored the split entirely and always emitted
+  `collect::<HashSet<_>>()`, so `[...new Set(list)]` broke for every non-safe
+  element type.
+
+New container `SmeltJsSet<T>` (runtime prelude, in the `needs_unknown` block
+next to `SmeltJsMap`): an insertion-ordered `Vec<T>` whose membership projects
+each element through its `IntoSmeltUnknown` erasure and compares the resulting
+runtime values with `SmeltJsKeyEq::same_js_key` — the same erased-key projection
+`SmeltJsMap` uses for keys. This makes one uniform, JS-correct container work
+for **every** element type that can be erased (no per-element `Eq + Hash`
+bound), including generics whose only bound is `IntoSmeltUnknown`. It exposes
+`new/len/is_empty/contains/insert/remove/iter/extend`, the set-algebra methods
+(`union`/`intersection`/`difference`/`symmetric_difference` returning `&T`
+iterators, `is_disjoint`/`is_subset`/`is_superset`), `Default`, `From<[T;N]>`,
+`FromIterator`, `IntoIterator` (by value and by ref), `PartialEq`, and
+`IntoSmeltUnknown` (erases to a sorted `SmeltUnknown::Array`, matching the old
+`HashSet`/`Vec` erasure).
+
+Split rule (`type_is_hash_set_key_safe`, now the single source of truth):
+`HashSet` only for value-equality primitives (`bool`/`i64`/`String`, and
+`Optional`/`Union` recursively of those) where `Eq + Hash` both exists and
+matches SameValueZero. Everything else routes through `SmeltJsSet`.
+
+Wiring: `type_text`, `default_value`, the `Rvalue::Set` literal, and
+`list_to_set_text` all emit the chosen container; `set_add_text` dropped its
+`f64` `push` special-case (both containers now dedup on `insert`); membership
+(`set_contains_text`) routes uniformly through `.contains`, which is
+SameValueZero on `SmeltJsSet` and value-equality on `HashSet` (this fixed the
+`NaN` membership bug).
+
+Gating: a `Set` whose element type is not a value-equality primitive is emitted
+as `SmeltJsSet`, whose erased projection needs the `SmeltUnknown` carrier and
+its traits. `needs_unknown_type` therefore returns true when such a set exists
+(module-level `module_hash_set_key_safe` mirror of the emitter predicate), so
+the carrier is always present when `SmeltJsSet` is used. Consequence: a small
+crate that mixes a non-primitive `Set` with a string-keyed `Map` now backs that
+`Map` with identity-preserving `SmeltRecord` (functionally a superset). Tests
+`part_5_tests::emits_map_and_set_projection_methods` and the
+`set_collection_emission` snapshot were updated accordingly; the snapshot input
+switched to `Set<string>` (stays `HashSet`, small prelude) and dedicated
+`SmeltJsSet` coverage moved to `emits_smelt_js_set_container`.
+
+### Verification
+
+`emits_smelt_js_set_container` (codegen unit test) asserts `SmeltJsSet<f64>`,
+`SmeltJsSet::from([...])`, and `collect::<SmeltJsSet<_>>()`. End-to-end fixture
+(built + run with the branch binary) asserts:
+
+- dedup on construction (`new Set([1,1,2,3,2]).size === 3`)
+- insertion-order iteration (`1,2,3`)
+- `NaN` membership (`new Set([NaN]).has(NaN) === true`)
+- `+0`/`-0` SameValueZero (`new Set([0]).has(-0) === true`)
+- object identity membership (`has(a) === true`, `has({...a}) === false`)
+- `add` dedup + `delete`
+
+All observed outputs correct.
+
+## Other E0277 fixes
+
+- **escape/unescape `SmeltUnknown: AsRef<str>` (-2).** The regex
+  `replace_all` `Replacer` closure must yield a `String`, but a callback typed
+  to return `unknown` (here an erased `Record` lookup) yields `SmeltUnknown`.
+  `regex_replace_callback_text` now coerces the callback result to `String`
+  (JS ToString via erase + String-extract) when the callback's declared return
+  type is not already `String`; the `String` fast path is unchanged. Regression
+  test `coerces_non_string_regex_replace_callback_result`.
+- **`SmeltJsMap` `Debug` (-2).** `SmeltJsMap` derived only `Clone`; struct
+  fields holding a `SmeltJsMap` failed `#[derive(Debug)]`. Added `Debug` to the
+  derive.
+
+## Deferrals (with reasons)
+
+- **E0599 generic `SmeltJsMap<T, String>` cluster (`CustomCache` in main.rs,
+  ~5 + related E0277).** The class is generic over `T` but its field is
+  `SmeltJsMap<T, String>` while its constructor builds
+  `SmeltJsMap<SmeltUnknown, String>` and its methods take `SmeltUnknown` keys.
+  The `same_js_key`/`SmeltFromUnknown` method-bound failures are a symptom of a
+  frontend key-erasure bug (`T` should be erased to `SmeltUnknown` in the field
+  type). Relaxing `SmeltJsMap` method bounds to the erased projection would
+  make the methods resolve but expose the underlying `T`-vs-`SmeltUnknown`
+  mismatch as E0308 (sibling's lane) — net-neutral and risks the just-landed
+  reference-class `SmeltJsMap` usage. Left for the frontend erasure fix.
+- **E0609 (10): debounce/throttle `.apply`, `unzipWith .length` on
+  `SmeltList`, `truncate .result` on `SmeltMatch`, `HttpError.name`.** Each is a
+  distinct struct/field-modeling or reference-class field-access gap
+  (`self.name` should be `self.0.borrow().name` on a reference class;
+  `.length` on a list value was not lowered to a `Len` op inside a callback;
+  `.result`/`.apply` are missing fields on `SmeltMatch`/`DebouncedFunction`).
+  None is a clean isolated emitter change; they touch reference-class field
+  access and frontend lowering. Deferred.
+- **E0282 (7) / E0382 (4) / remaining E0631 (3).** Untyped `Default::default()`,
+  moved-value, and closure-arg mismatches; time-bounded, left for a follow-up.
+
+## Validation
+
+- `cargo test -p smelt-codegen-rust --lib`: 544 passed.
+- `cargo check --workspace`: clean.
+- `cargo test -p smelt-transpiler` incl. `end_to_end_examples_match_expected_outputs`:
+  passing. `examples/.../27_optional_chains/expected.rs` (embeds the full runtime
+  prelude as golden output) regenerated to include the `SmeltJsSet` block and the
+  `SmeltJsMap` `Debug` derive; MIR and stdout unchanged.
+- `cargo clippy -p smelt-codegen-rust --lib -W clippy::pedantic`: no new warnings
+  from this change (the two shadow warnings I introduced were renamed away).
+- Full `cargo test --workspace --exclude smelt-gui` could not complete in this
+  environment due to ENOSPC on the shared disk; the codegen + transpiler suites
+  above (the surfaces this change touches) all pass.
+
+### Remeda no-regression spot-check
+
+Remeda pinned `3c80f28bb394edbf89f1fc9978571dec8ed20edc` with
+`.github/compat/remeda/Smelt.toml`: `smelt build` succeeded and
+`cargo check` on the generated crate reported **0 errors** (warnings only).
+`SmeltJsSet` is exercised in 12 generated files (`unique`, `uniqueBy`,
+`sample`, `isDeepEqual`, `isShallowEqual`, ...), confirming the Set rewiring
+compiles cleanly on remeda's Set usage. Generated `cargo test` (baseline
+1789/1789) was not run — the shared disk was too low to build the full remeda
+test crate; `cargo check` at 0 errors establishes no compile regression.

--- a/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
@@ -212,10 +212,10 @@ impl FunctionEmitter<'_> {
                 Ok(format!("vec![{items_text}]"))
             }
             Rvalue::Set(items) => {
-                let set_uses_vec = matches!(self.mir.types.get(dest_ty), Some(Type::Set(item)) if !self.type_is_hash_set_key_safe(*item));
+                let set_uses_js_set = matches!(self.mir.types.get(dest_ty), Some(Type::Set(item)) if !self.type_is_hash_set_key_safe(*item));
                 if items.is_empty() {
-                    return Ok(if set_uses_vec {
-                        "Vec::new()".to_owned()
+                    return Ok(if set_uses_js_set {
+                        "SmeltJsSet::new()".to_owned()
                     } else {
                         "::std::collections::HashSet::new()".to_owned()
                     });
@@ -235,8 +235,8 @@ impl FunctionEmitter<'_> {
                     })
                     .collect::<Result<Vec<_>, _>>()?
                     .join(", ");
-                if set_uses_vec {
-                    return Ok(format!("vec![{items_text}]"));
+                if set_uses_js_set {
+                    return Ok(format!("SmeltJsSet::from([{items_text}])"));
                 }
                 Ok(format!("::std::collections::HashSet::from([{items_text}])"))
             }

--- a/crates/smelt-codegen-rust/src/emitter/core.rs
+++ b/crates/smelt-codegen-rust/src/emitter/core.rs
@@ -1722,7 +1722,7 @@ impl<'mir> FunctionEmitter<'mir> {
     }
 
     /// Find the ID of an already interned type.
-    fn existing_type_id(&self, ty: Type) -> Option<TypeId> {
+    pub(super) fn existing_type_id(&self, ty: Type) -> Option<TypeId> {
         self.mir
             .types
             .all()
@@ -4077,28 +4077,27 @@ impl<'mir> FunctionEmitter<'mir> {
         }
     }
 
-    /// Returns whether a Rust `HashSet` can store values of this type.
+    /// Returns whether a Rust `HashSet` is a correct backing for a set of this
+    /// element type.
+    ///
+    /// `HashSet` is used only for value-equality primitives (`bool`, `i64`,
+    /// `String`) where Rust `Eq + Hash` both exists and matches JavaScript
+    /// SameValueZero. Every other element type — `f64` (no `Eq`), generated
+    /// unions and generic type parameters (no `Eq + Hash` bound), and
+    /// object-like values whose JS equality is by reference, not structure —
+    /// routes through the `SmeltJsSet` runtime container instead, which
+    /// projects each element through its `IntoSmeltUnknown` erasure for
+    /// SameValueZero membership and preserves insertion order.
     pub(super) fn type_is_hash_set_key_safe(&self, ty: TypeId) -> bool {
         match self.mir.types.get(ty) {
-            Some(Type::Float | Type::Dict(_, _) | Type::Set(_) | Type::Function(_)) => false,
-            Some(Type::List(_) | Type::Tuple(_)) => false,
+            Some(Type::Bool | Type::Int | Type::String) => true,
             Some(Type::Optional(inner) | Type::Future(inner)) => {
                 self.type_is_hash_set_key_safe(*inner)
             }
             Some(Type::Union(items)) => items
                 .iter()
                 .all(|item| self.type_is_hash_set_key_safe(*item)),
-            Some(
-                Type::Bool
-                | Type::Int
-                | Type::String
-                | Type::Unknown
-                | Type::Never
-                | Type::TypeParam { .. }
-                | Type::None
-                | Type::Class { .. },
-            )
-            | None => true,
+            _ => false,
         }
     }
 

--- a/crates/smelt-codegen-rust/src/emitter/list.rs
+++ b/crates/smelt-codegen-rust/src/emitter/list.rs
@@ -91,14 +91,25 @@ impl FunctionEmitter<'_> {
         let Some(Type::List(item_ty)) = self.mir.types.get(list_ty) else {
             return Err(EmitError::new("list-to-set source must be a list"));
         };
-        if !matches!(self.mir.types.get(dest_ty), Some(Type::Set(dest_item)) if dest_item == item_ty)
+        let set_item_ty = *item_ty;
+        if !matches!(self.mir.types.get(dest_ty), Some(Type::Set(dest_item)) if *dest_item == set_item_ty)
         {
             return Err(EmitError::new(
                 "list-to-set destination must be set of the list item type",
             ));
         }
+        // Collect into whichever container the destination `Set` uses: a plain
+        // `HashSet` for value-equality primitives, or `SmeltJsSet` (SameValueZero
+        // membership, insertion order) for `f64`, unions, generics, and
+        // object-like elements. Both dedup on `FromIterator`, matching JS
+        // `new Set(array)`.
+        let container = if self.type_is_hash_set_key_safe(set_item_ty) {
+            "::std::collections::HashSet<_>"
+        } else {
+            "SmeltJsSet<_>"
+        };
         Ok(format!(
-            "{}.iter().cloned().collect::<::std::collections::HashSet<_>>()",
+            "{}.iter().cloned().collect::<{container}>()",
             self.operand_text(list)?
         ))
     }

--- a/crates/smelt-codegen-rust/src/emitter/set.rs
+++ b/crates/smelt-codegen-rust/src/emitter/set.rs
@@ -26,16 +26,10 @@ impl FunctionEmitter<'_> {
             let inner = *opt_inner;
             let set_text = self.operand_text(set)?;
             let body = if inner == item_ty {
-                if self.mir.types.get(item_ty) == Some(&Type::Float) {
-                    format!("{set_text}.iter().any(|value| *value == smelt_needle)")
-                } else if matches!(
-                    self.mir.types.get(item_ty),
-                    Some(Type::Unknown | Type::TypeParam { .. } | Type::Union(_))
-                ) {
-                    format!("{set_text}.iter().any(|value| value.same_js_key(&smelt_needle))")
-                } else {
-                    format!("{set_text}.contains(&smelt_needle)")
-                }
+                // The narrowed needle has the element type, so the container's
+                // own `contains` applies the correct membership (SameValueZero
+                // through `SmeltJsSet`, value equality for the `HashSet` backing).
+                format!("{set_text}.contains(&smelt_needle)")
             } else if matches!(
                 self.mir.types.get(inner),
                 Some(Type::Unknown | Type::TypeParam { .. })
@@ -53,28 +47,14 @@ impl FunctionEmitter<'_> {
             ));
         }
         let item_text = self.value_at_type(item, item_ty)?;
-        if self.mir.types.get(item_ty) == Some(&Type::Float) {
-            return Ok(format!(
-                "{}.iter().any(|value| *value == {item_text})",
-                self.operand_text(set)?
-            ));
-        }
-        // A `Set<unknown>` follows JS `Set.prototype.has` reference semantics
-        // (SameValueZero): objects/arrays match by identity, not structural
-        // contents — exactly like the data-first `Array.prototype.includes` path
-        // (`same_js_key`). `HashSet::contains` would instead use SmeltUnknown's
-        // structural `Eq`, so e.g. `new Set([obj]).has({...obj})` would wrongly
-        // report `true`. Primitive elements still compare by value because
-        // `same_js_key` falls through to `==` for them.
-        if matches!(
-            self.mir.types.get(item_ty),
-            Some(Type::Unknown | Type::TypeParam { .. } | Type::Union(_))
-        ) {
-            return Ok(format!(
-                "{}.iter().any(|value| value.same_js_key(&{item_text}))",
-                self.operand_text(set)?
-            ));
-        }
+        // Membership goes through the container's own `contains`. For the
+        // `HashSet` backing (`bool`/`i64`/`String`) that is value equality, which
+        // matches JS SameValueZero for those primitives. For every other element
+        // type the set is a `SmeltJsSet`, whose `contains` applies SameValueZero
+        // via each element's erased runtime value: `NaN` equals `NaN`, `+0`
+        // equals `-0`, and objects/functions match by reference identity — the
+        // JS `Set.prototype.has` semantics — rather than `HashSet`'s structural
+        // `Eq`.
         Ok(format!(
             "{}.contains(&{})",
             self.operand_text(set)?,
@@ -136,21 +116,10 @@ impl FunctionEmitter<'_> {
             return Err(EmitError::new("set add receiver must be a set"));
         };
         let item_text = self.value_at_type(item, *item_ty)?;
-        if self.mir.types.get(*item_ty) == Some(&Type::Float) {
-            return if matches!(self.mir.types.get(dest_ty), Some(Type::None)) {
-                Ok(format!(
-                    "{{ if !{set_text}.iter().any(|value| *value == {item_text}) {{ {set_text}.push({item_text}); }} () }}"
-                ))
-            } else if dest_ty == set_ty {
-                Ok(format!(
-                    "{{ if !{set_text}.iter().any(|value| *value == {item_text}) {{ {set_text}.push({item_text}); }} {set_text}.clone() }}"
-                ))
-            } else {
-                Err(EmitError::new(
-                    "set add destination must be None or the receiver set type",
-                ))
-            };
-        }
+        // Both backings (`HashSet` for value-equality primitives, `SmeltJsSet`
+        // for everything else) expose an `insert` that dedups, so a single
+        // insertion shape works for every element type — including `f64`, whose
+        // `SmeltJsSet` insert applies SameValueZero (`NaN` equals `NaN`).
         if matches!(self.mir.types.get(dest_ty), Some(Type::None)) {
             Ok(format!("{{ {set_text}.insert({item_text}); () }}"))
         } else if dest_ty == set_ty {

--- a/crates/smelt-codegen-rust/src/emitter/strings.rs
+++ b/crates/smelt-codegen-rust/src/emitter/strings.rs
@@ -348,9 +348,18 @@ impl FunctionEmitter<'_> {
         let callback_text = self
             .closure_operand_text(callback)
             .or_else(|_| self.operand_text(callback))?;
-        let replacement = format!(
-            "|caps: &regex::Captures<'_>| ({callback_text})(caps.get(0).expect(\"regex match missing\").as_str().to_string())"
+        // JavaScript `String.prototype.replace(re, fn)` converts the callback's
+        // return value to a string (ToString) before substituting it. The Rust
+        // `regex` `Replacer` closure must therefore yield a `String`
+        // (`AsRef<str>`); a callback typed to return `unknown`/a union/etc.
+        // yields `SmeltUnknown`, which is not `AsRef<str>`. When the callback
+        // does not already return `String`, route its result through the erase +
+        // String-extract boundary so the closure hands `replace` a real string.
+        let call_expr = format!(
+            "({callback_text})(caps.get(0).expect(\"regex match missing\").as_str().to_string())"
         );
+        let replacement_expr = self.regex_replacement_as_string(call_expr, callback)?;
+        let replacement = format!("|caps: &regex::Captures<'_>| {replacement_expr}");
         Ok(match op {
             smelt_hir::StringReplaceOp::First => {
                 format!("{regex_text}.replace(&{haystack_text}, {replacement}).to_string()")
@@ -359,6 +368,31 @@ impl FunctionEmitter<'_> {
                 format!("{regex_text}.replace_all(&{haystack_text}, {replacement}).to_string()")
             }
         })
+    }
+
+    /// Coerce a regex replacement callback's return value to a Rust `String`.
+    ///
+    /// JS ToStrings the callback result before substituting. A callback already
+    /// returning `String` needs no wrapping (it is a valid `Replacer`); any
+    /// other return type is erased to `SmeltUnknown` and extracted back as a
+    /// `String`, applying the same ToString rules JS uses.
+    fn regex_replacement_as_string(
+        &self,
+        call_expr: String,
+        callback: &Operand,
+    ) -> Result<String, EmitError> {
+        let return_ty = match self.mir.types.get(self.operand_ty(callback)?) {
+            Some(Type::Function(function)) => function.return_ty,
+            _ => return Ok(call_expr),
+        };
+        if matches!(self.mir.types.get(return_ty), Some(Type::String)) {
+            return Ok(call_expr);
+        }
+        let Some(string_ty) = self.existing_type_id(Type::String) else {
+            return Ok(call_expr);
+        };
+        let erased = self.erase_value_text(&call_expr, return_ty)?;
+        self.extract_value_text(&erased, string_ty)
     }
 
     /// Converts regex replacement with an uppercase first-match callback.

--- a/crates/smelt-codegen-rust/src/emitter/types.rs
+++ b/crates/smelt-codegen-rust/src/emitter/types.rs
@@ -760,7 +760,7 @@ impl FunctionEmitter<'_> {
                 self.type_text_with_scoped_type_params(*item, false, scoped_type_params)?
             )),
             Type::Set(item) => Ok(format!(
-                "Vec<{}>",
+                "SmeltJsSet<{}>",
                 self.type_text_with_scoped_type_params(*item, false, scoped_type_params)?
             )),
             Type::Dict(key, value) if self.dict_uses_smelt_record(*key) => Ok(format!(
@@ -881,7 +881,7 @@ impl FunctionEmitter<'_> {
             Type::Set(item) if self.type_is_hash_set_key_safe(*item) => {
                 Ok("::std::collections::HashSet::new()".to_owned())
             }
-            Type::Set(_) => Ok("Vec::new()".to_owned()),
+            Type::Set(_) => Ok("SmeltJsSet::new()".to_owned()),
             Type::Dict(key, _) if self.dict_uses_smelt_record(*key) => {
                 Ok("SmeltRecord::new()".to_owned())
             }

--- a/crates/smelt-codegen-rust/src/lib.rs
+++ b/crates/smelt-codegen-rust/src/lib.rs
@@ -740,7 +740,7 @@ fn emit_source_with_free_function_router(
         writer.line("    fn eq(&self, other: &::std::collections::HashMap<K, V>) -> bool { self.values.borrow().eq(other) }");
         writer.line("}");
         writer.blank_line();
-        writer.line("#[derive(Clone)]");
+        writer.line("#[derive(Clone, Debug)]");
         writer.line("pub struct SmeltJsMap<K, V> {");
         writer.line("    entries: Vec<(K, V)>,");
         writer.line("}");
@@ -787,6 +787,55 @@ fn emit_source_with_free_function_router(
         writer.line("    fn eq(&self, other: &Self) -> bool { self.entries.len() == other.entries.len() && self.entries.iter().all(|(key, value)| other.get(key).is_some_and(|other_value| other_value == *value)) }");
         writer.line("}");
         writer.line("impl<K: SmeltJsKeyEq + Clone, V: Eq + Clone> Eq for SmeltJsMap<K, V> {}");
+        writer.blank_line();
+        // JS `Set` container with SameValueZero membership and insertion order.
+        //
+        // Rust `HashSet` demands `Eq + Hash`, which is impossible for `f64`,
+        // generated unions, and generic type parameters, and is the wrong
+        // equality besides: JavaScript `Set` compares objects/functions by
+        // reference identity and treats `NaN` as equal to itself. Rather than
+        // require a per-element `Eq + Hash`, membership projects each element
+        // through its `IntoSmeltUnknown` erasure and compares the resulting
+        // runtime values with `SmeltJsKeyEq::same_js_key` (the same erased-key
+        // projection `SmeltJsMap` uses for keys). This makes one uniform,
+        // JS-correct container work for every element type that can be erased.
+        // Elements are stored in a `Vec` so iteration preserves insertion order
+        // like a real JS `Set`.
+        writer.line("#[derive(Clone, Debug)]");
+        writer.line("pub struct SmeltJsSet<T> {");
+        writer.line("    entries: Vec<T>,");
+        writer.line("}");
+        writer.blank_line();
+        writer.line("impl<T> SmeltJsSet<T> {");
+        writer.line("    fn new() -> Self { Self { entries: Vec::new() } }");
+        writer.line("}");
+        writer.blank_line();
+        writer.line("impl<T: Clone + IntoSmeltUnknown> SmeltJsSet<T> {");
+        writer.line("    /// SameValueZero equality via each element's erased runtime value.");
+        writer.line("    fn same_member(left: &T, right: &T) -> bool { left.clone().into_smelt_unknown().same_js_key(&right.clone().into_smelt_unknown()) }");
+        writer.line("    fn len(&self) -> usize { self.entries.len() }");
+        writer.line("    fn is_empty(&self) -> bool { self.entries.is_empty() }");
+        writer.line("    fn contains(&self, value: &T) -> bool { self.entries.iter().any(|existing| Self::same_member(existing, value)) }");
+        writer.line("    fn insert(&mut self, value: T) -> bool { if self.contains(&value) { false } else { self.entries.push(value); true } }");
+        writer.line("    fn remove(&mut self, value: &T) -> bool { if let Some(index) = self.entries.iter().position(|existing| Self::same_member(existing, value)) { self.entries.remove(index); true } else { false } }");
+        writer.line("    fn iter(&self) -> ::std::slice::Iter<'_, T> { self.entries.iter() }");
+        writer.line("    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) { for value in iter { self.insert(value); } }");
+        writer.line("    fn is_disjoint(&self, other: &Self) -> bool { self.entries.iter().all(|value| !other.contains(value)) }");
+        writer.line("    fn is_subset(&self, other: &Self) -> bool { self.entries.iter().all(|value| other.contains(value)) }");
+        writer.line("    fn is_superset(&self, other: &Self) -> bool { other.is_subset(self) }");
+        writer.line("    fn union<'smelt_set>(&'smelt_set self, other: &'smelt_set Self) -> ::std::vec::IntoIter<&'smelt_set T> { let mut out: Vec<&T> = self.entries.iter().collect(); for value in other.entries.iter() { if !out.iter().any(|existing| Self::same_member(existing, value)) { out.push(value); } } out.into_iter() }");
+        writer.line("    fn intersection<'smelt_set>(&'smelt_set self, other: &'smelt_set Self) -> ::std::vec::IntoIter<&'smelt_set T> { self.entries.iter().filter(|value| other.contains(value)).collect::<Vec<_>>().into_iter() }");
+        writer.line("    fn difference<'smelt_set>(&'smelt_set self, other: &'smelt_set Self) -> ::std::vec::IntoIter<&'smelt_set T> { self.entries.iter().filter(|value| !other.contains(value)).collect::<Vec<_>>().into_iter() }");
+        writer.line("    fn symmetric_difference<'smelt_set>(&'smelt_set self, other: &'smelt_set Self) -> ::std::vec::IntoIter<&'smelt_set T> { let mut out: Vec<&T> = self.entries.iter().filter(|value| !other.contains(value)).collect(); for value in other.entries.iter() { if !self.contains(value) { out.push(value); } } out.into_iter() }");
+        writer.line("}");
+        writer.blank_line();
+        writer.line("impl<T> Default for SmeltJsSet<T> { fn default() -> Self { Self::new() } }");
+        writer.line("impl<T: Clone + IntoSmeltUnknown, const N: usize> From<[T; N]> for SmeltJsSet<T> { fn from(values: [T; N]) -> Self { values.into_iter().collect() } }");
+        writer.line("impl<T: Clone + IntoSmeltUnknown> ::std::iter::FromIterator<T> for SmeltJsSet<T> { fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self { let mut set = Self::new(); set.extend(iter); set } }");
+        writer.line("impl<T> IntoIterator for SmeltJsSet<T> { type Item = T; type IntoIter = ::std::vec::IntoIter<T>; fn into_iter(self) -> Self::IntoIter { self.entries.into_iter() } }");
+        writer.line("impl<'smelt_set, T> IntoIterator for &'smelt_set SmeltJsSet<T> { type Item = &'smelt_set T; type IntoIter = ::std::slice::Iter<'smelt_set, T>; fn into_iter(self) -> Self::IntoIter { self.entries.iter() } }");
+        writer.line("impl<T: Clone + IntoSmeltUnknown> PartialEq for SmeltJsSet<T> { fn eq(&self, other: &Self) -> bool { self.entries.len() == other.entries.len() && self.entries.iter().all(|value| other.contains(value)) } }");
+        writer.line("impl<T: IntoSmeltUnknown> IntoSmeltUnknown for SmeltJsSet<T> { fn into_smelt_unknown(self) -> SmeltUnknown { let mut values = self.entries.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) } }");
         writer.blank_line();
         writer.line("pub trait SmeltJsKeyEq {");
         writer.line("    fn same_js_key(&self, other: &Self) -> bool;");

--- a/crates/smelt-codegen-rust/src/stdlib.rs
+++ b/crates/smelt-codegen-rust/src/stdlib.rs
@@ -255,6 +255,23 @@ fn rvalue_needs_reqwest(rvalue: &Rvalue) -> bool {
     )
 }
 
+/// Returns whether a set element type backs a plain Rust `HashSet`.
+///
+/// Mirrors [`FunctionEmitter::type_is_hash_set_key_safe`] at module scope so
+/// the `needs_unknown` gate can decide whether a `Set` forces the `SmeltJsSet`
+/// runtime (and therefore the unknown carrier) on. Only value-equality
+/// primitives back a `HashSet`; everything else uses `SmeltJsSet`.
+fn module_hash_set_key_safe(mir: &Mir, ty: smelt_hir::TypeId) -> bool {
+    match mir.types.get(ty) {
+        Some(Type::Bool | Type::Int | Type::String) => true,
+        Some(Type::Optional(inner) | Type::Future(inner)) => {
+            module_hash_set_key_safe(mir, *inner)
+        }
+        Some(Type::Union(items)) => items.iter().all(|item| module_hash_set_key_safe(mir, *item)),
+        _ => false,
+    }
+}
+
 /// Returns true when generated Rust needs the opaque `unknown` carrier type.
 #[must_use]
 pub(crate) fn needs_unknown_type(mir: &Mir) -> bool {
@@ -289,6 +306,16 @@ pub(crate) fn needs_unknown_type(mir: &Mir) -> bool {
             .all()
             .iter()
             .any(|ty| matches!(ty, Type::Unknown | Type::Never | Type::Union(_)))
+        // A `Set` whose element type is not a value-equality primitive is
+        // emitted as the `SmeltJsSet` runtime container, whose SameValueZero
+        // membership projects elements through `IntoSmeltUnknown`. That carrier
+        // and its traits live in the `needs_unknown` prelude block, so such a
+        // set forces the unknown runtime on.
+        || mir
+            .types
+            .all()
+            .iter()
+            .any(|ty| matches!(ty, Type::Set(item) if !module_hash_set_key_safe(mir, *item)))
         || mir.functions.iter().any(|function| {
             function.blocks.iter().any(|block| {
                 block.statements.iter().any(|statement| {

--- a/crates/smelt-codegen-rust/src/tests/part_4_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_4_tests.rs
@@ -643,14 +643,38 @@ const fromSource = new Set(source);
 ",
     );
 
-    assert!(source.contains("let values: Vec<f64>"), "{source}");
+    // A `Set<number>` (f64 elements) has no correct `HashSet` backing, so it
+    // uses the `SmeltJsSet` runtime container; a `Set<string>` keeps `HashSet`.
+    assert!(source.contains("let values: SmeltJsSet<f64>"), "{source}");
     assert!(
         source.contains("let empty: ::std::collections::HashSet<String>"),
         "{source}"
     );
-    assert!(source.contains(".iter().any(|value| *value == 2.0);"));
+    assert!(source.contains(".contains(&2.0)"));
     assert!(source.contains("::std::collections::HashSet::new();"));
-    assert!(source.contains(".iter().cloned().collect::<::std::collections::HashSet<_>>()"));
+    assert!(source.contains(".iter().cloned().collect::<SmeltJsSet<_>>()"));
+}
+
+#[test]
+fn emits_smelt_js_set_container() {
+    // A `Set<number>` cannot use `HashSet` (`f64` has no `Eq`/`Hash`), so it
+    // routes through the `SmeltJsSet` runtime container with SameValueZero
+    // membership and insertion order. The dedup-from-array shape (`[...new
+    // Set(array)]`) collects into `SmeltJsSet` too.
+    let source = source_for(
+        r"
+const values: Set<number> = new Set([1, 2, 3]);
+const source: number[] = [1, 2, 3];
+const deduped = new Set(source);
+",
+    );
+
+    assert!(source.contains("SmeltJsSet<f64>"), "{source}");
+    assert!(source.contains("SmeltJsSet::from(["), "{source}");
+    assert!(
+        source.contains(".iter().cloned().collect::<SmeltJsSet<_>>()"),
+        "{source}"
+    );
 }
 
 #[test]
@@ -664,7 +688,7 @@ const hits = values.filter((value) => selected.has(value));
     );
 
     assert!(
-        source.contains(".iter().any(|value| *value == closure_arg_0.clone())"),
+        source.contains(".contains(&closure_arg_0.clone())"),
         "{source}"
     );
 }

--- a/crates/smelt-codegen-rust/src/tests/part_5_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_5_tests.rs
@@ -329,21 +329,24 @@ const mapEntries = mapping.entries();
 ",
     );
 
+    // A non-primitive `Set` (here `Set<number>`) turns on the unknown carrier,
+    // so the string-keyed `Map` is backed by identity-preserving `SmeltRecord`
+    // and its projections use the record key/value filters.
     assert!(
         source.contains(
-            ".keys().filter(|key| !key.starts_with(\"__smelt_symbol:\")).cloned().collect::<Vec<_>>()"
+            ".keys().filter(|key| !key.starts_with(\"__smelt_symbol:\") && smelt_is_for_in_record_key(&"
         ),
         "{source}"
     );
     assert!(
         source.contains(
-            ".iter().filter(|(key, _)| !key.starts_with(\"__smelt_symbol:\") && key != \"__smelt_class\").map(|(_, value)| value.clone()).collect::<Vec<_>>()"
+            ".iter().filter(|(key, _)| !key.starts_with(\"__smelt_symbol:\") && key != \"__smelt_class\").map(|(_, value)| value).collect::<Vec<_>>()"
         ),
         "{source}"
     );
     assert!(
         source.contains(
-            ".iter().filter(|(key, _)| !key.starts_with(\"__smelt_symbol:\") && key != \"__smelt_class\").map(|(key, value)| (key.clone(), value.clone())).collect::<Vec<_>>()"
+            ".iter().filter(|(key, _)| !key.starts_with(\"__smelt_symbol:\") && key != \"__smelt_class\").collect::<Vec<_>>()"
         ),
         "{source}"
     );

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -1500,6 +1500,38 @@ export function localize(enNumber: number): string {
         !source.contains("|caps: &regex::Captures<'_>| (_smelt_tmp_"),
         "{source}"
     );
+    // A callback that already returns `String` is a valid `Replacer`, so it is
+    // handed to `replace_all` without a ToString wrapper.
+    assert!(
+        !source.contains("|caps: &regex::Captures<'_>| match ("),
+        "{source}"
+    );
+}
+
+#[test]
+fn coerces_non_string_regex_replace_callback_result() {
+    // The callback's result flows through an erased record lookup, so it is
+    // typed `unknown` (`SmeltUnknown`), which is not `AsRef<str>`. The regex
+    // replacement must ToString it so the `Replacer` closure yields a `String`.
+    let source = source_for(
+        r#"
+const htmlEscapes: Record<string, string> = { "&": "&amp;" };
+export function escape(str: string): string {
+  return str.replace(/[&<>"']/g, (match) => htmlEscapes[match]);
+}
+"#,
+    );
+
+    assert!(source.contains("replace_all"), "{source}");
+    // The replacement is wrapped in the SmeltUnknown -> String ToString match.
+    assert!(
+        source.contains("|caps: &regex::Captures<'_>| match ("),
+        "{source}"
+    );
+    assert!(
+        source.contains("SmeltUnknown::Undefined => \"undefined\".to_owned()"),
+        "{source}"
+    );
 }
 
 #[test]

--- a/crates/smelt-codegen-rust/src/tests/snapshot_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/snapshot_tests.rs
@@ -180,16 +180,22 @@ function lookup(): number | undefined {
 }
 
 /// Snapshot set construction and membership emission.
+///
+/// Uses a `Set<string>`, whose value-equality element type keeps the plain
+/// `HashSet` backing (and therefore a small prelude). Non-primitive sets route
+/// through the `SmeltJsSet` runtime container, which pulls in the unknown
+/// carrier; that path is covered by the dedicated `emits_smelt_js_set_container`
+/// unit test and the end-to-end fixture instead of this whole-module snapshot.
 #[test]
 fn set_collection_emission() {
     assert_emitted_source_snapshot(
         "set_collection_emission",
-        r"
+        r#"
 function contains(): boolean {
-  const values = new Set<number>([1, 2]);
-  return values.has(2);
+  const values = new Set<string>(["a", "b"]);
+  return values.has("b");
 }
-",
+"#,
         None,
     );
 }

--- a/crates/smelt-codegen-rust/src/tests/snapshots/smelt_codegen_rust__tests__snapshot_tests__set_collection_emission.snap
+++ b/crates/smelt-codegen-rust/src/tests/snapshots/smelt_codegen_rust__tests__snapshot_tests__set_collection_emission.snap
@@ -7,9 +7,9 @@ expression: emitted
 
 // @smelt:prelude-end — generated program below
 fn contains() -> bool {
-    let _smelt_tmp_1: Vec<f64> = vec![1.0, 2.0];
-    let values: Vec<f64> = _smelt_tmp_1;
-    let _smelt_tmp_2: bool = values.iter().any(|value| *value == 2.0);
+    let _smelt_tmp_1: ::std::collections::HashSet<String> = ::std::collections::HashSet::from(["a".to_owned(), "b".to_owned()]);
+    let values: ::std::collections::HashSet<String> = _smelt_tmp_1;
+    let _smelt_tmp_2: bool = values.contains(&"b".to_owned());
     return _smelt_tmp_2;
 }
 

--- a/examples/typescript/end-to-end/27_optional_chains/expected.rs
+++ b/examples/typescript/end-to-end/27_optional_chains/expected.rs
@@ -165,7 +165,7 @@ impl<K, V> PartialEq<::std::collections::HashMap<K, V>> for SmeltRecord<K, V> wh
     fn eq(&self, other: &::std::collections::HashMap<K, V>) -> bool { self.values.borrow().eq(other) }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SmeltJsMap<K, V> {
     entries: Vec<(K, V)>,
 }
@@ -208,6 +208,42 @@ impl<K: SmeltJsKeyEq + Clone, V: PartialEq + Clone> PartialEq for SmeltJsMap<K, 
     fn eq(&self, other: &Self) -> bool { self.entries.len() == other.entries.len() && self.entries.iter().all(|(key, value)| other.get(key).is_some_and(|other_value| other_value == *value)) }
 }
 impl<K: SmeltJsKeyEq + Clone, V: Eq + Clone> Eq for SmeltJsMap<K, V> {}
+
+#[derive(Clone, Debug)]
+pub struct SmeltJsSet<T> {
+    entries: Vec<T>,
+}
+
+impl<T> SmeltJsSet<T> {
+    fn new() -> Self { Self { entries: Vec::new() } }
+}
+
+impl<T: Clone + IntoSmeltUnknown> SmeltJsSet<T> {
+    /// SameValueZero equality via each element's erased runtime value.
+    fn same_member(left: &T, right: &T) -> bool { left.clone().into_smelt_unknown().same_js_key(&right.clone().into_smelt_unknown()) }
+    fn len(&self) -> usize { self.entries.len() }
+    fn is_empty(&self) -> bool { self.entries.is_empty() }
+    fn contains(&self, value: &T) -> bool { self.entries.iter().any(|existing| Self::same_member(existing, value)) }
+    fn insert(&mut self, value: T) -> bool { if self.contains(&value) { false } else { self.entries.push(value); true } }
+    fn remove(&mut self, value: &T) -> bool { if let Some(index) = self.entries.iter().position(|existing| Self::same_member(existing, value)) { self.entries.remove(index); true } else { false } }
+    fn iter(&self) -> ::std::slice::Iter<'_, T> { self.entries.iter() }
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) { for value in iter { self.insert(value); } }
+    fn is_disjoint(&self, other: &Self) -> bool { self.entries.iter().all(|value| !other.contains(value)) }
+    fn is_subset(&self, other: &Self) -> bool { self.entries.iter().all(|value| other.contains(value)) }
+    fn is_superset(&self, other: &Self) -> bool { other.is_subset(self) }
+    fn union<'smelt_set>(&'smelt_set self, other: &'smelt_set Self) -> ::std::vec::IntoIter<&'smelt_set T> { let mut out: Vec<&T> = self.entries.iter().collect(); for value in other.entries.iter() { if !out.iter().any(|existing| Self::same_member(existing, value)) { out.push(value); } } out.into_iter() }
+    fn intersection<'smelt_set>(&'smelt_set self, other: &'smelt_set Self) -> ::std::vec::IntoIter<&'smelt_set T> { self.entries.iter().filter(|value| other.contains(value)).collect::<Vec<_>>().into_iter() }
+    fn difference<'smelt_set>(&'smelt_set self, other: &'smelt_set Self) -> ::std::vec::IntoIter<&'smelt_set T> { self.entries.iter().filter(|value| !other.contains(value)).collect::<Vec<_>>().into_iter() }
+    fn symmetric_difference<'smelt_set>(&'smelt_set self, other: &'smelt_set Self) -> ::std::vec::IntoIter<&'smelt_set T> { let mut out: Vec<&T> = self.entries.iter().filter(|value| !other.contains(value)).collect(); for value in other.entries.iter() { if !self.contains(value) { out.push(value); } } out.into_iter() }
+}
+
+impl<T> Default for SmeltJsSet<T> { fn default() -> Self { Self::new() } }
+impl<T: Clone + IntoSmeltUnknown, const N: usize> From<[T; N]> for SmeltJsSet<T> { fn from(values: [T; N]) -> Self { values.into_iter().collect() } }
+impl<T: Clone + IntoSmeltUnknown> ::std::iter::FromIterator<T> for SmeltJsSet<T> { fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self { let mut set = Self::new(); set.extend(iter); set } }
+impl<T> IntoIterator for SmeltJsSet<T> { type Item = T; type IntoIter = ::std::vec::IntoIter<T>; fn into_iter(self) -> Self::IntoIter { self.entries.into_iter() } }
+impl<'smelt_set, T> IntoIterator for &'smelt_set SmeltJsSet<T> { type Item = &'smelt_set T; type IntoIter = ::std::slice::Iter<'smelt_set, T>; fn into_iter(self) -> Self::IntoIter { self.entries.iter() } }
+impl<T: Clone + IntoSmeltUnknown> PartialEq for SmeltJsSet<T> { fn eq(&self, other: &Self) -> bool { self.entries.len() == other.entries.len() && self.entries.iter().all(|value| other.contains(value)) } }
+impl<T: IntoSmeltUnknown> IntoSmeltUnknown for SmeltJsSet<T> { fn into_smelt_unknown(self) -> SmeltUnknown { let mut values = self.entries.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) } }
 
 pub trait SmeltJsKeyEq {
     fn same_js_key(&self, other: &Self) -> bool;


### PR DESCRIPTION
## Summary

Adds the last speced architectural container: **`SmeltJsSet<T>`** — insertion-ordered, SameValueZero membership via the same erased-key projection `SmeltJsMap` uses (`IntoSmeltUnknown` + `same_js_key`), so one uniform container serves every erasable element type with **no `Eq+Hash` bound**. `HashSet` remains only for value-equality primitives (bool/i64/String). Wired through `type_text`, `default_value`, Set literals, `list_to_set_text` (fixing `[...new Set(list)]`, which previously emitted `HashSet` unconditionally), `set_add`, and membership (fixing NaN membership).

Verified e2e: dedup, insertion order, `NaN` membership, `+0/-0` SameValueZero, object identity (`has(a)` true / `has({...a})` false), add/delete.

Tail fixes: escape/unescape replacer `ToString`-coercion (E0277 −2), `SmeltJsMap` Debug derive (−2). Per its baseline: E0277 19→9, E0631 −2, plus Set-representation cascades across E0308/E0425/E0596 — **−40 total on its baseline**.

## Verification

- Rebased over #148; combined suites green (33 targets, full `cargo test --workspace --exclude smelt-gui` run by the orchestrator after the agent hit disk limits).
- Remeda (pinned): `smelt build` + generated `cargo check` 0 errors with SmeltJsSet exercised in 12 files; the generated 1789-test run happens in the post-merge combined verification.
- Deferrals documented in `blocker-logs/estk-jsset-and-tail.md` (CustomCache generic-key frontend bug, E0609 field-modeling gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_