### PR TITLE
fix(ci): find compat metadata at any artifact depth; fail loudly on none

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -125,9 +125,16 @@ jobs:
 
       - name: Update COMPAT.md
         run: |
-          shopt -s nullglob
-          for metadata in target/compat-results/compat-*/metadata.env; do
+          # download-artifact extracts a single matched artifact directly into
+          # the target path (no per-artifact subdirectory), so locate every
+          # metadata.env at any depth instead of assuming one fixed layout, and
+          # fail loudly when none are found rather than silently committing
+          # nothing (the nullglob loop previously skipped zero matches).
+          found=0
+          while IFS= read -r metadata; do
+            found=1
             result_dir="$(dirname "$metadata")"
+            echo "Updating COMPAT.md from $metadata"
             . "$metadata"
             python3 scripts/update_compat.py \
               --compat COMPAT.md \
@@ -137,7 +144,12 @@ jobs:
               --run-url "$run_url" \
               --report "$result_dir/report.md" \
               --status "$status"
-          done
+          done < <(find target/compat-results -name metadata.env | sort)
+          if [ "$found" -eq 0 ]; then
+            echo "::error::no compat metadata.env found under target/compat-results"
+            find target/compat-results -maxdepth 3 -print || true
+            exit 1
+          fi
 
       - name: Commit compatibility updates
         uses: stefanzweifel/git-auto-commit-action@v7


### PR DESCRIPTION
## Summary

The manual Compatibility run you linked ([29080010937](https://github.com/Bombatomica64/smelt/actions/runs/29080010937)) went green end to end but committed nothing: `download-artifact@v7` extracted the single pattern-matched `compat-remeda` artifact **directly into** `target/compat-results/` (no per-artifact subdirectory — the job log confirms the extraction path), so the fixed-depth glob `compat-*/metadata.env` matched nothing and `nullglob` silently skipped the entire update loop — `update_compat.py` never ran, and the auto-commit saw "Working tree clean."

Fix: locate `metadata.env` with `find` at any depth (tolerant of both single-artifact and multi-artifact extraction layouts), log each processed file, and **fail the job with a listing when zero results are found** so a future layout drift can never silently no-op again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB

---
_Generated by [Claude Code](https://claude.ai/code/session_019KXZZbV1JFnVgwwMrMfkqB)_