### PR TITLE
fix(frontend-ts): lower empty statements as no-ops

### DIFF
--- a/blocker-logs/date-fns-full-baseline.md
+++ b/blocker-logs/date-fns-full-baseline.md
@@ -1,0 +1,49 @@
+# date-fns full-corpus baseline (2026-07-10)
+
+## Reproduction
+
+- Source: `date-fns/date-fns` at `09ece22eaea4ffab1a8fa396beeeb6a451dcfbf4`
+  (the latest commit available at the documented May 12, 2026 probe date).
+- Corpus: `src/**/*.ts` and `src/**/*.tsx`, excluding declaration files through
+  Smelt's normal manifest discovery.
+- Build manifest: local ignored probe manifest with `src/index.ts` as the entry
+  and the full source tree as test globs.
+- Command: `smelt rust-test-report --build-manifest <manifest>
+  --cargo-manifest <dist>/Cargo.toml --full --diagnostics --suppress-warnings`.
+
+## First blocker
+
+The report command stops during source lowering before a generated Cargo
+manifest exists:
+
+```text
+src/_lib/defaultOptions/index.ts
+module-level mutable binding initializer must be a literal for now
+```
+
+The source shape is a module-level mutable, concretely typed empty options
+record:
+
+```ts
+let defaultOptions: DefaultOptions = {};
+```
+
+An isolated type probe shows `DefaultOptions` lowers to
+`Dict<String, Unknown>`; the value is not a TypeScript `unknown` boundary.
+Current mutable-global HIR and MIR items carry only a primitive `Literal` /
+`Constant` initializer, and Rust codegen only emits `Cell` for numeric/bool
+values or `RefCell<String>` for strings. The newer module-global lift therefore
+rejects this previously reached date-fns surface before Rust emission.
+
+## Required general fix
+
+Extend mutable globals with an explicit typed default/empty-collection
+initializer through HIR and MIR, and emit non-copy concrete global types through
+`RefCell<T>`. This must preserve the concrete dictionary shape; routing the
+record through `SmeltUnknown` would violate the repository's static-shape
+boundary rules. No `SmeltUnknown` usage was added during this investigation.
+
+After that frontend gate is cleared, rerun `smelt rust-test-report` to obtain the
+generated Rust diagnostic families. The older May baseline expected the next
+tail to include optional-callable representation and Date-setter numeric casts,
+but those assumptions must be remeasured on current main.

--- a/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
+++ b/crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs
@@ -576,6 +576,7 @@ impl ModuleBuilder<'_> {
     ) -> Result<(), SmeltError> {
         let previous_statement_block = self.current_statement_block.replace(block);
         let result = match statement {
+            Statement::EmptyStatement(_) => Ok(()),
             Statement::VariableDeclaration(decl) => self.variable_declaration(decl, body, block),
             Statement::FunctionDeclaration(function) => {
                 self.local_function_declaration(function, body, block)

--- a/crates/smelt-frontend-ts/src/tests/part02_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part02_tests.rs
@@ -740,6 +740,32 @@ const value = values[index++];
 }
 
 #[test]
+fn lowers_empty_statements_as_noops() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function answer(): number {
+  ;
+  {
+    ;
+  }
+  return 42;
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = function_body(&ctx, function_item(&ctx, module, 0)?)?;
+    ensure!(
+        matches!(body.stmts.as_slice(), [Stmt::Return(Some(_))]),
+        "expected empty statements to emit nothing before the return: {:?}",
+        body.stmts,
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn keeps_postfix_update_expression_side_effect_inside_loop_body() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/docs/superpowers/plans/2026-07-10-empty-statements.md
+++ b/docs/superpowers/plans/2026-07-10-empty-statements.md
@@ -1,0 +1,33 @@
+# TypeScript Empty Statements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Treat TypeScript empty statements as semantic no-ops during block lowering.
+
+**Architecture:** Add an explicit `Statement::EmptyStatement` arm to the central block statement dispatcher. Protect it with a frontend test containing empty statements at function and nested-block scope.
+
+**Tech Stack:** Rust, Oxc TypeScript AST, Smelt HIR frontend tests.
+
+## Global Constraints
+
+- Do not add source-library-specific lowering.
+- Do not introduce or expand `SmeltUnknown`.
+- Run `cargo check`, `cargo clippy`, and full `cargo test` before commit.
+
+---
+
+### Task 1: Ignore empty statements
+
+**Files:**
+- Modify: `crates/smelt-frontend-ts/src/lowering/decls/types_iface.rs`
+- Test: `crates/smelt-frontend-ts/src/tests/part02_tests.rs`
+
+**Interfaces:**
+- Consumes: Oxc `Statement::EmptyStatement` nodes.
+- Produces: successful HIR lowering with no emitted statement for those nodes.
+
+- [ ] **Step 1:** Add a failing frontend test with `;` in a function and nested block.
+- [ ] **Step 2:** Run `cargo test -p smelt-frontend-ts lowers_empty_statements_as_noops -- --nocapture` and confirm the unsupported-statement diagnostic.
+- [ ] **Step 3:** Add `Statement::EmptyStatement(_) => Ok(())` to `statement_in_block`.
+- [ ] **Step 4:** Re-run the focused test and the radash probe scan.
+- [ ] **Step 5:** Run repository gates, review the diff, and commit as `fix(frontend-ts): lower empty statements as no-ops`.


### PR DESCRIPTION
## What changed

- Lower TypeScript `EmptyStatement` nodes as semantic no-ops in block bodies.
- Add a regression proving empty statements emit no HIR statements and do not stop later returns.
- Record the current full date-fns probe boundary at concrete object-valued mutable globals.

## Why

The daily radash probe contained a standalone empty-statement blocker even though JavaScript/TypeScript `;` has no runtime effect. The date-fns rerun also needed a readable handoff artifact because it now stops before generated Rust emission.

## Validation

- `cargo check` passes.
- `cargo clippy` completes with three pre-existing warnings.
- Focused frontend test passes.
- Radash blocker scan drops files with blockers from 9 to 8 and no longer reports `EmptyStatement`.
- Full `cargo test` passes 547/547 codegen tests and 7/7 Python parity tests, then the existing TypeScript decorator parity fixture fails to compile under the locally installed `tsc 6.0.3`; the fixture declares TypeScript 5.9.3.