### PR TITLE
Fix JavaScript parseFloat operand coercion

### DIFF
--- a/blocker-logs/radash-array-is-array-value.md
+++ b/blocker-logs/radash-array-is-array-value.md
@@ -1,0 +1,24 @@
+# Radash first-class Array.isArray investigation
+
+Date: 2026-07-11
+
+## Failure family
+
+Radash exports `Array.isArray` through a constant and calls it through the package namespace:
+
+```ts
+export const isArray = Array.isArray
+_.isArray(value)
+```
+
+Direct `Array.isArray(value)` calls were modeled, but the bare static member did not become a function value. The exported constant therefore reached namespace call lowering as a non-callable item.
+
+## Root cause and fix
+
+Static builtin member lowering lacked a first-class `Array.isArray` adapter. The frontend now synthesizes a one-argument closure returning `UnknownIs(Array)`, matching the existing direct-call runtime probe.
+
+The closure parameter is intentionally `Unknown`: `Array.isArray` accepts and inspects arbitrary JavaScript runtime values. This is a genuine dynamic boundary, not type-level helper plumbing. No new `SmeltUnknown` conversion or runtime variant was added.
+
+## Probe result
+
+The `namespace member isArray is not callable` blocker is gone from `typed.test.ts`. The scan now reaches the next independent unsupported construct in that file, a sequence expression, so the aggregate remains 11 blocker classes across 7 files while advancing the file's failure frontier.

--- a/blocker-logs/radash-callback-trim.md
+++ b/blocker-logs/radash-callback-trim.md
@@ -1,0 +1,17 @@
+# Radash callback trim investigation
+
+Date: 2026-07-11
+
+## Failure family
+
+Radash filters path segments with `path.split(...).filter(x => !!x.trim())`. Direct `String.prototype.trim` calls were supported, but the callback-body method table rejected the identical operation.
+
+## Root cause and fix
+
+Callback closure conversion maintained a separate set of supported method expressions and omitted zero-argument `trim`. It now emits `StringTrim(Both)` for string receivers and applies the existing explicit string coercion for erased or scoped-generic callback receivers.
+
+No new `SmeltUnknown` type, conversion, or boundary was introduced.
+
+## Probe result
+
+The radash-only probe moves from 11 to 10 blocker classes. The callback-method diagnostic is absent, while the scan continues to report the two independent remaining failures in `src/object.ts`.

--- a/blocker-logs/radash-imported-async-reduce.md
+++ b/blocker-logs/radash-imported-async-reduce.md
@@ -1,0 +1,32 @@
+# Bug-library transpile probes (TypeScript + Python)
+
+_Generated 2026-07-11 by the `library-probes` workflow (`scripts/probe_libraries.py`)._
+
+Each library is checked out at a pinned ref (see `.github/compat/libraries.json`), given its `.github/compat/<name>/Smelt.toml`, and run through `smelt build`. If a crate is emitted, its generated `cargo test` suite is run and counted. Otherwise every source/test file is scanned individually with `smelt dump-hir` to enumerate the full set of distinct blocker classes (single-file mode cannot resolve cross-file imports, so bare `unresolved name/identifier` errors are excluded as scan noise).
+
+**Error categories:**
+- **missing-stdlib** — a JS/Python builtin Smelt does not model yet (`Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`, ...).
+- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the construct into Rust that compiles (missing return-type annotations, `try`/`except`, decorators, callback methods not lowered into closures, non-primitive exported `const`, ...).
+
+## Summary
+
+| Library | Lang | Transpile | Tests (pass/fail) | First abort | Blocker classes | Dominant |
+| --- | --- | --- | --- | --- | ---: | --- |
+| [radash](https://github.com/sodiray/radash) | TS | **no** | n/a | `home/lollo/Playground/smelt/src/async.ts` | 6 | non-working Rust (6r/0s) |
+
+## radash
+
+- Source: `sodiray/radash` @ `4cab1900d08e`
+- Transpile: **no** — `smelt build` aborts at `home/lollo/Playground/smelt/src/async.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 19 · with blockers: 5
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(None)) |
+| 1 | 1 | non-working Rust | dynamic Date constructor calls require exactly one value argument |
+| 1 | 1 | non-working Rust | local closure return type does not match its annotation: actual Some(List(TypeId(0))), exp |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(Dict(TypeId(7), TypeId(0)))) |
+| 1 | 1 | non-working Rust | field access is only lowered for Record<string, T>, class, and interface values for now (r |
+| 1 | 1 | non-working Rust | expression kind is not lowered yet: SequenceExpression(SequenceExpression { span: Span { s |
+

--- a/blocker-logs/radash-named-promise-executor.md
+++ b/blocker-logs/radash-named-promise-executor.md
@@ -1,0 +1,34 @@
+# Bug-library transpile probes (TypeScript + Python)
+
+_Generated 2026-07-11 by the `library-probes` workflow (`scripts/probe_libraries.py`)._
+
+Each library is checked out at a pinned ref (see `.github/compat/libraries.json`), given its `.github/compat/<name>/Smelt.toml`, and run through `smelt build`. If a crate is emitted, its generated `cargo test` suite is run and counted. Otherwise every source/test file is scanned individually with `smelt dump-hir` to enumerate the full set of distinct blocker classes (single-file mode cannot resolve cross-file imports, so bare `unresolved name/identifier` errors are excluded as scan noise).
+
+**Error categories:**
+- **missing-stdlib** — a JS/Python builtin Smelt does not model yet (`Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`, ...).
+- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the construct into Rust that compiles (missing return-type annotations, `try`/`except`, decorators, callback methods not lowered into closures, non-primitive exported `const`, ...).
+
+## Summary
+
+| Library | Lang | Transpile | Tests (pass/fail) | First abort | Blocker classes | Dominant |
+| --- | --- | --- | --- | --- | ---: | --- |
+| [radash](https://github.com/sodiray/radash) | TS | **no** | n/a | `home/lollo/Playground/smelt/src/async.ts` | 8 | non-working Rust (8r/0s) |
+
+## radash
+
+- Source: `sodiray/radash` @ `4cab1900d08e`
+- Transpile: **no** — `smelt build` aborts at `home/lollo/Playground/smelt/src/async.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 19 · with blockers: 6
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 1 | 1 | non-working Rust | call argument kind is not lowered yet: UpdateExpression(UpdateExpression { span: Span { st |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(None)) |
+| 1 | 1 | non-working Rust | dynamic Date constructor calls require exactly one value argument |
+| 1 | 1 | non-working Rust | local closure return type does not match its annotation: actual Some(List(TypeId(0))), exp |
+| 1 | 1 | non-working Rust | array reduce callback returns an unsupported type |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(Dict(TypeId(7), TypeId(0)))) |
+| 1 | 1 | non-working Rust | field access is only lowered for Record<string, T>, class, and interface values for now (r |
+| 1 | 1 | non-working Rust | expression kind is not lowered yet: SequenceExpression(SequenceExpression { span: Span { s |
+

--- a/blocker-logs/radash-namespace-replace.md
+++ b/blocker-logs/radash-namespace-replace.md
@@ -1,0 +1,17 @@
+# Radash utility namespace replace investigation
+
+Date: 2026-07-11
+
+## Failure family
+
+Radash tests call `utility.replace(list, replacement, predicate)`. Both regex replacement and literal string replacement interceptors claimed every static member named `replace` and rejected the collection-helper signature before resolving the namespace receiver.
+
+## Root cause and fix
+
+Both string/regex replacement paths now defer imported utility/object namespace receivers before instance-method arity validation. The existing namespace member-call path remains responsible for lowering the free function and all its arguments.
+
+No `SmeltUnknown` type or conversion was added.
+
+## Probe result
+
+The replacement arity blockers are gone. `array.test.ts` advances to a later independent `never` assertion failure. The aggregate remains 10 blocker classes across 7 files while moving that file's failure frontier.

--- a/blocker-logs/radash-namespace-sort.md
+++ b/blocker-logs/radash-namespace-sort.md
@@ -1,0 +1,17 @@
+# Radash utility namespace sort investigation
+
+Date: 2026-07-11
+
+## Failure family
+
+Radash tests call the package free function as `utility.sort(list, getter, descending)`. Smelt's array instance-method interceptor claimed every static member named `sort` and rejected the third argument before establishing that the receiver was a list.
+
+## Root cause and fix
+
+Instance-method dispatch performed arity validation before namespace ownership resolution. `list_sort_call` now defers imported utility/object namespace receivers to the existing namespace member-call path before applying `Array.prototype.sort` rules.
+
+No `SmeltUnknown` type or conversion was added.
+
+## Probe result
+
+The `array sort requires at most one comparator argument` blocker is gone. `array.test.ts` now reaches its next independent failure, a utility namespace `replace` call incorrectly claimed by regex replacement lowering. The aggregate remains 10 blocker classes across 7 files while advancing that file's failure frontier.

--- a/blocker-logs/radash-never-assertion.md
+++ b/blocker-logs/radash-never-assertion.md
@@ -1,0 +1,17 @@
+# Radash runtime-erased never assertion investigation
+
+Date: 2026-07-11
+
+## Failure family
+
+Radash deliberately passes `null as unknown as never` to exercise null handling through a generic API. Smelt rejected the assertion because it treated the target as storage that must materialize a `never` value.
+
+## Root cause and fix
+
+TypeScript type assertions are erased at runtime. An impossible assertion does not construct its target type; it evaluates the original operand. Assertions whose target requires `never` now preserve the operand's concrete/runtime shape. Declarations and non-empty containers whose actual storage type requires `never` remain rejected by the existing declaration/literal checks.
+
+No `SmeltUnknown` variant or conversion was added. The existing `unknown` assertion in the source remains its explicit runtime boundary.
+
+## Probe result
+
+The `type assertion cannot construct a never value` blocker is gone. `array.test.ts` advances to a later independent namespace/instance `shift` arity failure. The aggregate remains 10 blocker classes across 7 files while advancing the file frontier.

--- a/blocker-logs/radash-parse-float.md
+++ b/blocker-logs/radash-parse-float.md
@@ -1,0 +1,33 @@
+# Radash parseFloat investigation
+
+Date: 2026-07-11
+
+## Selected failure family
+
+`radash/src/number.ts` called the global JavaScript `parseFloat` with a value typed as `any`. Smelt rejected the call because both global `parseFloat` and `Number.parseFloat` required an already-string operand.
+
+## Root cause
+
+JavaScript applies string coercion before parsing. Smelt represented the operation as the generic `ToFloat` primitive cast and therefore had no place to preserve that coercion step or JavaScript's non-throwing invalid-input result.
+
+## Implemented lowering
+
+- Both call spellings share `parse_float_operand`.
+- Existing string operands pass through unchanged.
+- Other supported primitive or erased operands lower through an explicit `ToString` cast.
+- A distinct `ParseFloat` cast emits a non-panicking parse result (`NaN` on invalid complete input), leaving generic/Python `ToFloat` behavior unchanged.
+- First-class global `parseFloat` values use the same distinct cast when synthesized as callbacks.
+- No `SmeltUnknown` variants or conversions were added. The tested `any` value uses the pre-existing erased-source boundary.
+
+This slice does not yet implement ECMAScript's longest-valid-prefix parsing for strings such as `"12px"`; Rust's complete-string parser returns `NaN` for that case. That broader runtime semantic gap is independent of the radash coercion blocker addressed here.
+
+## Probe comparison
+
+The radash-only probe used the same job fixture and Smelt binary before and after the change.
+
+| Metric | Before | After |
+| --- | ---: | ---: |
+| Blocker classes | 12 | 11 |
+| Files with blockers | 8 | 7 |
+
+The `parseFloat requires a string argument` diagnostic is absent after the change. Remaining blockers belong to other failure families such as update-expression arguments, Promise executors, local callable values, dynamic Date construction, and callback methods.

--- a/blocker-logs/radash-update-call-argument.md
+++ b/blocker-logs/radash-update-call-argument.md
@@ -1,0 +1,33 @@
+# Bug-library transpile probes (TypeScript + Python)
+
+_Generated 2026-07-11 by the `library-probes` workflow (`scripts/probe_libraries.py`)._
+
+Each library is checked out at a pinned ref (see `.github/compat/libraries.json`), given its `.github/compat/<name>/Smelt.toml`, and run through `smelt build`. If a crate is emitted, its generated `cargo test` suite is run and counted. Otherwise every source/test file is scanned individually with `smelt dump-hir` to enumerate the full set of distinct blocker classes (single-file mode cannot resolve cross-file imports, so bare `unresolved name/identifier` errors are excluded as scan noise).
+
+**Error categories:**
+- **missing-stdlib** — a JS/Python builtin Smelt does not model yet (`Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`, ...).
+- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the construct into Rust that compiles (missing return-type annotations, `try`/`except`, decorators, callback methods not lowered into closures, non-primitive exported `const`, ...).
+
+## Summary
+
+| Library | Lang | Transpile | Tests (pass/fail) | First abort | Blocker classes | Dominant |
+| --- | --- | --- | --- | --- | ---: | --- |
+| [radash](https://github.com/sodiray/radash) | TS | **no** | n/a | `home/lollo/Playground/smelt/src/async.ts` | 7 | non-working Rust (7r/0s) |
+
+## radash
+
+- Source: `sodiray/radash` @ `4cab1900d08e`
+- Transpile: **no** — `smelt build` aborts at `home/lollo/Playground/smelt/src/async.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 19 · with blockers: 6
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(None)) |
+| 1 | 1 | non-working Rust | dynamic Date constructor calls require exactly one value argument |
+| 1 | 1 | non-working Rust | local closure return type does not match its annotation: actual Some(List(TypeId(0))), exp |
+| 1 | 1 | non-working Rust | array reduce callback returns an unsupported type |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(Dict(TypeId(7), TypeId(0)))) |
+| 1 | 1 | non-working Rust | field access is only lowered for Record<string, T>, class, and interface values for now (r |
+| 1 | 1 | non-working Rust | expression kind is not lowered yet: SequenceExpression(SequenceExpression { span: Span { s |
+

--- a/blocker-logs/radash-utility-shift.md
+++ b/blocker-logs/radash-utility-shift.md
@@ -1,0 +1,35 @@
+# Bug-library transpile probes (TypeScript + Python)
+
+_Generated 2026-07-11 by the `library-probes` workflow (`scripts/probe_libraries.py`)._
+
+Each library is checked out at a pinned ref (see `.github/compat/libraries.json`), given its `.github/compat/<name>/Smelt.toml`, and run through `smelt build`. If a crate is emitted, its generated `cargo test` suite is run and counted. Otherwise every source/test file is scanned individually with `smelt dump-hir` to enumerate the full set of distinct blocker classes (single-file mode cannot resolve cross-file imports, so bare `unresolved name/identifier` errors are excluded as scan noise).
+
+**Error categories:**
+- **missing-stdlib** — a JS/Python builtin Smelt does not model yet (`Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`, ...).
+- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the construct into Rust that compiles (missing return-type annotations, `try`/`except`, decorators, callback methods not lowered into closures, non-primitive exported `const`, ...).
+
+## Summary
+
+| Library | Lang | Transpile | Tests (pass/fail) | First abort | Blocker classes | Dominant |
+| --- | --- | --- | --- | --- | ---: | --- |
+| [radash](https://github.com/sodiray/radash) | TS | **no** | n/a | `home/lollo/Playground/smelt/src/async.ts` | 9 | non-working Rust (9r/0s) |
+
+## radash
+
+- Source: `sodiray/radash` @ `4cab1900d08e`
+- Transpile: **no** — `smelt build` aborts at `home/lollo/Playground/smelt/src/async.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 19 · with blockers: 6
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 1 | 1 | non-working Rust | call argument kind is not lowered yet: UpdateExpression(UpdateExpression { span: Span { st |
+| 1 | 1 | non-working Rust | Promise constructor lowering supports one arrow executor |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(None)) |
+| 1 | 1 | non-working Rust | dynamic Date constructor calls require exactly one value argument |
+| 1 | 1 | non-working Rust | local closure return type does not match its annotation: actual Some(List(TypeId(0))), exp |
+| 1 | 1 | non-working Rust | array reduce callback returns an unsupported type |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(Dict(TypeId(7), TypeId(0)))) |
+| 1 | 1 | non-working Rust | field access is only lowered for Record<string, T>, class, and interface values for now (r |
+| 1 | 1 | non-working Rust | expression kind is not lowered yet: SequenceExpression(SequenceExpression { span: Span { s |
+

--- a/crates/smelt-codegen-rust/src/emitter/types.rs
+++ b/crates/smelt-codegen-rust/src/emitter/types.rs
@@ -111,6 +111,9 @@ impl FunctionEmitter<'_> {
             (smelt_hir::PrimitiveCastOp::ToFloat, Type::Float, Type::String) => Ok(format!(
                 "{operand_text}.parse::<f64>().expect(\"float() parse failed\")"
             )),
+            (smelt_hir::PrimitiveCastOp::ParseFloat, Type::Float, Type::String) => Ok(format!(
+                "{operand_text}.parse::<f64>().unwrap_or(f64::NAN)"
+            )),
             (smelt_hir::PrimitiveCastOp::ToFloat, Type::Float, Type::Optional(inner))
                 if matches!(self.mir.types.get(*inner), Some(Type::Float)) =>
             {

--- a/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
@@ -761,6 +761,32 @@ const upper = word.toUpperCase();
 }
 
 #[test]
+fn emits_string_trim_inside_filter_callback_body() {
+    let source = source_for(
+        r#"
+const values = [" a ", " "].filter(value => !!value.trim());
+"#,
+    );
+
+    assert!(source.contains(".trim().to_owned()"), "{source}");
+    assert!(source.contains(".filter("), "{source}");
+}
+
+#[test]
+fn emits_erased_string_coercion_before_callback_trim() {
+    let source = source_for(
+        r#"
+function clean(value: any): any[] {
+  return [value].filter(item => !!item.trim());
+}
+"#,
+    );
+
+    assert!(source.contains("SmeltUnknown::String(value)"), "{source}");
+    assert!(source.contains(".trim().to_owned()"), "{source}");
+}
+
+#[test]
 fn emits_string_trim_method() {
     let source = source_for(
         r#"

--- a/crates/smelt-codegen-rust/src/tests/part_2_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_2_tests.rs
@@ -36,7 +36,30 @@ const value = Number.parseFloat("42.5");
 "#,
     );
 
-    assert!(source.contains(".parse::<f64>().expect(\"float() parse failed\")"));
+    assert!(source.contains(".parse::<f64>().unwrap_or(f64::NAN)"));
+}
+
+#[test]
+fn emits_parse_float_string_coercion_for_erased_inputs() {
+    let source = source_for(
+        r#"
+function parseValue(value: any): number {
+  return parseFloat(value);
+}
+"#,
+    );
+    let program = source
+        .split_once(PRELUDE_END_MARKER)
+        .map_or(source.as_str(), |(_, program)| program);
+
+    assert!(
+        program.contains("SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value"),
+        "expected erased input to pass through JavaScript string coercion: {program}"
+    );
+    assert!(
+        program.contains(".parse::<f64>().unwrap_or(f64::NAN)"),
+        "expected the coerced string to feed parseFloat: {program}"
+    );
 }
 
 #[test]
@@ -144,7 +167,7 @@ const floatValue = parseFloat("42.5");
     );
 
     assert!(source.contains(".parse::<i64>().map(|value| value as f64).unwrap_or(f64::NAN)"));
-    assert!(source.contains(".parse::<f64>().expect(\"float() parse failed\")"));
+    assert!(source.contains(".parse::<f64>().unwrap_or(f64::NAN)"));
 }
 
 #[test]

--- a/crates/smelt-codegen-rust/src/tests/part_6_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_6_tests.rs
@@ -49,6 +49,30 @@ const no = Array.isArray(1);
 }
 
 #[test]
+fn emits_first_class_array_is_array_runtime_probe() {
+    let source = source_for(
+        r#"
+const isArray = Array.isArray;
+const arrayResult = isArray([1]);
+const stringResult = isArray("value");
+"#,
+    );
+
+    assert!(
+        source.contains("matches!(closure_arg_0.clone(), SmeltUnknown::Array(_))"),
+        "expected the first-class builtin to retain its runtime array probe: {source}"
+    );
+    assert!(
+        source.contains("SmeltUnknown::Array("),
+        "expected concrete arrays to adapt into the runtime-inspection boundary: {source}"
+    );
+    assert!(
+        source.contains("SmeltUnknown::String("),
+        "expected concrete primitives to adapt into the runtime-inspection boundary: {source}"
+    );
+}
+
+#[test]
 fn emits_object_projection_methods() {
     let source = source_for(
         r#"

--- a/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_7_tests.rs
@@ -2006,6 +2006,28 @@ function isArray(value: unknown): boolean {
 }
 
 #[test]
+fn preserves_runtime_value_through_never_assertion() {
+    let source = source_for(
+        r#"
+function consume(value: unknown): boolean {
+  return value === null;
+}
+const result = consume(null as unknown as never);
+const tuple = [1] as unknown as [never];
+const record = {} as Record<string, never>;
+"#,
+    );
+
+    assert!(
+        source.contains(": SmeltUnknown = SmeltUnknown::Null;")
+            && source.contains("consume(_smelt_tmp_")
+            && source.contains("SmeltUnknown::Array(vec![SmeltUnknown::Number(1.0 as f64)]")
+            && source.contains("SmeltRecord::from([])"),
+        "erased direct and compound assertions must retain their runtime values: {source}"
+    );
+}
+
+#[test]
 fn emits_array_entries_for_guarded_erased_generic() {
     let source = source_for(
         r"

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/closures.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/closures.rs
@@ -7,6 +7,7 @@ use crate::lowering::{
     FunctionType, HashMap, ListSearchOp, Literal, LocalCallbackDefault, LocalDecl, ModuleBuilder,
     Param, PrimitiveCastOp, SmeltError, Span, Stmt, StringAffixOp, StringCaseOp, Type,
 };
+use smelt_hir::StringTrimSide;
 
 impl ModuleBuilder<'_> {
     /// Validate the inferred callback return type for an array method.
@@ -801,6 +802,23 @@ impl ModuleBuilder<'_> {
                         needle,
                     },
                     ty,
+                    span,
+                }))
+            }
+            "trim" if args.is_empty()
+                && matches!(
+                    self.ctx.krate.types.get(receiver_ty),
+                    Some(Type::String | Type::Unknown | Type::TypeParam { .. })
+                ) =>
+            {
+                let string_ty = self.ctx.krate.types.intern(Type::String);
+                let operand = Self::callback_coerce_to_string(receiver, string_ty, body, span);
+                Ok(body.push_expr(Expr {
+                    kind: ExprKind::StringTrim {
+                        operand,
+                        side: StringTrimSide::Both,
+                    },
+                    ty: string_ty,
                     span,
                 }))
             }

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/list_ops.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/list_ops.rs
@@ -748,6 +748,18 @@ impl ModuleBuilder<'_> {
         if member.property.name != "reduce" {
             return Ok(None);
         }
+        // A star-imported namespace owns its exported `reduce` function. Its
+        // callback contract may differ from `Array.prototype.reduce` (for
+        // example, an async reducer returning `Promise<T>`), so leave opaque
+        // imports to generic namespace-call lowering. Locally registered
+        // utility objects can still use the modeled static reduce form below.
+        if matches!(
+            &member.object,
+            Expression::Identifier(object)
+                if self.namespace_imports.contains(object.name.as_str())
+        ) {
+            return Ok(None);
+        }
         if Self::is_static_reduce_utility_call(call) {
             return self.static_reduce_utility_call(call, body, member);
         }

--- a/crates/smelt-frontend-ts/src/lowering/expr/references.rs
+++ b/crates/smelt-frontend-ts/src/lowering/expr/references.rs
@@ -412,9 +412,10 @@ impl ModuleBuilder<'_> {
             "Boolean" => {
                 self.builtin_cast_closure_expression(PrimitiveCastOp::ToBool, Type::Bool, span, outer_body)
             }
-            // String-to-number parse functions used as callbacks. Both take a
-            // single string argument here (matching the direct-call lowering,
-            // which requires a string operand): callers that need JavaScript's
+            // String-to-number parse functions used as callbacks. Both expose a
+            // single string parameter here; direct `parseFloat` calls separately
+            // make JavaScript's implicit `ToString` coercion explicit. Callers
+            // that need JavaScript's
             // `(value, index)` arity (e.g. `arr.map(parseInt)`) wrap them in
             // `unary`/`ary` first, so a one-parameter closure is faithful. The
             // parameter is typed `string` so the cast emits the real numeric
@@ -425,7 +426,7 @@ impl ModuleBuilder<'_> {
                 outer_body,
             ),
             "parseFloat" => self.builtin_string_cast_closure_expression(
-                PrimitiveCastOp::ToFloat,
+                PrimitiveCastOp::ParseFloat,
                 span,
                 outer_body,
             ),

--- a/crates/smelt-frontend-ts/src/lowering/guards.rs
+++ b/crates/smelt-frontend-ts/src/lowering/guards.rs
@@ -1085,6 +1085,7 @@ impl ModuleBuilder<'_> {
             }
             Argument::LogicalExpression(logical) => self.logical_expression(logical, body),
             Argument::UnaryExpression(unary) => self.unary_expression(unary, body),
+            Argument::UpdateExpression(update) => self.update_expression(update, body),
             Argument::ArrayExpression(array) => self.array_expression(array, body, None),
             Argument::ObjectExpression(object) => self.object_expression(object, body, None),
             Argument::CallExpression(call) => self.call_expression(call, body),

--- a/crates/smelt-frontend-ts/src/lowering/guards.rs
+++ b/crates/smelt-frontend-ts/src/lowering/guards.rs
@@ -943,13 +943,14 @@ impl ModuleBuilder<'_> {
             return self.expression(expression, body);
         }
         let target = self.ts_type_to_hir(annotation)?;
-        if self.concrete_type_requires_never_value(target)
-            && !Self::is_empty_object_expression(expression)
-        {
-            return Err(SmeltError::unsupported(
-                self.span(span.start, span.end),
-                "type assertion cannot construct a never value",
-            ));
+        if self.concrete_type_requires_never_value(target) {
+            // TypeScript assertions are erased at runtime. An assertion such
+            // as `null as unknown as never` does not construct an impossible
+            // value; it evaluates the original `null`. Keep the operand's real
+            // shape instead of forcing an uninhabited Rust destination. Actual
+            // declarations/containers whose storage type requires `never`
+            // remain rejected by their declaration and literal checks.
+            return self.expression(expression, body);
         }
         if let Some(parsed) = self.json_parse_call_with_target(expression, target, span, body)? {
             return Ok(parsed);
@@ -984,26 +985,6 @@ impl ModuleBuilder<'_> {
                     TSTypeName::IdentifierReference(name) if name.name == "const"
                 )
         )
-    }
-
-    /// Return whether an expression is an empty object literal after TS-only wrappers.
-    pub(super) fn is_empty_object_expression(expression: &Expression<'_>) -> bool {
-        match expression {
-            Expression::ObjectExpression(object) => object.properties.is_empty(),
-            Expression::ParenthesizedExpression(parenthesized) => {
-                Self::is_empty_object_expression(&parenthesized.expression)
-            }
-            Expression::TSAsExpression(assertion) => {
-                Self::is_empty_object_expression(&assertion.expression)
-            }
-            Expression::TSSatisfiesExpression(assertion) => {
-                Self::is_empty_object_expression(&assertion.expression)
-            }
-            Expression::TSNonNullExpression(assertion) => {
-                Self::is_empty_object_expression(&assertion.expression)
-            }
-            _ => false,
-        }
     }
 
     /// Lower a function call argument.

--- a/crates/smelt-frontend-ts/src/lowering/guards.rs
+++ b/crates/smelt-frontend-ts/src/lowering/guards.rs
@@ -1493,10 +1493,10 @@ impl ModuleBuilder<'_> {
         if callee.name != "Promise" {
             return Ok(None);
         }
-        let [Argument::ArrowFunctionExpression(executor)] = new_expr.arguments.as_slice() else {
+        let [executor_arg] = new_expr.arguments.as_slice() else {
             return Err(SmeltError::unsupported(
                 self.span(new_expr.span.start, new_expr.span.end),
-                "Promise constructor lowering supports one arrow executor",
+                "Promise constructor lowering requires one executor",
             ));
         };
         let output_ty = type_hint
@@ -1515,8 +1515,14 @@ impl ModuleBuilder<'_> {
         // timer callback does real work (e.g. `() => resolve(value)`) must flow
         // through `AsyncOp::Promise`, which threads `resolve`/`reject`; treating
         // it as `Sleep` would silently discard the resolved value.
-        let bare_delay_timer = Self::promise_executor_timer_call(executor)
-            .filter(|timer_call| Self::promise_executor_is_bare_delay(executor, timer_call));
+        let bare_delay_timer = match executor_arg {
+            Argument::ArrowFunctionExpression(executor) => {
+                Self::promise_executor_timer_call(executor).filter(|timer_call| {
+                    Self::promise_executor_is_bare_delay(executor, timer_call)
+                })
+            }
+            _ => None,
+        };
         let duration = if let Some(timer_call) = bare_delay_timer {
             let Some(duration_argument) = timer_call.arguments.get(1) else {
                 return Err(SmeltError::unsupported(
@@ -1561,9 +1567,6 @@ impl ModuleBuilder<'_> {
                 is_async: false,
                 may_throw: false,
             }));
-            let Some(executor_arg) = new_expr.arguments.first() else {
-                return Ok(None);
-            };
             let executor_expr = self.argument_with_hint(executor_arg, body, Some(executor_ty))?;
             return Ok(Some(body.push_expr(Expr {
                 kind: ExprKind::AsyncOp {

--- a/crates/smelt-frontend-ts/src/lowering/stdlib.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib.rs
@@ -1681,6 +1681,12 @@ impl ModuleBuilder<'_> {
         if member.property.name != "shift" {
             return Ok(None);
         }
+        // A utility namespace can export a free function named
+        // `shift(list, amount)`. Defer it before applying the zero-argument
+        // contract of `Array.prototype.shift`.
+        if self.imported_utility_object(&member.object) {
+            return Ok(None);
+        }
         if !call.arguments.is_empty() {
             return Err(SmeltError::unsupported(
                 self.span(call.span.start, call.span.end),

--- a/crates/smelt-frontend-ts/src/lowering/stdlib.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib.rs
@@ -1774,6 +1774,13 @@ impl ModuleBuilder<'_> {
         if member.property.name != "sort" {
             return Ok(None);
         }
+        // A star-import/object utility namespace may export a free function
+        // named `sort(list, getter, descending)`. It is not an invocation of
+        // `Array.prototype.sort`, so defer before validating instance-method
+        // arity or lowering a comparator.
+        if self.imported_utility_object(&member.object) {
+            return Ok(None);
+        }
         let comparator_argument = match call.arguments.as_slice() {
             [] => None,
             [argument] => Some(argument),

--- a/crates/smelt-frontend-ts/src/lowering/stdlib/numbers_math.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/numbers_math.rs
@@ -26,6 +26,12 @@ impl ModuleBuilder<'_> {
             "replaceAll" => StringReplaceOp::All,
             _ => return Ok(None),
         };
+        // Utility namespaces may export a collection helper named `replace`
+        // with a wider signature. Defer before applying String/RegExp instance
+        // arity rules so the namespace member-call path owns that invocation.
+        if self.imported_utility_object(&member.object) {
+            return Ok(None);
+        }
         let [pattern_arg, replacement_arg] = call.arguments.as_slice() else {
             return Err(SmeltError::unsupported(
                 self.span(call.span.start, call.span.end),

--- a/crates/smelt-frontend-ts/src/lowering/stdlib/numbers_math.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/numbers_math.rs
@@ -640,28 +640,57 @@ return_ty: string_ty,
         if object.name != "Number" || member.property.name != "parseFloat" {
             return Ok(None);
         }
-        let [argument] = call.arguments.as_slice() else {
-            return Err(SmeltError::unsupported(
-                self.span(call.span.start, call.span.end),
-                "Number.parseFloat requires exactly one string argument",
-            ));
-        };
-        let operand = self.argument(argument, body)?;
-        if self.ctx.krate.types.get(Self::expr_ty(body, operand)) != Some(&Type::String) {
-            return Err(SmeltError::unsupported(
-                self.span(call.span.start, call.span.end),
-                "Number.parseFloat requires a string argument",
-            ));
-        }
+        let operand = self.parse_float_operand("Number.parseFloat", call, body)?;
         let ty = self.ctx.krate.types.intern(Type::Float);
         Ok(Some(body.push_expr(Expr {
             kind: ExprKind::PrimitiveCast {
-                op: PrimitiveCastOp::ToFloat,
+                op: PrimitiveCastOp::ParseFloat,
                 operand,
             },
             ty,
             span: self.span(call.span.start, call.span.end),
         })))
+    }
+
+    /// Lower one JavaScript `parseFloat` operand through its `ToString` step.
+    ///
+    /// ECMAScript parses the string representation of its input rather than
+    /// requiring the runtime value to already be a string. Keeping this as an
+    /// explicit nested primitive cast preserves erased `any`/`unknown` values
+    /// until the existing string coercion boundary instead of asserting that
+    /// their runtime representation is a Rust `String`.
+    pub(in crate::lowering) fn parse_float_operand(
+        &mut self,
+        source_name: &str,
+        call: &oxc::ast::ast::CallExpression<'_>,
+        body: &mut Body,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let [argument] = call.arguments.as_slice() else {
+            return Err(SmeltError::unsupported(
+                self.span(call.span.start, call.span.end),
+                format!("{source_name} requires exactly one argument"),
+            ));
+        };
+        let operand = self.argument(argument, body)?;
+        let operand_ty = Self::expr_ty(body, operand);
+        if self.ctx.krate.types.get(operand_ty) == Some(&Type::String) {
+            return Ok(operand);
+        }
+        if !self.primitive_cast_accepts_operand(PrimitiveCastOp::ToString, operand_ty) {
+            return Err(SmeltError::unsupported(
+                self.span(call.span.start, call.span.end),
+                format!("{source_name} argument cannot be coerced to a string"),
+            ));
+        }
+        let string_ty = self.ctx.krate.types.intern(Type::String);
+        Ok(body.push_expr(Expr {
+            kind: ExprKind::PrimitiveCast {
+                op: PrimitiveCastOp::ToString,
+                operand,
+            },
+            ty: string_ty,
+            span: self.span(argument.span().start, argument.span().end),
+        }))
     }
 
     /// Lower direct TypeScript `Number.parseInt(...)` calls.

--- a/crates/smelt-frontend-ts/src/lowering/stdlib/objects.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/objects.rs
@@ -1663,6 +1663,9 @@ return_ty,
             "replaceAll" => StringReplaceOp::All,
             _ => return Ok(None),
         };
+        if self.imported_utility_object(&member.object) {
+            return Ok(None);
+        }
         let [pattern_argument, replacement_argument] = call.arguments.as_slice() else {
             return Err(SmeltError::unsupported(
                 self.span(call.span.start, call.span.end),

--- a/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
@@ -14,7 +14,7 @@ use oxc::ast::ast::{
 use smelt_hir::{
     BinOp, Body, CaptureMode, ClosureCapture, DictProjectionOp, Expr, ExprKind, FunctionType, Item,
     Literal, LocalDecl, NumericPredicateOp, NumericRoundOp, NumericUnaryFuncOp, Param, Pattern,
-    PrimitiveCastOp, Span, Stmt, Type,
+    PrimitiveCastOp, Span, Stmt, Type, UnknownKind,
 };
 
 impl ModuleBuilder<'_> {
@@ -338,6 +338,9 @@ impl ModuleBuilder<'_> {
         if let Some(expr) = self.number_predicate_member_expression(member, body) {
             return Ok(expr);
         }
+        if let Some(expr) = self.array_is_array_member_expression(member, body) {
+            return Ok(expr);
+        }
         if let Some(expr) = self.object_static_function_member(member, body) {
             return Ok(expr);
         }
@@ -472,6 +475,83 @@ impl ModuleBuilder<'_> {
             kind: ExprKind::Field { receiver, field },
             ty,
             span: self.span(member.span.start, member.span.end),
+        }))
+    }
+
+    /// Lower `Array.isArray` in value position to a callable runtime probe.
+    ///
+    /// The parameter is intentionally `Unknown`: JavaScript defines this
+    /// predicate for every runtime value, so inspecting the tagged dynamic
+    /// representation is the genuine boundary rather than erased type-level
+    /// plumbing. Concrete callers are adapted into that boundary normally.
+    pub(in crate::lowering) fn array_is_array_member_expression(
+        &mut self,
+        member: &oxc::ast::ast::StaticMemberExpression<'_>,
+        outer_body: &mut Body,
+    ) -> Option<smelt_hir::ExprId> {
+        let Expression::Identifier(object) = &member.object else {
+            return None;
+        };
+        if object.name != "Array"
+            || member.property.name != "isArray"
+            || self.builtin_call_identifier_is_shadowed("Array")
+        {
+            return None;
+        }
+        let span = self.span(member.span.start, member.span.end);
+        let unknown_ty = self.ctx.krate.types.intern(Type::Unknown);
+        let bool_ty = self.ctx.krate.types.intern(Type::Bool);
+        let value_name = self.intern_source_name("value");
+        let mut closure_body = Body::new(None, span);
+        let value_local = closure_body.push_local(LocalDecl {
+            name: Some(value_name),
+            ty: unknown_ty,
+            mutable: false,
+            span,
+        });
+        closure_body.params.push(value_local);
+        let value = closure_body.push_expr(Expr {
+            kind: ExprKind::Local(value_local),
+            ty: unknown_ty,
+            span,
+        });
+        let result = closure_body.push_expr(Expr {
+            kind: ExprKind::UnknownIs {
+                value,
+                kind: UnknownKind::Array,
+            },
+            ty: bool_ty,
+            span,
+        });
+        closure_body.push_stmt(Stmt::Return(Some(result)));
+        let body_id = self.ctx.krate.push_body(closure_body);
+        let closure_ty = self.ctx.krate.types.intern(Type::Function(FunctionType {
+            params: vec![unknown_ty],
+            rest: None,
+            required_params: None,
+            mutable_params: Vec::new(),
+            return_ty: bool_ty,
+            is_async: false,
+            may_throw: false,
+        }));
+        Some(outer_body.push_expr(Expr {
+            kind: ExprKind::Closure(smelt_hir::ClosureExpr {
+                params: vec![Param {
+                    name: value_name,
+                    local: value_local,
+                    ty: unknown_ty,
+                    span,
+                }],
+                rest: None,
+                required_params: None,
+                return_ty: bool_ty,
+                captures: Vec::new(),
+                body: body_id,
+                function_item: None,
+                span,
+            }),
+            ty: closure_ty,
+            span,
         }))
     }
 

--- a/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs
@@ -1454,10 +1454,22 @@ impl ModuleBuilder<'_> {
                 span: self.span(call.span.start, call.span.end),
             })));
         }
+        if callee.name == "parseFloat" {
+            let operand = self.parse_float_operand("parseFloat", call, body)?;
+            let ty = self.ctx.krate.types.intern(Type::Float);
+            return Ok(Some(body.push_expr(Expr {
+                kind: ExprKind::PrimitiveCast {
+                    op: PrimitiveCastOp::ParseFloat,
+                    operand,
+                },
+                ty,
+                span: self.span(call.span.start, call.span.end),
+            })));
+        }
         let (op, result_ty) = match callee.name.as_str() {
             "String" => (PrimitiveCastOp::ToString, Type::String),
             "Number" => (PrimitiveCastOp::ToJsNumber, Type::Float),
-            "parseFloat" | "BigInt" => (PrimitiveCastOp::ToFloat, Type::Float),
+            "BigInt" => (PrimitiveCastOp::ToFloat, Type::Float),
             "Boolean" => (PrimitiveCastOp::ToBool, Type::Bool),
             _ => return Ok(None),
         };
@@ -1500,14 +1512,6 @@ impl ModuleBuilder<'_> {
             return Err(SmeltError::unsupported(
                 self.span(call.span.start, call.span.end),
                 "String currently supports number and string arguments",
-            ));
-        }
-        if matches!(callee.name.as_str(), "parseFloat" | "parseInt")
-            && operand_type != Some(&Type::String)
-        {
-            return Err(SmeltError::unsupported(
-                self.span(call.span.start, call.span.end),
-                format!("{} requires a string argument", callee.name),
             ));
         }
         let ty = self.ctx.krate.types.intern(result_ty);

--- a/crates/smelt-frontend-ts/src/tests/part01_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part01_tests.rs
@@ -305,6 +305,50 @@ fn rejects_runtime_never_values() -> Result<(), String> {
 }
 
 #[test]
+fn preserves_runtime_value_of_never_assertions() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function intersects<T>(left: readonly T[], right: readonly T[]): boolean {
+  return false;
+}
+
+const left = intersects(null as unknown as never, []);
+const right = intersects([], null as unknown as never);
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+    let calls = body
+        .exprs
+        .iter()
+        .filter_map(|expr| match &expr.kind {
+            ExprKind::Call { args, .. } => Some(args),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    ensure_eq!(calls.len(), 2);
+    for args in calls {
+        ensure!(args.iter().any(|argument| {
+            let Some(ExprKind::TypeAssert { value }) = body
+                .exprs
+                .get(argument.0 as usize)
+                .map(|expr| &expr.kind)
+            else {
+                return false;
+            };
+            matches!(
+                body.exprs.get(value.0 as usize).map(|expr| &expr.kind),
+                Some(ExprKind::Literal(Literal::None))
+            )
+        }));
+    }
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn allows_never_inside_uninhabited_union_assertion_branch() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-frontend-ts/src/tests/part02_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part02_tests.rs
@@ -514,10 +514,50 @@ const value = Number.parseFloat("42.5");
     ensure!(body.exprs.iter().any(|expr| matches!(
         expr.kind,
         ExprKind::PrimitiveCast {
-            op: PrimitiveCastOp::ToFloat,
+            op: PrimitiveCastOp::ParseFloat,
             ..
         }
     )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_parse_float_erased_inputs_through_string_coercion() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function parseValues(value: any): number[] {
+  return [parseFloat(value), Number.parseFloat(value)];
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = function_body(&ctx, function_item(&ctx, module, 0)?)?;
+    let coerced_parse_count = body
+        .exprs
+        .iter()
+        .filter(|expr| {
+            let ExprKind::PrimitiveCast {
+                op: PrimitiveCastOp::ParseFloat,
+                operand,
+            } = expr.kind
+            else {
+                return false;
+            };
+            usize::try_from(operand.0).ok().is_some_and(|index| {
+                matches!(
+                    body.exprs.get(index).map(|operand| &operand.kind),
+                    Some(ExprKind::PrimitiveCast {
+                        op: PrimitiveCastOp::ToString,
+                        ..
+                    })
+                )
+            })
+        })
+        .count();
+    ensure_eq!(coerced_parse_count, 2);
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
     Ok(())
 }
@@ -3477,7 +3517,7 @@ const floatValue = parseFloat("42.5");
     ensure!(body.exprs.iter().any(|expr| matches!(
         expr.kind,
         ExprKind::PrimitiveCast {
-            op: PrimitiveCastOp::ToFloat,
+            op: PrimitiveCastOp::ParseFloat,
             ..
         }
     )));

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -1352,6 +1352,26 @@ const result = utility.sort([3, 1, 2], value => value, true);
 }
 
 #[test]
+fn utility_namespace_replace_defers_before_string_arity_validation() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+import * as utility from "./utility";
+const result = utility.replace(["a"], "b", value => value === "a");
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+    ensure!(!body.exprs.iter().any(|expr| matches!(
+        expr.kind,
+        ExprKind::StringReplace { .. }
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn lowers_string_trim_inside_filter_callback_body() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -1332,6 +1332,58 @@ const no = isArray("value");
 }
 
 #[test]
+fn lowers_string_trim_inside_filter_callback_body() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+const values = [" a ", " "].filter(value => !!value.trim());
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(ctx.krate.bodies.iter().any(|body| body.exprs.iter().any(
+        |expr| matches!(
+            expr.kind,
+            ExprKind::StringTrim {
+                side: StringTrimSide::Both,
+                ..
+            }
+        )
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn coerces_erased_string_trim_receiver_inside_callback_body() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function clean(value: any): any[] {
+  return [value].filter(item => !!item.trim());
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(ctx.krate.bodies.iter().any(|body| {
+        body.exprs.iter().any(|expr| {
+            let ExprKind::StringTrim { operand, .. } = expr.kind else {
+                return false;
+            };
+            usize::try_from(operand.0).ok().is_some_and(|index| {
+                matches!(
+                    body.exprs.get(index).map(|operand| &operand.kind),
+                    Some(ExprKind::TypeAssert { .. })
+                )
+            })
+        })
+    }));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn first_class_array_is_array_respects_shadowing() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -1332,6 +1332,26 @@ const no = isArray("value");
 }
 
 #[test]
+fn utility_namespace_sort_defers_before_array_arity_validation() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+import * as utility from "./utility";
+const result = utility.sort([3, 1, 2], value => value, true);
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+    ensure!(!body.exprs.iter().any(|expr| matches!(
+        expr.kind,
+        ExprKind::ListSort { .. }
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn lowers_string_trim_inside_filter_callback_body() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -1372,6 +1372,27 @@ const result = utility.shift([1, 2, 3], 2);
 }
 
 #[test]
+fn imported_namespace_reduce_defers_async_callback_contract() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+import * as utility from "./utility";
+const sum = async (left: number, right: number): Promise<number> => left + right;
+const result = utility.reduce([1, 2, 3], sum, 0);
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+    ensure!(!body
+        .exprs
+        .iter()
+        .any(|expr| matches!(expr.kind, ExprKind::ListReduce { .. })));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn utility_namespace_replace_defers_before_string_arity_validation() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -1240,7 +1240,7 @@ const checkFinite = take(isFinite);
         PrimitiveCastOp::ToString,   // String
         PrimitiveCastOp::ToBool,     // Boolean
         PrimitiveCastOp::ToInt,      // parseInt
-        PrimitiveCastOp::ToFloat,    // parseFloat
+        PrimitiveCastOp::ParseFloat, // parseFloat
     ] {
         ensure!(cast_ops.contains(&expected), "missing cast op {expected:?}");
     }

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -3386,6 +3386,29 @@ function makeQueue(): Promise<number[]> {
 }
 
 #[test]
+fn lowers_postfix_update_as_call_argument() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function collect(value: number): number {
+  return value;
+}
+let index = 0;
+const previous = collect(index++);
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+    ensure!(body
+        .exprs
+        .iter()
+        .any(|expr| matches!(expr.kind, ExprKind::Call { .. })));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn lowers_function_length_to_len_expr() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -1299,6 +1299,63 @@ const finite = [1, 2, 3].filter(isFinite);
 }
 
 #[test]
+fn lowers_array_is_array_as_first_class_function_value() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+const isArray = Array.isArray;
+const yes = isArray([1]);
+const no = isArray("value");
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+    ensure!(
+        body.exprs
+            .iter()
+            .any(|expr| matches!(expr.kind, ExprKind::Closure(_)))
+    );
+    ensure!(
+        ctx.krate.bodies.iter().any(
+            |closure_body| closure_body.exprs.iter().any(|expr| matches!(
+                expr.kind,
+                ExprKind::UnknownIs {
+                    kind: smelt_hir::UnknownKind::Array,
+                    ..
+                }
+            ))
+        )
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn first_class_array_is_array_respects_shadowing() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+const Array = { isArray: (value: unknown): boolean => false };
+const predicate = Array.isArray;
+const result = predicate([1]);
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+    ensure!(!body.exprs.iter().any(|expr| matches!(
+        expr.kind,
+        ExprKind::UnknownIs {
+            kind: smelt_hir::UnknownKind::Array,
+            ..
+        }
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn lowers_object_projection_methods() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -3358,6 +3358,34 @@ function makeValue(): Promise<number> {
 }
 
 #[test]
+fn lowers_named_promise_constructor_executor_as_future() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function makeQueue(): Promise<number[]> {
+  const processor = async (resolve: (value: number[]) => void) => {
+    resolve([1, 2]);
+  };
+  return new Promise(processor);
+}
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = function_item(&ctx, module, 0)?;
+    let body = function_body(&ctx, function)?;
+    ensure!(body.exprs.iter().any(|expr| matches!(
+        expr.kind,
+        ExprKind::AsyncOp {
+            op: smelt_hir::AsyncOp::Promise,
+            ..
+        }
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn lowers_function_length_to_len_expr() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -1352,6 +1352,26 @@ const result = utility.sort([3, 1, 2], value => value, true);
 }
 
 #[test]
+fn utility_namespace_shift_defers_before_array_arity_validation() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+import * as utility from "./utility";
+const result = utility.shift([1, 2, 3], 2);
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+    ensure!(!body.exprs.iter().any(|expr| matches!(
+        expr.kind,
+        ExprKind::ListShift { .. }
+    )));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn utility_namespace_replace_defers_before_string_arity_validation() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-hir/src/expr/ops.rs
+++ b/crates/smelt-hir/src/expr/ops.rs
@@ -95,6 +95,8 @@ pub enum PrimitiveCastOp {
     ToInt,
     /// Convert to floating-point number.
     ToFloat,
+    /// Parse a JavaScript-coerced string as a floating-point number.
+    ParseFloat,
     /// Convert with JavaScript `Number(...)` and unary-plus semantics.
     ToJsNumber,
     /// Convert to string.

--- a/crates/smelt-hir/src/format/call.rs
+++ b/crates/smelt-hir/src/format/call.rs
@@ -136,6 +136,7 @@ pub(super) fn expr_text(krate: &Crate, expr: &Expr) -> String {
                 crate::expr::PrimitiveCastOp::ToBool => "bool",
                 crate::expr::PrimitiveCastOp::ToInt => "int",
                 crate::expr::PrimitiveCastOp::ToFloat => "float",
+                crate::expr::PrimitiveCastOp::ParseFloat => "parse_float",
                 crate::expr::PrimitiveCastOp::ToJsNumber => "js_number",
                 crate::expr::PrimitiveCastOp::ToString => "string",
             };

--- a/crates/smelt-mir/src/format.rs
+++ b/crates/smelt-mir/src/format.rs
@@ -447,6 +447,7 @@ fn rvalue_text(value: &Rvalue) -> String {
                 smelt_hir::PrimitiveCastOp::ToBool => "bool",
                 smelt_hir::PrimitiveCastOp::ToInt => "int",
                 smelt_hir::PrimitiveCastOp::ToFloat => "float",
+                smelt_hir::PrimitiveCastOp::ParseFloat => "parse_float",
                 smelt_hir::PrimitiveCastOp::ToJsNumber => "js_number",
                 smelt_hir::PrimitiveCastOp::ToString => "string",
             };

--- a/docs/superpowers/plans/2026-07-11-parse-float-coercion.md
+++ b/docs/superpowers/plans/2026-07-11-parse-float-coercion.md
@@ -1,0 +1,36 @@
+# JavaScript parseFloat Coercion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Lower global and `Number.parseFloat` calls with JavaScript's string-coercion semantics for non-string inputs.
+
+**Architecture:** Centralize argument validation/coercion in a `parse_float_operand` helper. Preserve string operands directly; otherwise emit `PrimitiveCastOp::ToString`, then a dedicated `PrimitiveCastOp::ParseFloat` whose Rust emission returns `NaN` for invalid text without changing generic/Python float conversion.
+
+**Tech Stack:** Rust, Oxc TypeScript AST, Smelt HIR and Rust codegen.
+
+## Global Constraints
+
+- Do not add radash- or function-owner-specific special cases.
+- Do not add or expand `SmeltUnknown`; source `any`/`unknown` is an existing legitimate dynamic boundary.
+- Keep TypeScript lowering helpers in focused modules and document new helpers.
+- Run `cargo check`, `cargo clippy`, and full `cargo test` before commit.
+
+---
+
+### Task 1: Coerce parseFloat inputs through strings
+
+**Files:**
+- Modify: `crates/smelt-frontend-ts/src/lowering/stdlib/numbers_math.rs`
+- Modify: `crates/smelt-frontend-ts/src/lowering/stmt/assignments.rs`
+- Test: `crates/smelt-frontend-ts/src/tests/part02_tests.rs`
+- Test: `crates/smelt-codegen-rust/src/tests/part_2_tests.rs`
+
+**Interfaces:**
+- Produces: `ModuleBuilder::parse_float_operand(source_name, call, body) -> Result<ExprId, SmeltError>`.
+- Consumes: `PrimitiveCastOp::ToString` and the new `PrimitiveCastOp::ParseFloat`.
+
+- [x] **Step 1:** Add failing frontend coverage for global and `Number.parseFloat` calls receiving `any`, asserting `ParseFloat` consumes a `ToString` expression.
+- [x] **Step 2:** Run the focused frontend tests and confirm the current string-argument diagnostic.
+- [x] **Step 3:** Implement `parse_float_operand` and route both call spellings through it.
+- [x] **Step 4:** Add codegen coverage proving erased input is string-coerced before parsing, then rerun the radash blocker scan.
+- [ ] **Step 5:** Run repository gates, review the diff, commit, push, and open a draft PR.


### PR DESCRIPTION
## What changed

- add a distinct `ParseFloat` HIR/MIR primitive cast
- lower global and `Number.parseFloat` operands through JavaScript-style `ToString` coercion
- keep generic/Python float conversion behavior unchanged
- update first-class `parseFloat` callback lowering
- add frontend and Rust emission regressions plus a radash investigation report

## Why

Radash passes an `any`-typed value to `parseFloat`. Smelt incorrectly required the operand to already be a string, blocking `src/number.ts`. The generated Rust also used the generic float conversion path, which panicked on invalid complete inputs.

## Impact

The radash probe improves from 12 to 11 blocker classes and from 8 to 7 files with blockers. No new `SmeltUnknown` conversion or variant is introduced.

## Validation

- `cargo check` — passed
- `cargo clippy` — passed with unrelated existing warnings
- focused frontend/codegen parseFloat tests — passed
- first-class builtin closure test — passed
- full `cargo test` — 548 codegen unit tests and Python parity passed; stopped at the existing TypeScript decorator parity fixture compile failure
- global `cargo fmt --all -- --check` is currently obstructed by unrelated shared-worktree formatting differences

## Known boundary

This slice fixes operand coercion and non-panicking invalid complete inputs. ECMAScript longest-valid-prefix parsing (such as `parseFloat("12px")`) remains a separate runtime-semantic gap.