### PR TITLE
Fix radash nullish and generic inference blockers

### DIFF
--- a/blocker-logs/radash-generic-inference-priority.md
+++ b/blocker-logs/radash-generic-inference-priority.md
@@ -1,0 +1,30 @@
+# Bug-library transpile probes (TypeScript + Python)
+
+_Generated 2026-07-12 by the `library-probes` workflow (`scripts/probe_libraries.py`)._
+
+Each library is checked out at a pinned ref (see `.github/compat/libraries.json`), given its `.github/compat/<name>/Smelt.toml`, and run through `smelt build`. If a crate is emitted, its generated `cargo test` suite is run and counted. Otherwise every source/test file is scanned individually with `smelt dump-hir` to enumerate the full set of distinct blocker classes (single-file mode cannot resolve cross-file imports, so bare `unresolved name/identifier` errors are excluded as scan noise).
+
+**Error categories:**
+- **missing-stdlib** — a JS/Python builtin Smelt does not model yet (`Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`, ...).
+- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the construct into Rust that compiles (missing return-type annotations, `try`/`except`, decorators, callback methods not lowered into closures, non-primitive exported `const`, ...).
+
+## Summary
+
+| Library | Lang | Transpile | Tests (pass/fail) | First abort | Blocker classes | Dominant |
+| --- | --- | --- | --- | --- | ---: | --- |
+| [radash](https://github.com/sodiray/radash) | TS | **no** | n/a | `src/tests/curry.test.ts` | 4 | non-working Rust (4r/0s) |
+
+## radash
+
+- Source: `sodiray/radash` @ `4cab1900d08e`
+- Transpile: **no** — `smelt build` aborts at `src/tests/curry.test.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 19 · with blockers: 3
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 1 | 1 | non-working Rust | dynamic Date constructor calls require exactly one value argument |
+| 1 | 1 | non-working Rust | local closure return type does not match its annotation: actual Some(List(TypeId(0))), exp |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(Dict(TypeId(7), TypeId(0)))) |
+| 1 | 1 | non-working Rust | expression kind is not lowered yet: SequenceExpression(SequenceExpression { span: Span { s |
+

--- a/blocker-logs/radash-nullish-callback-union.md
+++ b/blocker-logs/radash-nullish-callback-union.md
@@ -1,0 +1,31 @@
+# Bug-library transpile probes (TypeScript + Python)
+
+_Generated 2026-07-12 by the `library-probes` workflow (`scripts/probe_libraries.py`)._
+
+Each library is checked out at a pinned ref (see `.github/compat/libraries.json`), given its `.github/compat/<name>/Smelt.toml`, and run through `smelt build`. If a crate is emitted, its generated `cargo test` suite is run and counted. Otherwise every source/test file is scanned individually with `smelt dump-hir` to enumerate the full set of distinct blocker classes (single-file mode cannot resolve cross-file imports, so bare `unresolved name/identifier` errors are excluded as scan noise).
+
+**Error categories:**
+- **missing-stdlib** — a JS/Python builtin Smelt does not model yet (`Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`, ...).
+- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the construct into Rust that compiles (missing return-type annotations, `try`/`except`, decorators, callback methods not lowered into closures, non-primitive exported `const`, ...).
+
+## Summary
+
+| Library | Lang | Transpile | Tests (pass/fail) | First abort | Blocker classes | Dominant |
+| --- | --- | --- | --- | --- | ---: | --- |
+| [radash](https://github.com/sodiray/radash) | TS | **no** | n/a | `src/tests/curry.test.ts` | 5 | non-working Rust (5r/0s) |
+
+## radash
+
+- Source: `sodiray/radash` @ `4cab1900d08e`
+- Transpile: **no** — `smelt build` aborts at `src/tests/curry.test.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 19 · with blockers: 4
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 1 | 1 | non-working Rust | dynamic Date constructor calls require exactly one value argument |
+| 1 | 1 | non-working Rust | local closure return type does not match its annotation: actual Some(List(TypeId(0))), exp |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(Dict(TypeId(7), TypeId(0)))) |
+| 1 | 1 | non-working Rust | field access is only lowered for Record<string, T>, class, and interface values for now (r |
+| 1 | 1 | non-working Rust | expression kind is not lowered yet: SequenceExpression(SequenceExpression { span: Span { s |
+

--- a/blocker-logs/radash-post-152-baseline.md
+++ b/blocker-logs/radash-post-152-baseline.md
@@ -1,0 +1,32 @@
+# Bug-library transpile probes (TypeScript + Python)
+
+_Generated 2026-07-12 by the `library-probes` workflow (`scripts/probe_libraries.py`)._
+
+Each library is checked out at a pinned ref (see `.github/compat/libraries.json`), given its `.github/compat/<name>/Smelt.toml`, and run through `smelt build`. If a crate is emitted, its generated `cargo test` suite is run and counted. Otherwise every source/test file is scanned individually with `smelt dump-hir` to enumerate the full set of distinct blocker classes (single-file mode cannot resolve cross-file imports, so bare `unresolved name/identifier` errors are excluded as scan noise).
+
+**Error categories:**
+- **missing-stdlib** — a JS/Python builtin Smelt does not model yet (`Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`, ...).
+- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the construct into Rust that compiles (missing return-type annotations, `try`/`except`, decorators, callback methods not lowered into closures, non-primitive exported `const`, ...).
+
+## Summary
+
+| Library | Lang | Transpile | Tests (pass/fail) | First abort | Blocker classes | Dominant |
+| --- | --- | --- | --- | --- | ---: | --- |
+| [radash](https://github.com/sodiray/radash) | TS | **no** | n/a | `home/lollo/Playground/smelt/src/async.ts` | 6 | non-working Rust (6r/0s) |
+
+## radash
+
+- Source: `sodiray/radash` @ `4cab1900d08e`
+- Transpile: **no** — `smelt build` aborts at `home/lollo/Playground/smelt/src/async.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 19 · with blockers: 5
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(None)) |
+| 1 | 1 | non-working Rust | dynamic Date constructor calls require exactly one value argument |
+| 1 | 1 | non-working Rust | local closure return type does not match its annotation: actual Some(List(TypeId(0))), exp |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(Dict(TypeId(7), TypeId(0)))) |
+| 1 | 1 | non-working Rust | field access is only lowered for Record<string, T>, class, and interface values for now (r |
+| 1 | 1 | non-working Rust | expression kind is not lowered yet: SequenceExpression(SequenceExpression { span: Span { s |
+

--- a/blocker-logs/radash-refreshed-main.md
+++ b/blocker-logs/radash-refreshed-main.md
@@ -1,0 +1,31 @@
+# Bug-library transpile probes (TypeScript + Python)
+
+_Generated 2026-07-12 by the `library-probes` workflow (`scripts/probe_libraries.py`)._
+
+Each library is checked out at a pinned ref (see `.github/compat/libraries.json`), given its `.github/compat/<name>/Smelt.toml`, and run through `smelt build`. If a crate is emitted, its generated `cargo test` suite is run and counted. Otherwise every source/test file is scanned individually with `smelt dump-hir` to enumerate the full set of distinct blocker classes (single-file mode cannot resolve cross-file imports, so bare `unresolved name/identifier` errors are excluded as scan noise).
+
+**Error categories:**
+- **missing-stdlib** — a JS/Python builtin Smelt does not model yet (`Array`, `Number`, `Reflect`, `TextEncoder`, `Proxy`, ...).
+- **non-working Rust** — a frontend/IR lowering gap: Smelt cannot lower the construct into Rust that compiles (missing return-type annotations, `try`/`except`, decorators, callback methods not lowered into closures, non-primitive exported `const`, ...).
+
+## Summary
+
+| Library | Lang | Transpile | Tests (pass/fail) | First abort | Blocker classes | Dominant |
+| --- | --- | --- | --- | --- | ---: | --- |
+| [radash](https://github.com/sodiray/radash) | TS | **no** | n/a | `src/tests/curry.test.ts` | 5 | non-working Rust (5r/0s) |
+
+## radash
+
+- Source: `sodiray/radash` @ `4cab1900d08e`
+- Transpile: **no** — `smelt build` aborts at `src/tests/curry.test.ts`
+- Tests passing: **n/a** (no Rust crate emitted)
+- Files scanned: 19 · with blockers: 4
+
+| Occurrences | Files | Category | Blocker class |
+| ---: | ---: | --- | --- |
+| 1 | 1 | non-working Rust | dynamic Date constructor calls require exactly one value argument |
+| 1 | 1 | non-working Rust | local closure return type does not match its annotation: actual Some(List(TypeId(0))), exp |
+| 1 | 1 | non-working Rust | local `X` is not callable (Some(Dict(TypeId(7), TypeId(0)))) |
+| 1 | 1 | non-working Rust | field access is only lowered for Record<string, T>, class, and interface values for now (r |
+| 1 | 1 | non-working Rust | expression kind is not lowered yet: SequenceExpression(SequenceExpression { span: Span { s |
+

--- a/crates/smelt-frontend-ts/src/lowering/expr/operators.rs
+++ b/crates/smelt-frontend-ts/src/lowering/expr/operators.rs
@@ -1767,9 +1767,11 @@ impl ModuleBuilder<'_> {
         } else if matches!(
             self.ctx.krate.types.get(ty),
             Some(Type::Union(items)) if items.contains(&fallback_ty)
-        ) || self.allow_unknown_index_access
-        {
-            fallback_ty
+        ) {
+            // The fallback is already one arm of the value surface. Selecting
+            // it does not narrow every successful left-hand value to that one
+            // arm: `value ?? null` must retain the other union members.
+            ty
         } else if self.nullish_fallback_matches_union_member(ty, fallback_ty) {
             ty
         } else if self.nullish_fallback_types_are_structurally_compatible(ty, fallback_ty) {

--- a/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
@@ -779,7 +779,17 @@ impl<'builder> ModuleBuilder<'builder> {
                 && self.overload_constraint_contains_unresolved_type_param(return_ty)
             {
                 let mut substitutions = HashMap::new();
-                for (param, arg) in params.iter().zip(&args) {
+                let mut inference_inputs = params.iter().zip(&args).collect::<Vec<_>>();
+                // Infer naked type-parameter arguments before structural
+                // callback/container arguments. A direct value such as
+                // `initValue: T` is a stronger constraint than a callback body
+                // whose contextual `T` is still unresolved; processing the
+                // callback first can prematurely bind `T` from an incidental
+                // operation and then reject the concrete initializer.
+                inference_inputs.sort_by_key(|(param, _)| {
+                    !matches!(self.ctx.krate.types.get(**param), Some(Type::TypeParam { .. }))
+                });
+                for (param, arg) in inference_inputs {
                     let arg_ty = Self::expr_ty(body, *arg);
                     let _ = self.infer_overload_type(*param, arg_ty, &mut substitutions);
                 }

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -3432,6 +3432,32 @@ function makeQueue(): Promise<number[]> {
 }
 
 #[test]
+fn preserves_optional_callback_local_in_async_generic_arrow() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r#"
+declare function range(start: number, end: number): number[];
+declare function sleep(milliseconds: number): Promise<void>;
+
+export const retry = async <TResponse>(options: {
+  times?: number;
+  backoff?: (count: number) => number;
+}): Promise<TResponse> => {
+  const times = options?.times ?? 3;
+  const backoff = options?.backoff ?? null;
+  for (const i of range(1, times)) {
+    if (backoff) await sleep(backoff(i));
+  }
+  return undefined as unknown as TResponse;
+};
+"#),
+        &mut ctx,
+    )?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn lowers_postfix_update_as_call_argument() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -1393,6 +1393,32 @@ const result = utility.reduce([1, 2, 3], sum, 0);
 }
 
 #[test]
+fn direct_generic_initializer_outweighs_contextual_callback_inference() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+function iterate<T>(count: number, step: (value: T) => T, initial: T): T {
+  return initial;
+}
+function uid(length: number): string {
+  return iterate(length, value => value + "x", "");
+}
+const result = uid(10);
+const length = result.length;
+"#),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let body = module_body(&ctx, module)?;
+    ensure!(body
+        .exprs
+        .iter()
+        .any(|expr| matches!(expr.kind, ExprKind::Len { .. })));
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn utility_namespace_replace_defers_before_string_arity_validation() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(


### PR DESCRIPTION
## Summary

- preserve callable members when nullish coalescing selects a fallback already present in a union
- prioritize direct generic type-parameter arguments over weaker contextual callback inference
- add focused regressions for async optional callbacks and generic accumulator/initializer inference
- record before/after radash compatibility probes

## Why

Two general inference defects blocked radash. `value ?? null` could collapse an entire callable union to `null`, making a guarded callback uncallable. Separately, generic calls processed structural callback constraints before direct `T` arguments, so an incidental callback operation could bind `T` before a concrete initializer was considered.

The fixes retain the full nullish union and treat direct naked type-parameter arguments as stronger inference inputs. The radash probe drops from six blocker classes across five files to four classes across three files.

## Validation

- focused frontend regressions pass
- `cargo check` passes
- radash compatibility probe reports 4 remaining blocker classes
- full `cargo test` passes 637 codegen tests and Python parity; it still fails the pre-existing `typescript_specialization_parity::decorated_members_match_node_output` fixture compile
- `cargo clippy` reaches an unrelated pre-existing `redundant clone` error in `crates/smelt-codegen-rust/src/emitter/coercion.rs:1395` on current `main`
