### PR TITLE
fix(codegen): keep both-erased relational compares lexical for strings

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call_runtime.rs
@@ -1886,6 +1886,34 @@ impl FunctionEmitter<'_> {
         {
             return Ok(None);
         }
+        // When BOTH operands are erased, either could hold a string at runtime.
+        // JavaScript's relational algorithm compares two strings *lexically*, so
+        // blind `ToNumber` coercion (`NaN` for non-numeric text) would make every
+        // string comparison `false` and break generic string-keyed sorts / binary
+        // searches (remeda's `sortedIndex`, `firstBy`, `sortBy`, …). Route these
+        // through the runtime abstract-relational helper, which stays lexical for
+        // two strings and falls back to `ToNumber` for every other pairing.
+        if lhs_erased && rhs_erased {
+            let lhs_text = self.erase(lhs)?;
+            let rhs_text = self.erase(rhs)?;
+            // The guard at the top of this function restricts `op` to the four
+            // relational operators, so the `Gte` wildcard is the only remaining
+            // case (`match` cannot see through that earlier guard).
+            let ordering_pattern = match op {
+                smelt_hir::BinOp::Lt => "::std::cmp::Ordering::Less",
+                smelt_hir::BinOp::Lte => {
+                    "::std::cmp::Ordering::Less | ::std::cmp::Ordering::Equal"
+                }
+                smelt_hir::BinOp::Gt => "::std::cmp::Ordering::Greater",
+                _ => "::std::cmp::Ordering::Greater | ::std::cmp::Ordering::Equal",
+            };
+            return Ok(Some(format!(
+                "matches!(smelt_unknown_js_relational_ordering(&({lhs_text}), &({rhs_text})), Some({ordering_pattern}))"
+            )));
+        }
+        // Exactly one side is erased and the other is statically numeric: JS keeps
+        // this on the `ToNumber` path (only the both-strings case is lexical), so
+        // coerce both operands to `f64` and compare directly.
         let float_ty = self.type_id(Type::Float)?;
         let lhs_text = self.value_at_type(lhs, float_ty)?;
         let rhs_text = self.value_at_type(rhs, float_ty)?;
@@ -1895,6 +1923,9 @@ impl FunctionEmitter<'_> {
         )))
     }
 
+    /// Emits an equality or relational comparison between two statically numeric
+    /// operands, coercing both to a shared scalar type (`i64`/`f64`) first so Rust
+    /// does not reject a mixed `i64`-vs-`f64` comparison.
     fn numeric_comparison_text(
         &self,
         op: smelt_hir::BinOp,

--- a/crates/smelt-codegen-rust/src/lib.rs
+++ b/crates/smelt-codegen-rust/src/lib.rs
@@ -1709,6 +1709,43 @@ fn emit_source_with_free_function_router(
             },
         );
         writer.blank_line();
+        // JavaScript's Abstract Relational Comparison (`<`, `<=`, `>`, `>=`) for
+        // two erased values: when *both* operands are strings it compares them
+        // lexically (byte order over the UTF-8 encoding, matching JS's UTF-16
+        // code-unit order for the BMP), otherwise it runs `ToNumber` on both and
+        // compares as `f64`. A `NaN` on either side yields `None` (an unordered
+        // result), so every relational operator reports `false` — exactly the JS
+        // outcome. Codegen routes the both-erased relational arms here so a
+        // runtime string comparison stays lexical instead of collapsing to
+        // `NaN`-vs-`NaN` under blind numeric coercion.
+        writer.block(
+            "fn smelt_unknown_js_relational_ordering(left: &SmeltUnknown, right: &SmeltUnknown) -> Option<::std::cmp::Ordering>",
+            |fn_writer| {
+                fn_writer.block("match (left, right)", |match_writer| {
+                    match_writer.line("(SmeltUnknown::String(left), SmeltUnknown::String(right)) => Some(left.cmp(right)),");
+                    match_writer.line("_ => smelt_unknown_to_number(left).partial_cmp(&smelt_unknown_to_number(right)),");
+                });
+            },
+        );
+        writer.blank_line();
+        // `ToNumber` for an erased value, mirroring the inline coercion codegen
+        // emits when a `SmeltUnknown` flows into a numeric context: numeric
+        // strings parse to their value, non-numeric strings become `NaN`, booleans
+        // map to `0`/`1`, `__smelt_date` objects surface their timestamp, and
+        // every remaining shape is `NaN`.
+        writer.block(
+            "fn smelt_unknown_to_number(value: &SmeltUnknown) -> f64",
+            |fn_writer| {
+                fn_writer.block("match value", |match_writer| {
+                    match_writer.line("SmeltUnknown::Number(value) => *value,");
+                    match_writer.line("SmeltUnknown::Object(value) => match value.get(\"__smelt_date\") { Some(SmeltUnknown::Number(value)) => value, _ => f64::NAN },");
+                    match_writer.line("SmeltUnknown::String(value) => value.parse::<f64>().unwrap_or(f64::NAN),");
+                    match_writer.line("SmeltUnknown::Bool(value) => if *value { 1.0 } else { 0.0 },");
+                    match_writer.line("SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => f64::NAN,");
+                });
+            },
+        );
+        writer.blank_line();
         writer.block("pub trait IntoSmeltUnknown", |trait_writer| {
             trait_writer.line("fn into_smelt_unknown(self) -> SmeltUnknown;");
         });


### PR DESCRIPTION
## Problem

On `main`, remeda's generated test suite regressed from **1789/0 to 1772/17**. All 17 failures were one bug: a JS relational comparison (`< <= > >=`) where **both operands are erased `SmeltUnknown` and hold strings at runtime** compiled to a numeric (`ToNumber`) comparison, so `"apple" < "banana"` became `NaN < NaN` → always `false`. This silently broke every generic string-keyed sort / binary search: `sortedIndex`, `sortedIndexBy`, `sortedLastIndex(By)`, `firstBy`, `nthBy`, `sortBy` (the shared `purryOrderRules` comparator).

## Root cause

`bare_erased_relational_text` (added in `ce827d2a` to fix a `string | number`-vs-number compile error, E0277) unconditionally coerced **both** operands to `f64` whenever one side was erased and neither was *statically* `String`. JavaScript's abstract relational comparison compares two strings **lexically** and only `ToNumber`-coerces otherwise.

## Fix

- **Runtime prelude** (`lib.rs`): add `smelt_unknown_js_relational_ordering` (both strings → lexical `str::cmp`; else `ToNumber` → `f64::partial_cmp`; `NaN` → unordered → every operator `false`) plus a shared `smelt_unknown_to_number` helper.
- **Emitter** (`call_runtime.rs`): when **both** operands are erased, emit `matches!(smelt_unknown_js_relational_ordering(&l, &r), Some(…))`. The one-side-statically-numeric case keeps the existing `ToNumber` path, so the `ce827d2a` union-vs-number fix is preserved.

## Verification

- remeda generated tests: **1772/17 → 1789/0**.
- Full `cargo test`: all pass except `decorated_members_match_node_output`, which fails identically on unmodified `main` (pre-existing environmental `tsc` fixture issue).
- `cargo clippy -p smelt-codegen-rust`: no warnings in changed code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)