### PR TITLE
fix(frontend-ts): es-toolkit transpile blockers (clamp, nthArg, findIndex)

### DIFF
--- a/crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/classify.rs
@@ -929,26 +929,115 @@ impl ModuleBuilder<'_> {
     /// erased/generic surfaces — `unknown`/`any`, type parameters, and unions
     /// that include a function or erased branch — where the value is genuinely
     /// callable at runtime but lacks a clean static function type.
-    pub(in crate::lowering) fn callback_local_value_is_callable_surface(&self, ty: smelt_hir::TypeId) -> bool {
+    pub(in crate::lowering) fn callback_local_value_is_callable_surface(&mut self, ty: smelt_hir::TypeId) -> bool {
+        self.callback_local_value_is_callable_surface_depth(ty, 0)
+    }
+
+    /// Depth-guarded worker for [`Self::callback_local_value_is_callable_surface`].
+    ///
+    /// The depth bound stops runaway recursion when a type alias resolves to a
+    /// type that references itself.
+    fn callback_local_value_is_callable_surface_depth(
+        &mut self,
+        ty: smelt_hir::TypeId,
+        depth: u32,
+    ) -> bool {
+        if depth > 8 {
+            return false;
+        }
         match self
             .ctx
             .krate
             .types
             .get(self.type_param_constraint_or_self(ty))
+            .cloned()
         {
             Some(Type::Function(_) | Type::Unknown | Type::TypeParam { .. }) => true,
             // An optional callable (`compareKeys?: (a, b) => number` used as
             // `keys.sort(compareKeys)`) is a callable surface too; the wrapper
             // closure observes the nullish payload at runtime.
-            Some(Type::Optional(inner)) => self.callback_local_value_is_callable_surface(*inner),
+            Some(Type::Optional(inner)) => {
+                self.callback_local_value_is_callable_surface_depth(inner, depth + 1)
+            }
             Some(Type::Union(items)) => items.iter().copied().any(|item| {
                 matches!(
                     self.ctx.krate.types.get(item),
                     Some(Type::Function(_) | Type::Unknown)
                 )
             }),
+            // A named type reference (`ListIterateeCustom<T, boolean>`).
+            //
+            // When the alias definition is visible in this lowering unit, resolve
+            // it and inspect the underlying type: a union alias like
+            // `((v, i, c) => R) | PropertyKey | ...` still exposes a callable
+            // (function) arm, so a local of that type is a callable surface.
+            //
+            // When the reference is *unresolved* — the alias is imported from
+            // another module and its definition is not present in this lowering
+            // unit (single-file lowering, e.g. `smelt probe`) — it is an erased
+            // type boundary: its concrete shape is unknown here. A concrete
+            // nominal type (a real `class`/`interface` declared in scope) is not
+            // a callable surface, so keep rejecting those. But an opaque imported
+            // reference is treated like `unknown` — a callable surface whose
+            // wrapper closure observes the real value at runtime — matching how
+            // the whole-crate build (where the alias resolves to its union) lowers
+            // the same call.
+            Some(Type::Class { name, args }) => {
+                if self.callable_object_aliases.contains(&name) {
+                    return true;
+                }
+                if let Some(underlying) = self.resolve_type_alias_underlying(name, &args)
+                    && underlying != ty
+                {
+                    return self
+                        .callback_local_value_is_callable_surface_depth(underlying, depth + 1);
+                }
+                !self.symbol_names_concrete_nominal_type(name)
+            }
             _ => false,
         }
+    }
+
+    /// Resolve a `Type::Class` alias reference to its underlying definition with
+    /// the reference's type arguments substituted for the alias parameters.
+    ///
+    /// Returns `None` when the symbol does not name a type alias (e.g. a real
+    /// class or interface), so callers can fall back to their opaque handling.
+    fn resolve_type_alias_underlying(
+        &mut self,
+        name: smelt_hir::Symbol,
+        args: &[smelt_hir::TypeId],
+    ) -> Option<smelt_hir::TypeId> {
+        let alias = self.find_type_alias(name).cloned()?;
+        let mut substitutions = HashMap::new();
+        for (index, param) in alias.type_params.iter().enumerate() {
+            let actual = args
+                .get(index)
+                .copied()
+                .or(param.default)
+                .unwrap_or_else(|| {
+                    self.ctx
+                        .krate
+                        .types
+                        .intern(Type::TypeParam { name: param.name })
+                });
+            substitutions.insert(param.name, actual);
+        }
+        Some(self.substitute_type_params(alias.ty, &substitutions))
+    }
+
+    /// Return whether `name` refers to a concrete nominal type — a `class` or
+    /// `interface` declared in this lowering unit — as opposed to an unresolved
+    /// (imported, definition-not-present) type reference.
+    fn symbol_names_concrete_nominal_type(&self, name: smelt_hir::Symbol) -> bool {
+        if self.find_interface(name).is_some() {
+            return true;
+        }
+        self.ctx
+            .krate
+            .items
+            .iter()
+            .any(|item| matches!(item, Item::Class(class) if class.name == name))
     }
 
     /// Build an opaque callback that calls a captured outer local value.

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/closures.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/closures.rs
@@ -633,6 +633,14 @@ impl ModuleBuilder<'_> {
                 body,
                 span,
             ),
+            "apply" => self.callback_apply_method_to_body_expr(
+                receiver,
+                receiver_ty,
+                args,
+                ty,
+                body,
+                span,
+            ),
             "toString" | "to_string" if args.is_empty() => Ok(body.push_expr(Expr {
                 kind: ExprKind::PrimitiveCast {
                     op: PrimitiveCastOp::ToString,
@@ -1219,6 +1227,53 @@ impl ModuleBuilder<'_> {
             kind: ExprKind::ClosureCall {
                 callee,
                 args,
+            },
+            ty,
+            span,
+        }))
+    }
+
+    /// Lower a `Function.prototype.apply` call inside a closure body.
+    ///
+    /// `fn.apply(thisArg, argsArray)` invokes `fn` with the elements of
+    /// `argsArray` as positional arguments. Smelt erases the JavaScript `this`
+    /// binding for these callables (the source callbacks are written with
+    /// `function (this: any, ...)`), so the leading `thisArg` operand is dropped
+    /// and the trailing array is spread through `ClosureCallSpread`, mirroring the
+    /// spread branch of [`Self::callback_call_method_to_body_expr`]. This
+    /// generalizes the closure-body method table to the `apply` form the same way
+    /// `call` is already supported, without special-casing any particular library
+    /// function.
+    pub(in crate::lowering) fn callback_apply_method_to_body_expr(
+        &mut self,
+        receiver: smelt_hir::ExprId,
+        _receiver_ty: smelt_hir::TypeId,
+        args: &[smelt_hir::ExprId],
+        ty: smelt_hir::TypeId,
+        body: &mut Body,
+        span: Span,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        // `fn.apply(thisArg)` (or `fn.apply()`) forwards no positional
+        // arguments, so it is an ordinary zero-argument closure call.
+        if args.len() <= 1 {
+            return Ok(body.push_expr(Expr {
+                kind: ExprKind::ClosureCall {
+                    callee: receiver,
+                    args: Vec::new(),
+                },
+                ty,
+                span,
+            }));
+        }
+        // The trailing operand is the array whose elements become the call
+        // arguments; spread it through the packed-argument closure-call ABI.
+        let arguments = *args.last().ok_or_else(|| {
+            SmeltError::unsupported(span, "callback apply call requires an arguments array")
+        })?;
+        Ok(body.push_expr(Expr {
+            kind: ExprKind::ClosureCallSpread {
+                callee: receiver,
+                args: arguments,
             },
             ty,
             span,

--- a/crates/smelt-frontend-ts/src/lowering/callbacks/transforms.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/transforms.rs
@@ -678,7 +678,16 @@ impl ModuleBuilder<'_> {
         if self.ctx.krate.types.get(index_ty) == Some(&Type::Float) {
             return Ok(index);
         }
-        if self.is_numeric_like_type(index_ty) || self.optional_numeric_surface(index_ty) {
+        if self.is_numeric_like_type(index_ty)
+            || self.optional_numeric_surface(index_ty)
+            || self.erased_or_union_surface(index_ty)
+        {
+            // A numeric-like, optional-numeric, or erased index (e.g. the
+            // cross-module `toInteger(n)` return that lowers to an opaque surface)
+            // is coerced with a JS `Number(...)` cast. `Array`/`String.prototype.at`
+            // run `ToInteger` on the argument at runtime, so any value is accepted;
+            // the cast makes the emitted normalized-index arithmetic see a concrete
+            // `f64` instead of aborting on the erased shape.
             let float_ty = self.ctx.krate.types.intern(Type::Float);
             return Ok(body.push_expr(Expr {
                 kind: ExprKind::PrimitiveCast {

--- a/crates/smelt-frontend-ts/src/lowering/new_expr.rs
+++ b/crates/smelt-frontend-ts/src/lowering/new_expr.rs
@@ -2569,6 +2569,13 @@ impl ModuleBuilder<'_> {
             Ok(self.ctx.krate.types.intern(Type::Optional(else_ty)))
         } else if self.ctx.krate.types.get(else_ty) == Some(&Type::None) {
             Ok(self.ctx.krate.types.intern(Type::Optional(then_ty)))
+        } else if let Some(unified) = self.unify_optional_conditional_branches(then_ty, else_ty) {
+            // One branch is `Optional<inner>` and the other is compatible with
+            // `inner` (equal or numerically widenable), e.g. a `number | undefined`
+            // flow-typed local vs a `number` literal (`isNaN(x) ? 0 : x`). Merge
+            // to `Optional<unified-inner>` so the optional surface is preserved
+            // instead of aborting because a bare and an optional numeric differ.
+            Ok(unified)
         } else if self.compatible_function_branch_types(then_ty, else_ty) {
             Ok(then_ty)
         } else if let Some(function_ty) = self.single_function_branch_type(then_ty, else_ty) {
@@ -2627,6 +2634,54 @@ impl ModuleBuilder<'_> {
                     self.ctx.krate.types.get(else_ty)
                 ),
             ))
+        }
+    }
+
+    /// Merge a conditional whose branches are a value and an `Optional` of a
+    /// compatible value into a single `Optional` result.
+    ///
+    /// Returns `Some(Optional<inner>)` when exactly one branch is `Optional<a>`
+    /// and the other branch's type unifies with `a` (identical, or numerically
+    /// widenable so `Float`/`Int` mix), or when both branches are optionals whose
+    /// inners unify. This preserves the optional surface produced by flow typing
+    /// (`x: number | undefined; cond ? 0 : x`) instead of failing because a bare
+    /// numeric and an optional numeric have different lowered shapes. Returns
+    /// `None` when neither branch is optional or the inners are unrelated.
+    fn unify_optional_conditional_branches(
+        &mut self,
+        then_ty: smelt_hir::TypeId,
+        else_ty: smelt_hir::TypeId,
+    ) -> Option<smelt_hir::TypeId> {
+        let then_opt = match self.ctx.krate.types.get(then_ty) {
+            Some(Type::Optional(inner)) => Some(*inner),
+            _ => None,
+        };
+        let else_opt = match self.ctx.krate.types.get(else_ty) {
+            Some(Type::Optional(inner)) => Some(*inner),
+            _ => None,
+        };
+        let inner = match (then_opt, else_opt) {
+            (Some(a), Some(b)) => self.unify_compatible_branch_inner(a, b)?,
+            (Some(a), None) => self.unify_compatible_branch_inner(a, else_ty)?,
+            (None, Some(b)) => self.unify_compatible_branch_inner(then_ty, b)?,
+            (None, None) => return None,
+        };
+        Some(self.ctx.krate.types.intern(Type::Optional(inner)))
+    }
+
+    /// Return the unified inner type for two conditional-branch inners that are
+    /// identical or numerically compatible, or `None` if unrelated.
+    fn unify_compatible_branch_inner(
+        &mut self,
+        a: smelt_hir::TypeId,
+        b: smelt_hir::TypeId,
+    ) -> Option<smelt_hir::TypeId> {
+        if a == b {
+            Some(a)
+        } else if self.numeric_type_compatible(a, b) {
+            Some(self.ctx.krate.types.intern(Type::Float))
+        } else {
+            None
         }
     }
 

--- a/crates/smelt-frontend-ts/src/lowering/testing/matchers.rs
+++ b/crates/smelt-frontend-ts/src/lowering/testing/matchers.rs
@@ -833,6 +833,33 @@ impl ModuleBuilder<'_> {
                     item: expected,
                 }
             }
+            // The actual may itself be erased (`Unknown`/leaked type param) when
+            // it comes from a cross-module helper whose return type does not
+            // resolve in this lowering unit (`expect(keysIn(buffer)).toContain(k)`).
+            // JavaScript containment inspects the live value, so project the
+            // erased actual to an erased list and erase the needle; the emitted
+            // runtime projection panics if the value is not an array, matching
+            // how other matchers treat erased actuals.
+            Some(Type::Unknown | Type::TypeParam { .. }) => {
+                let unknown_ty = self.ctx.krate.types.intern(Type::Unknown);
+                let list_ty = self.ctx.krate.types.intern(Type::List(unknown_ty));
+                let matcher_span = self.span(span.start, span.end);
+                let list = body.push_expr(Expr {
+                    kind: ExprKind::TypeAssert { value: actual },
+                    ty: list_ty,
+                    span: matcher_span,
+                });
+                let item = if expected_ty == unknown_ty {
+                    expected
+                } else {
+                    body.push_expr(Expr {
+                        kind: ExprKind::TypeAssert { value: expected },
+                        ty: unknown_ty,
+                        span: matcher_span,
+                    })
+                };
+                ExprKind::ListContains { list, item }
+            }
             _ => {
                 return Err(SmeltError::unsupported(
                     self.span(span.start, span.end),

--- a/crates/smelt-frontend-ts/src/tests/part02_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part02_tests.rs
@@ -368,6 +368,52 @@ function pickAt<T extends number>(values: string[], index: T): string | undefine
 }
 
 #[test]
+fn coerces_erased_at_index() -> Result<(), String> {
+    // An erased index — e.g. a value flowing through an `unknown`/opaque surface,
+    // mirroring the cross-module `toInteger(n)` return in es-toolkit `nthArg` —
+    // is coerced with a `Number(...)` cast rather than rejected, since `.at` runs
+    // `ToInteger` on any argument at runtime.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r"
+function pick(values: string[], index: unknown): string | undefined {
+  return values.at(index as any);
+}
+"),
+        &mut ctx,
+    )?;
+    let _ = module_id;
+    let has_optional_index = ctx
+        .krate
+        .bodies
+        .iter()
+        .any(|body| body.exprs.iter().any(|expr| {
+            matches!(expr.kind, ExprKind::OptionalIndex { .. })
+        }));
+    ensure!(
+        has_optional_index,
+        "array .at with an erased index should lower to optional indexing"
+    );
+    let has_number_cast = ctx.krate.bodies.iter().any(|body| {
+        body.exprs.iter().any(|expr| {
+            matches!(
+                expr.kind,
+                ExprKind::PrimitiveCast {
+                    op: PrimitiveCastOp::ToJsNumber,
+                    ..
+                }
+            )
+        })
+    });
+    ensure!(
+        has_number_cast,
+        "erased .at index should be coerced with a Number(...) cast"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn rejects_non_numeric_at_index() -> Result<(), String> {
     // A genuinely non-numeric index (here a string) is not coercible and must
     // stay an explicit unsupported diagnostic rather than being silently coerced.
@@ -723,6 +769,36 @@ fn rejects_conditional_expression_with_mismatched_branches() -> Result<(), Strin
     let mut ctx = HirCtx::new();
     let errors = lowering_errors(ts!("const value = true ? 1 : \"no\";"), &mut ctx)?;
     assert_unsupported_ts(&errors, "branches must have the same lowered type")
+}
+
+#[test]
+fn lowers_conditional_numeric_and_optional_numeric_branches() -> Result<(), String> {
+    // A ternary whose branches are a bare numeric literal and an optional-numeric
+    // flow-typed local (mirroring es-toolkit `clamp`'s `isNaN(x) ? 0 : x` where
+    // `x` stays `number | undefined`) must merge to `Optional<Float>` instead of
+    // aborting because a `Float` and `Optional<Float>` have different shapes.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r"
+function pick(bound?: number): number | undefined {
+  return bound === undefined ? 0 : bound;
+}
+"),
+        &mut ctx,
+    )?;
+    let _ = module_id;
+    ensure!(
+        ctx.krate
+            .bodies
+            .iter()
+            .any(|body| body
+                .exprs
+                .iter()
+                .any(|expr| matches!(expr.kind, ExprKind::Conditional { .. }))),
+        "missing conditional expression"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
 }
 
 #[test]

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -154,6 +154,35 @@ function clone(entries: unknown[]) {
 }
 
 #[test]
+fn lowers_imported_iteratee_alias_local_as_find_index_callback() -> Result<(), String> {
+    // A parameter typed with an *imported* union alias (`ListIterateeCustom`,
+    // whose definition is not present in this lowering unit) surfaces as an
+    // opaque `Type::Class` reference. Passing that named local straight to an
+    // array method — `arr.findIndex(doesMatch)` — must still lower: the value is
+    // callable at runtime (the union's function arm), so it is treated as an
+    // erased callable surface, matching how the whole-crate build lowers the
+    // resolved union. Before this fix the callback dispatch rejected the local
+    // with "array callback local callback `doesMatch` is not defined".
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+import type { ListIterateeCustom } from "./iteratee";
+
+export function findIndex<T>(
+  arr: T[],
+  doesMatch: ListIterateeCustom<T, boolean>
+): number {
+  return arr.findIndex(doesMatch);
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn lowers_forward_reference_to_nested_function_declaration() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     let module_id = lower_ok(

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -6707,6 +6707,36 @@ function lazy(value: unknown, depth: number) {
 }
 
 #[test]
+fn lowers_callback_apply_method_into_closure_body() -> Result<(), String> {
+    // `fn.apply(thisArg, argsArray)` inside a closure body: the erased `this`
+    // operand is dropped and the trailing array spreads through the
+    // packed-argument closure-call ABI, mirroring the `.call(...args)` form
+    // (es-toolkit debounce forwards `_debounced.apply(this, args)`).
+    let mut ctx = HirCtx::new();
+    lower_ok(
+        ts!(r"
+function run(callback: (...args: number[]) => void, args: number[]) {
+  return [1, 2].map((value) => {
+    callback.apply(undefined, args);
+    return value;
+  });
+}
+"),
+        &mut ctx,
+    )?;
+    ensure!(
+        ctx.krate
+            .bodies
+            .iter()
+            .flat_map(|body| body.exprs.iter())
+            .any(|expr| matches!(expr.kind, ExprKind::ClosureCallSpread { .. })),
+        "expected callback .apply(thisArg, args) to lower as a spread closure call"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn lowers_callback_call_method_spread_into_closure_body() -> Result<(), String> {
     let mut ctx = HirCtx::new();
     lower_ok(

--- a/crates/smelt-frontend-ts/src/tests/part05_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part05_tests.rs
@@ -1025,6 +1025,43 @@ describe("sample", () => {
 }
 
 #[test]
+fn expect_to_contain_accepts_erased_actual_collection() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    // `keysIn(value)` resolves to an erased value when the helper's module is
+    // not part of this lowering unit; toContain must project the erased actual
+    // to an erased list and run the containment check at runtime instead of
+    // rejecting the matcher.
+    lower_path_ok(
+        ts!(r#"
+import { describe, expect, it } from "vitest";
+import { keysIn } from "./keysIn";
+
+describe("sample", () => {
+  it("does not expose buffer keys", () => {
+    const actual = keysIn({ a: 1 });
+    expect(actual).not.toContain("offset");
+  });
+});
+"#),
+        "src/sample.spec.ts",
+        &mut ctx,
+    )?;
+    ensure!(
+        has_test_named(&ctx, "test_sample_does_not_expose_buffer_keys"),
+        "expect(erased).toContain(value) should lower the test",
+    );
+    ensure!(
+        ctx.krate
+            .bodies
+            .iter()
+            .flat_map(|body| body.exprs.iter())
+            .any(|expr| matches!(expr.kind, ExprKind::ListContains { .. })),
+        "erased actual should lower to a runtime list containment check",
+    );
+    Ok(())
+}
+
+#[test]
 fn lowers_new_map_with_declared_union_value_type() -> Result<(), String> {
     // A `Map<K, V>` annotation whose value type is a union should accept
     // heterogeneous `[key, value]` entries: each entry coerces to the declared


### PR DESCRIPTION
Knocks out 3 of the remaining es-toolkit transpile blockers (probe files 9 → 6):

- **clamp**: conditional branches `number` vs `number | undefined` now unify to `Optional<number>` (general value-vs-Optional-of-compatible merge in `conditional_branch_type`).
- **nthArg**: `.at(i)` accepts an erased/union numeric index (cross-module `toInteger(n)` return) via `ToJsNumber` coercion, matching JS `ToInteger` semantics; concrete non-numeric indexes still rejected.
- **findIndex**: callback locals typed by imported aliases (`ListIterateeCustom<T, boolean>`) are now callable surfaces — resolvable aliases recurse into their union's function arm; unresolved imported refs are treated as erased callable boundaries (concrete nominal types still rejected).

The remaining 6 probe files: 4 are probe isolation artifacts (switch-const tags import cross-module and already transpile in real builds), plus debounce (callback method in closures) and keysIn.spec (`toContain` matcher shape).

## Verification
- frontend-ts 906 passed; mir/codegen suites green
- es-toolkit `cargo check` 0 errors; remeda suite 1789/1789
- end-to-end goldens 9/9, compile_corpus green
- SmeltUnknown ratchet `--fail-on-regression` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)