### PR TITLE
ci: add Immer and RxJS compatibility probes

### DIFF
--- a/.github/compat/README.md
+++ b/.github/compat/README.md
@@ -27,11 +27,18 @@ deliberately to re-baseline a probe against a newer library version.
 | `ts-pattern` | `gvergnaud/ts-pattern` | TS |
 | `valibot` | `fabian-hiller/valibot` | TS |
 | `neverthrow` | `supermacro/neverthrow` | TS |
+| `immer` | `immerjs/immer` | TS |
+| `rxjs` | `ReactiveX/rxjs` | TS |
 | `returns` | `dry-python/returns` | Py |
 | `result` | `rustedpy/result` | Py |
 | `more-itertools` | `more-itertools/more-itertools` | Py |
 | `funcy` | `Suor/funcy` | Py |
 | `toolz` | `pytoolz/toolz` | Py |
+
+Immer's upstream performance suite uses `.mjs`, and RxJS's benchmark helper
+uses `.js`. The TypeScript probe scanner intentionally excludes both until it
+supports JavaScript-family inputs; their TypeScript source and test suites are
+still included in full.
 
 ## Reproducing a probe
 

--- a/.github/compat/immer/Smelt.toml
+++ b/.github/compat/immer/Smelt.toml
@@ -1,0 +1,33 @@
+[project]
+name = "immer"
+version = "0.0.0"
+description = "Immer Smelt probe"
+
+[sources]
+roots = ["src", "__tests__"]
+test-globs = [
+    "draft.ts",
+    "empty.ts",
+    "immutable.ts",
+    "not-strict-copy.ts",
+    "produce.ts",
+    "redux.ts",
+    "spec_ts.ts",
+    "type-external.ts",
+]
+entries = ["src/immer.ts"]
+
+[output]
+target = "./dist-smelt"
+crate-name = "immer_probe"
+build = false
+
+[rust]
+edition = "2024"
+
+[strict]
+typescript = true
+python = true
+
+[runtime]
+clone-strategy = "aggressive"

--- a/.github/compat/libraries.json
+++ b/.github/compat/libraries.json
@@ -6,6 +6,8 @@
     { "name": "ts-pattern",     "repo": "gvergnaud/ts-pattern",            "ref": "c92ca435c7e1827e0fd55c539080ef1bfd6fe3f0", "lang": "ts", "roots": ["src", "tests"] },
     { "name": "valibot",        "repo": "fabian-hiller/valibot",           "ref": "1f9b18338ad5530f1f6c63c2cf241962bd82d6f8", "lang": "ts", "roots": ["library/src"] },
     { "name": "neverthrow",     "repo": "supermacro/neverthrow",           "ref": "5ef3a018bda74fb960e44b68fc3672635ee8037d", "lang": "ts", "roots": ["src", "tests"] },
+    { "name": "immer",          "repo": "immerjs/immer",                   "ref": "a3be9df762c1dbe9959a011ddbab0ce838cbc468", "lang": "ts", "roots": ["src", "__tests__"] },
+    { "name": "rxjs",           "repo": "ReactiveX/rxjs",                  "ref": "c15b37f81ba5f5abea8c872b0189a70b150df4cb", "lang": "ts", "roots": ["packages/rxjs/src", "packages/rxjs/spec"] },
     { "name": "returns",        "repo": "dry-python/returns",              "ref": "04e820c714615192baf815bcbe15eccbbd15541e", "lang": "py", "roots": ["returns", "tests"] },
     { "name": "result",         "repo": "rustedpy/result",                 "ref": "0b855e1e38a08d6f0a4b0138b10c127c01e54ab4", "lang": "py", "roots": ["src", "tests"] },
     { "name": "more-itertools", "repo": "more-itertools/more-itertools",   "ref": "5d946b3590bfe92f1465c1b9b9830dd434745c84", "lang": "py", "roots": ["more_itertools", "tests"] },

--- a/.github/compat/rxjs/Smelt.toml
+++ b/.github/compat/rxjs/Smelt.toml
@@ -1,0 +1,24 @@
+[project]
+name = "rxjs"
+version = "0.0.0"
+description = "RxJS Smelt probe"
+
+[sources]
+roots = ["packages/rxjs/src", "packages/rxjs/spec"]
+test-globs = ["**/*-spec.ts"]
+entries = ["packages/rxjs/src/index.ts"]
+
+[output]
+target = "./dist-smelt"
+crate-name = "rxjs_probe"
+build = false
+
+[rust]
+edition = "2024"
+
+[strict]
+typescript = true
+python = true
+
+[runtime]
+clone-strategy = "aggressive"


### PR DESCRIPTION
## Summary

- add pinned Immer and RxJS entries to the daily compatibility probe set
- add manifests for Immer source and TypeScript tests and RxJS source and runtime specs
- document why upstream JavaScript benchmark files are not scanned yet

## Impact

The daily probe now tracks 24 Immer and 376 RxJS TypeScript files, exposing compatibility blockers in two widely used typed libraries.

## Validation

- cargo check --lib --no-default-features: passes
- both manifests load and reach expected upstream test blockers
- pinned refs, roots, entries, JSON, and TOML validated against fresh upstream checkouts
- cargo clippy --lib --no-default-features: blocked by pre-existing main errors in new_expr.rs, callbacks/closures.rs, and map.rs
- cargo test: reached one pre-existing TypeScript specialization parity fixture compilation failure after 675 codegen tests passed