### PR TITLE
fix(frontend-ts): ternary-arm side effects and strict-eq on typeof-narrowed functions

### DIFF
--- a/crates/smelt-frontend-ts/src/lowering/expr/operators.rs
+++ b/crates/smelt-frontend-ts/src/lowering/expr/operators.rs
@@ -1215,8 +1215,22 @@ impl ModuleBuilder<'_> {
                 ));
             }
         };
-        let lhs = self.expression(&binary.left, body)?;
-        let rhs = self.expression(&binary.right, body)?;
+        let mut lhs = self.expression(&binary.left, body)?;
+        let mut rhs = self.expression(&binary.right, body)?;
+        // JavaScript `===`/`!==` on erased values compares the ORIGINAL erased
+        // `SmeltUnknown` (reference identity for objects/arrays/functions, value
+        // for primitives). A `typeof`-guard narrows an operand to a concrete
+        // type (e.g. `Function`), which lowers the reference as an
+        // `UnknownCast` that re-materializes the value through an adapter — for
+        // a function that means a FRESH `Rc` whose `Rc::ptr_eq` never matches,
+        // so `f === f` wrongly yields `false`. The narrowing carries no benefit
+        // for a bare strict-equality operand, so peel it back to the pre-cast
+        // erased value and let both sides compare as the untouched originals.
+        if matches!(op, BinOp::JsStrictEq | BinOp::JsStrictNotEq) {
+            lhs = self.peel_narrowing_cast_for_identity(body, lhs);
+            rhs = self.peel_narrowing_cast_for_identity(body, rhs);
+        }
+
         let lhs_ty = Self::expr_ty(body, lhs);
         let rhs_ty = Self::expr_ty(body, rhs);
         let ty = self.binary_result_type(op, lhs_ty, rhs_ty);
@@ -1225,6 +1239,60 @@ impl ModuleBuilder<'_> {
             ty,
             span: self.span(binary.span.start, binary.span.end),
         }))
+    }
+
+    /// Peel a narrowing [`ExprKind::UnknownCast`] off a strict-equality operand.
+    ///
+    /// A `typeof`/`instanceof` guard narrows an erased local to a concrete type
+    /// via an `UnknownCast` whose inner value is still an erased `SmeltUnknown`.
+    /// For a bare `===`/`!==` operand the narrowed concrete type is discarded
+    /// anyway (the comparison lowers through `js_strict_eq` on the erased
+    /// representation), and materializing the concrete shape can re-wrap the
+    /// value through an adapter that breaks JS reference identity (a function
+    /// becomes a fresh `Rc`, so `f === f` is `false`). Returning the pre-cast
+    /// erased value keeps the comparison on the untouched original. Only peels
+    /// when the inner value is genuinely erased, so ordinary casts are left
+    /// intact.
+    pub(in crate::lowering) fn peel_narrowing_cast_for_identity(
+        &self,
+        body: &mut Body,
+        expr: smelt_hir::ExprId,
+    ) -> smelt_hir::ExprId {
+        let index = usize::try_from(expr.0).expect("expr id should fit into usize");
+        let Some(Expr {
+            kind: ExprKind::UnknownCast { value, .. },
+            span,
+            ..
+        }) = body.exprs.get(index)
+        else {
+            return expr;
+        };
+        let inner = *value;
+        let span = *span;
+        // The narrowing cast rewraps a `Local` read at the narrowed type; recover
+        // the local and re-read it at its erased base type so the comparison sees
+        // the untouched original `SmeltUnknown`.
+        let inner_index = usize::try_from(inner.0).expect("expr id should fit into usize");
+        let Some(Expr {
+            kind: ExprKind::Local(local),
+            ..
+        }) = body.exprs.get(inner_index)
+        else {
+            return expr;
+        };
+        let local = *local;
+        let base_ty = Self::local_ty(body, local);
+        if matches!(
+            self.ctx.krate.types.get(base_ty),
+            Some(Type::Unknown | Type::Union(_) | Type::TypeParam { .. })
+        ) {
+            return body.push_expr(Expr {
+                kind: ExprKind::Local(local),
+                ty: base_ty,
+                span,
+            });
+        }
+        expr
     }
 
     /// Lower a logical expression.

--- a/crates/smelt-frontend-ts/src/lowering/new_expr.rs
+++ b/crates/smelt-frontend-ts/src/lowering/new_expr.rs
@@ -2015,8 +2015,17 @@ impl ModuleBuilder<'_> {
                         ));
                     }
                 };
-                let lhs = self.expression(&binary.left, body)?;
-                let rhs = self.expression(&binary.right, body)?;
+                let mut lhs = self.expression(&binary.left, body)?;
+                let mut rhs = self.expression(&binary.right, body)?;
+                // Strict-equality operands narrowed by a `typeof` guard must stay
+                // the erased originals: re-materializing a narrowed function
+                // through an adapter builds a fresh `Rc` whose `Rc::ptr_eq` never
+                // matches, so `f === f` would wrongly be `false`. See the peel in
+                // `binary_expression` for the full rationale.
+                if matches!(op, BinOp::JsStrictEq | BinOp::JsStrictNotEq) {
+                    lhs = self.peel_narrowing_cast_for_identity(body, lhs);
+                    rhs = self.peel_narrowing_cast_for_identity(body, rhs);
+                }
                 let lhs_ty = Self::expr_ty(body, lhs);
                 let rhs_ty = Self::expr_ty(body, rhs);
                 let ty = if op == BinOp::Add
@@ -2105,12 +2114,14 @@ impl ModuleBuilder<'_> {
                     return self.expression_with_hint(&conditional.consequent, body, type_hint);
                 }
                 let cond = self.condition_expression(&conditional.test, body)?;
+                let arm_span = self.span(conditional.span.start, conditional.span.end);
                 let then_narrowing = self.guard_narrowing(&conditional.test, body);
                 if let Some(narrowing) = then_narrowing.clone() {
                     self.narrowed_locals.push(narrowing);
                 }
-                let then_expr =
-                    self.expression_with_hint(&conditional.consequent, body, type_hint)?;
+                let then_expr = self.lower_conditional_arm(body, arm_span, |slf, body| {
+                    slf.expression_with_hint(&conditional.consequent, body, type_hint)
+                })?;
                 if then_narrowing.is_some() {
                     self.narrowed_locals.pop();
                 }
@@ -2119,8 +2130,9 @@ impl ModuleBuilder<'_> {
                 if let Some(narrowing) = else_narrowing.clone() {
                     self.narrowed_locals.push(narrowing);
                 }
-                let else_expr =
-                    self.expression_with_hint(&conditional.alternate, body, branch_hint)?;
+                let else_expr = self.lower_conditional_arm(body, arm_span, |slf, body| {
+                    slf.expression_with_hint(&conditional.alternate, body, branch_hint)
+                })?;
                 if else_narrowing.is_some() {
                     self.narrowed_locals.pop();
                 }
@@ -2552,6 +2564,43 @@ impl ModuleBuilder<'_> {
     }
 
     /// Lower a TypeScript conditional expression when it appears outside normal expression nodes.
+    /// Lower one arm of a conditional expression, capturing any statement-level
+    /// side effects it produces into a per-arm block so they run only when that
+    /// arm is taken.
+    ///
+    /// Effectful sub-expressions such as a postfix `k++` inside `xs[k++]` lower
+    /// their store into `self.current_statement_block` (see `update_expression`).
+    /// For a ternary operand that block is the *enclosing* statement block, so
+    /// without redirection the increment is hoisted out of the branch and runs
+    /// unconditionally on every evaluation — the es-toolkit `partial`/
+    /// `partialRight` `providedArgs[idx++]` placeholder bug. Redirecting the arm
+    /// to a fresh block and wrapping it as an `ExprKind::Block` (tail = the arm
+    /// value) keeps the increment inside the arm, where MIR lowers it within the
+    /// matching switch branch. Arms with no side effects return their expression
+    /// unwrapped so simple ternaries are unchanged.
+    fn lower_conditional_arm(
+        &mut self,
+        body: &mut Body,
+        span: Span,
+        lower: impl FnOnce(&mut Self, &mut Body) -> Result<smelt_hir::ExprId, SmeltError>,
+    ) -> Result<smelt_hir::ExprId, SmeltError> {
+        let arm_block = body.push_block(span);
+        let previous_block = self.current_statement_block.replace(arm_block);
+        let arm_result = lower(self, body);
+        self.current_statement_block = previous_block;
+        let arm_expr = arm_result?;
+        if body.blocks[arm_block.0 as usize].stmts.is_empty() {
+            return Ok(arm_expr);
+        }
+        body.blocks[arm_block.0 as usize].tail = Some(arm_expr);
+        let ty = Self::expr_ty(body, arm_expr);
+        Ok(body.push_expr(Expr {
+            kind: ExprKind::Block(arm_block),
+            ty,
+            span,
+        }))
+    }
+
     pub(super) fn conditional_expression(
         &mut self,
         conditional: &oxc::ast::ast::ConditionalExpression<'_>,
@@ -2574,9 +2623,14 @@ impl ModuleBuilder<'_> {
             return self.expression_with_hint(&conditional.consequent, body, type_hint);
         }
         let cond = self.condition_expression(&conditional.test, body)?;
-        let then_expr = self.expression_with_hint(&conditional.consequent, body, type_hint)?;
+        let arm_span = self.span(conditional.span.start, conditional.span.end);
+        let then_expr = self.lower_conditional_arm(body, arm_span, |slf, body| {
+            slf.expression_with_hint(&conditional.consequent, body, type_hint)
+        })?;
         let branch_hint = Some(Self::expr_ty(body, then_expr));
-        let else_expr = self.expression_with_hint(&conditional.alternate, body, branch_hint)?;
+        let else_expr = self.lower_conditional_arm(body, arm_span, |slf, body| {
+            slf.expression_with_hint(&conditional.alternate, body, branch_hint)
+        })?;
         let then_ty = Self::expr_ty(body, then_expr);
         let else_ty = Self::expr_ty(body, else_expr);
         let ty = self.conditional_branch_type(

--- a/crates/smelt-frontend-ts/src/tests/estk_mir_gate_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/estk_mir_gate_tests.rs
@@ -107,6 +107,59 @@ export function pick<T>(values: Array<(a: T, b: T) => boolean>): (a: T, b: T) =>
     Ok(())
 }
 
+/// `typeof a === 'function'` narrowing must NOT re-materialize the operand for
+/// a following `a === b` reference check. Narrowing lowers a bare reference as
+/// an `UnknownCast` to `Function`, which the emitter would extract into a fresh
+/// `Rc` closure before `js_strict_eq` — and `Rc::ptr_eq` on a freshly built
+/// closure never matches, so `f === f` would wrongly be `false`. The
+/// strict-equality operands must stay the erased originals (this mirrors
+/// es-toolkit `isEqualWith`'s `case 'function': return a === b`).
+#[test]
+fn typeof_function_strict_eq_compares_erased_originals() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r"
+export function pick(a: unknown, b: unknown): boolean {
+  if (typeof a === 'function' && typeof b === 'function') {
+    return a === b;
+  }
+  return false;
+}
+"),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = named_function_item(&ctx, module, "pick")?;
+    let body = function_body(&ctx, function)?;
+    let strict_eq = body
+        .exprs
+        .iter()
+        .find_map(|expr| match &expr.kind {
+            ExprKind::BinOp {
+                op: BinOp::JsStrictEq,
+                lhs,
+                rhs,
+            } => Some((*lhs, *rhs)),
+            _ => None,
+        })
+        .ok_or_else(|| "expected a `JsStrictEq` comparison for `a === b`".to_owned())?;
+    for operand in [strict_eq.0, strict_eq.1] {
+        let index = usize::try_from(operand.0).expect("expr id should fit into usize");
+        let operand_expr = &body.exprs[index];
+        ensure!(
+            !matches!(&operand_expr.kind, ExprKind::UnknownCast { .. }),
+            "strict-equality operand must be the erased original, not an \
+             `UnknownCast` that re-materializes a fresh function",
+        );
+        ensure!(
+            matches!(ctx.krate.types.get(operand_expr.ty), Some(Type::Unknown)),
+            "strict-equality operand must keep its erased `unknown` type so it \
+             compares via `js_strict_eq` on the original value",
+        );
+    }
+    Ok(())
+}
+
 /// A non-`async` test callback that returns `expect(promise).rejects.toThrow()`
 /// desugars into an inlined `await`, so the synthesized test function must be
 /// marked async (emitting `#[tokio::test] async fn`), matching JavaScript's

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -9000,3 +9000,56 @@ export function build(): boolean {
     );
     Ok(())
 }
+
+#[test]
+fn postfix_increment_in_ternary_consequent_stays_in_arm_block() -> Result<(), String> {
+    // Regression: a postfix `k++` inside a ternary consequent (`cond ? xs[k++] :
+    // y`) must increment `k` only when the consequent arm is taken. The update's
+    // store was previously pushed into the enclosing statement block, hoisting
+    // the increment out of the branch so it ran unconditionally — the es-toolkit
+    // `partial`/`partialRight` `providedArgs[idx++]` placeholder bug. The arm's
+    // side effects must now live in an `ExprKind::Block` wrapping the consequent.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r"
+export function pick(cond: boolean, xs: number[], y: number): number {
+  let k = 0;
+  return cond ? xs[k++] : y;
+}
+"),
+        &mut ctx,
+    )?;
+    let module = module(&ctx, module_id)?;
+    let function = function_item(&ctx, module, 0)?;
+    let body = function_body(&ctx, function)?;
+
+    // Locate the ternary and confirm its consequent is a block-wrapped arm whose
+    // block carries the increment store (a `Let`/`Assign`), not a bare index.
+    let then_expr = body
+        .exprs
+        .iter()
+        .find_map(|expr| match expr.kind {
+            ExprKind::Conditional { then_expr, .. } => Some(then_expr),
+            _ => None,
+        })
+        .ok_or_else(|| "no Conditional expression lowered".to_owned())?;
+    let ExprKind::Block(arm_block) = body.exprs[then_expr.0 as usize].kind else {
+        return Err("ternary consequent was not wrapped in an arm block".to_owned());
+    };
+    ensure!(
+        !body.blocks[arm_block.0 as usize].stmts.is_empty(),
+        "consequent arm block does not carry the `k++` increment store",
+    );
+
+    // The increment store must NOT be hoisted into the function root block.
+    let root_has_assign = body.blocks[body.root.0 as usize]
+        .stmts
+        .iter()
+        .any(|stmt_id| matches!(body.stmts[stmt_id.0 as usize], Stmt::Assign { .. }));
+    ensure!(
+        !root_has_assign,
+        "postfix increment store was hoisted to the enclosing statement block",
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}


### PR DESCRIPTION
Two general lowering fixes from the es-toolkit runtime campaign:

- **Ternary-arm side effects stayed unconditional**: a postfix increment inside a conditional-expression arm was pushed to the enclosing statement block — es-toolkit `partial`'s `cond ? providedArgs[i++] : args[i]` advanced the index on every iteration and dropped remaining arguments. Arms now lower through per-arm blocks. partial/partialRight: 13 → 10 failed.
- **`f === f` false after `typeof` narrowing**: the narrowing `UnknownCast` fed into `===` made the emitter re-wrap the callback in a fresh `Rc`, so pointer identity never matched. Strict-eq operands now peel the narrowing cast when the underlying local is erased and compare the original `SmeltUnknown` via `js_strict_eq`. Avoidable erasure −4.

## Verification
frontend-ts 920/0, mir + codegen green; es-toolkit `cargo check` 0 errors; remeda 1789/1789; goldens 9/9; corpus green; SmeltUnknown ratchet exit 0 (no re-snapshot needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)