### PR TITLE
fix(frontend-ts): overload rest-slot leak across same-named imports

### DIFF
--- a/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
+++ b/crates/smelt-frontend-ts/src/lowering/stdlib/call_dispatch.rs
@@ -692,6 +692,17 @@ impl<'builder> ModuleBuilder<'builder> {
                     }
                 }
             };
+            // Adopt a rest slot from the selected overload only when it names a
+            // valid rest position within *this* resolved item's own parameters.
+            // `selected_overload` is keyed by the bare callee name, so a
+            // same-named export in another module (compat's variadic
+            // `merge(object, ...sources)`) can be picked even when the explicit
+            // relative import resolved to a different, fixed-arity function
+            // (object's `merge(target, source)`). Without this guard the
+            // compat rest leaks in and packs the trailing positional argument
+            // into a spurious array. Mirrors the `function_rests` guard above:
+            // the concretely resolved item is the source of truth for whether a
+            // parameter slot is variadic.
             if rest.is_none()
                 && let Some(signature) = &selected_overload
                 && let Some(index) = signature.rest
@@ -699,6 +710,13 @@ impl<'builder> ModuleBuilder<'builder> {
                     .params
                     .get(index)
                     .and_then(|param| self.ctx.krate.types.get(*param))
+                && index < params.len()
+                && matches!(
+                    params
+                        .get(index)
+                        .and_then(|param| self.ctx.krate.types.get(*param)),
+                    Some(Type::List(_))
+                )
             {
                 rest = Some(RestParam {
                     index,

--- a/crates/smelt-frontend-ts/src/tests/estk6_coverage_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/estk6_coverage_tests.rs
@@ -777,3 +777,69 @@ export function useNs(value: unknown): unknown {
     ensure!(smelt_hir::validate(&ctx.krate).is_empty());
     Ok(())
 }
+
+/// An explicit relative import binds to *that* module's export, and rest-param
+/// packing follows the resolved function's own signature — never a same-named
+/// export from a different module.
+///
+/// A variadic `merge(object, ...sources)` in one module and a fixed two-param
+/// `merge(target, source)` in another collide on the bare name `merge` in the
+/// cross-module overload/rest tables (keyed by name only). A spec that imports
+/// the two-param `merge` via `./merge` must call it with two positional
+/// arguments; the compat overload's rest slot must not leak in and pack the
+/// trailing `source` into an array (`ExprKind::ListLit`). This mirrors es-toolkit
+/// `object/merge.spec.ts`, whose call previously lowered as
+/// `merge(target, [source])` and produced a result keyed by `"0"`.
+#[test]
+fn relative_import_uses_own_signature_not_same_named_variadic_rest() -> Result<(), String> {
+    let mut ctx = HirCtx::new();
+    // Variadic sibling lowered first so its rest/overload signatures populate
+    // the name-keyed cross-module tables for `merge`.
+    lower_path_ok(
+        ts!(r"
+export function merge<T, U>(object: T, source: U): T & U;
+export function merge<T, U, V>(object: T, source1: U, source2: V): T & U & V;
+export function merge(object: any, ...otherArgs: any[]): any;
+export function merge(object: any, ...sources: any[]): any {
+  return object;
+}
+"),
+        "compat_merge.ts",
+        &mut ctx,
+    )?;
+    // Fixed two-parameter `merge` — the explicit import target.
+    lower_path_ok(
+        ts!(r"
+export function merge<T extends Record<PropertyKey, any>, S extends Record<PropertyKey, any>>(
+  target: T,
+  source: S,
+): T & S {
+  return target;
+}
+"),
+        "merge.ts",
+        &mut ctx,
+    )?;
+    lower_path_ok(
+        ts!(r"
+import { merge } from './merge';
+export function run(): unknown {
+  const target = { a: 1, b: 2 };
+  const source = { b: 3, c: 4 };
+  return merge(target, source);
+}
+"),
+        "merge.spec.ts",
+        &mut ctx,
+    )?;
+    // The trailing `source` argument must stay positional. Both source object
+    // literals lower to records, and neither `merge` implementation builds a
+    // list, so any `ExprKind::ListLit` in the crate is the spurious rest array
+    // packed from the compat overload — the regression this guards.
+    ensure!(
+        !crate_has(&ctx, |kind| matches!(kind, ExprKind::ListLit(_))),
+        "relative-imported two-param `merge` must not pack `source` into a rest array",
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}


### PR DESCRIPTION
The overload/rest metadata tables are keyed by bare function name, so a spec explicitly importing the strict 2-param `merge(target, source)` still picked up the compat `merge(object, ...sources)` rest slot and packed the source into a spurious array (merged result got key `"0"`). The consumption site now applies an overload-derived rest slot only when the rest index names a List slot in the resolved item's own parameters (mirrors the existing `function_rests` guard). Full module-attribution of the overload table is a noted deeper follow-up.

es-toolkit `merge_spec`: **11 → 2 failed** (the 2 residuals are deep-merge semantics, unrelated). SmeltUnknown avoidable **−52**. New multi-module regression test (fails pre-fix).

## Verification
frontend-ts 924/0; es-toolkit `cargo check` 0 errors; remeda 1789/1789; goldens 9/9; corpus green; ratchet exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)