### PR TITLE
feat(codegen-rust): give JS Set a runtime identity across erasure (stage 3)

### DIFF
--- a/blocker-logs/smelt-unknown-baseline-es-toolkit.json
+++ b/blocker-logs/smelt-unknown-baseline-es-toolkit.json
@@ -1,10 +1,10 @@
 {
   "files_scanned": 745,
-  "total": 73543,
+  "total": 74770,
   "category_totals": {
-    "avoidable-erasure": 35371,
-    "legitimate-boundary": 36170,
-    "runtime-prelude": 2002
+    "avoidable-erasure": 35323,
+    "legitimate-boundary": 37173,
+    "runtime-prelude": 2274
   },
   "shapes": [
     {
@@ -17,7 +17,7 @@
     {
       "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: SmeltUnknown;",
-      "occurrences": 1556,
+      "occurrences": 1559,
       "files": 210,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/AbortError_spec.rs:18"
     },
@@ -33,7 +33,7 @@
       "shape": "_smelt_tmp_N = match _smelt_tmp_N.clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true };",
       "occurrences": 730,
       "files": 8,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:451"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:471"
     },
     {
       "category": "avoidable-erasure",
@@ -106,6 +106,20 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/AbortError_spec.rs:78"
     },
     {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 450,
+      "files": 4,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_spec.rs:495"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 440,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isTypedArray_spec.rs:73"
+    },
+    {
       "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = matches!(target_value.clone(), SmeltUnknown::Undefined);",
       "occurrences": 433,
@@ -134,13 +148,6 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/allKeyed.rs:10"
     },
     {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 420,
-      "files": 4,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_spec.rs:495"
-    },
-    {
       "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltUnknown> = vec![SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN)]; smelt_list_items }));",
       "occurrences": 376,
@@ -162,11 +169,25 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/allKeyed.rs:19"
     },
     {
+      "category": "runtime-prelude",
+      "shape": "Self::MN(match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) }).collect(), _ => SmeltRecord::new() })",
+      "occurrences": 370,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5400"
+    },
+    {
       "category": "legitimate-boundary",
       "shape": "_smelt_tmp_N = match _smelt_tmp_N.get(&\"S\".to_owned()).unwrap_or(SmeltUnknown::Null).clone().clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() };",
       "occurrences": 352,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:242"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "if matches!(value, SmeltUnknown::Object(_)) { return Self::MN(match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) }).collect(), _ => SmeltRecord::new() }); }",
+      "occurrences": 344,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5399"
     },
     {
       "category": "avoidable-erasure",
@@ -195,13 +216,6 @@
       "occurrences": 338,
       "files": 39,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/assignValue.rs:20"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 320,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isTypedArray_spec.rs:73"
     },
     {
       "category": "legitimate-boundary",
@@ -247,10 +261,24 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<fN> = { let smelt_src = (clone_deep_N({ let smelt_l = arr.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })?).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
+      "occurrences": 276,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:66"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "_smelt_tmp_N = { let smelt_function = match SmeltUnknown::Null.clone().clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltList<SmeltUnknown>) -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltList<SmeltUnknown>) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltList<SmeltUnknown>| -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(argN); smelt_call_args.push(SmeltUnknown::Array(argN.into())); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltList<SmeltUnknown>) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltList<SmeltUnknown>| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } };",
       "occurrences": 273,
       "files": 9,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/bind.rs:79"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (target_value.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 270,
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/defaultsDeep.rs:220"
     },
     {
       "category": "avoidable-erasure",
@@ -260,13 +288,6 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/AbortError_spec.rs:77"
     },
     {
-      "category": "runtime-prelude",
-      "shape": "Self::MN(match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) }).collect(), _ => SmeltRecord::new() })",
-      "occurrences": 256,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5386"
-    },
-    {
       "category": "avoidable-erasure",
       "shape": "SmeltUnknown::Object(SmeltObject::from_unknown_record((_smelt_tmp_N.clone()).clone()))",
       "occurrences": 256,
@@ -274,25 +295,11 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:614"
     },
     {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (target_value.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 252,
-      "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/defaultsDeep.rs:220"
-    },
-    {
       "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = windowed_N(_smelt_tmp_N.clone(), N.N, Some(N.N), Default::default()).unwrap_or_else(|error| panic!(\"S\", error));",
       "occurrences": 246,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/windowed_spec.rs:219"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "if matches!(value, SmeltUnknown::Object(_)) { return Self::MN(match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) }).collect(), _ => SmeltRecord::new() }); }",
-      "occurrences": 239,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5385"
     },
     {
       "category": "legitimate-boundary",
@@ -307,6 +314,13 @@
       "occurrences": 224,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:276"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 224,
+      "files": 5,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/ary_spec.rs:23"
     },
     {
       "category": "legitimate-boundary",
@@ -331,10 +345,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
+      "shape": "let _smelt_tmp_N: SmeltUnknown = SMELT_HOST_OVERRIDE_FILE.with(|slot| smelt_host_override_write(slot, SmeltUnknown::Function({ let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_object_value = (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }, Some(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null))); let smelt_struct_value = smelt_object_value.clone(); let mut smelt_object_entries = ::std::collections::HashMap::new(); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::String(smelt_object_value.name)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); SmeltUnknown::Object(SmeltObject::new(smelt_object_entries)) })) })));",
       "occurrences": 210,
-      "files": 5,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/ary_spec.rs:23"
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isFile_spec.rs:28"
     },
     {
       "category": "legitimate-boundary",
@@ -345,20 +359,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<fN> = { let smelt_src = (clone_deep_N({ let smelt_l = arr.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })?).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
-      "occurrences": 204,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:66"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltUnknown = SMELT_HOST_OVERRIDE_FILE.with(|slot| smelt_host_override_write(slot, SmeltUnknown::Function({ let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_object_value = (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }, Some(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null))); let smelt_struct_value = smelt_object_value.clone(); let mut smelt_object_entries = ::std::collections::HashMap::new(); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::String(smelt_object_value.name)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); SmeltUnknown::Object(SmeltObject::new(smelt_object_entries)) })) })));",
-      "occurrences": 204,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isFile_spec.rs:28"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "_smelt_tmp_N = match key.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() };",
       "occurrences": 200,
       "files": 1,
@@ -366,10 +366,24 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (array.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 195,
+      "files": 10,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/differenceBy.rs:26"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = (get_value_by_nested_path)(closure_arg_N.clone(), { let smelt_src = (_smelt_tmp_N.get(&\"S\".to_owned()).unwrap_or(SmeltUnknown::Null).clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| value).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 192,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:269"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "_smelt_tmp_N = match (_smelt_tmp_N).into_smelt_unknown() { SmeltUnknown::Object(value) => SmeltRecord::with_id_from_entries(value.id, value.into_iter()), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), value)).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| (index.to_string(), SmeltUnknown::String(ch.to_string()))).collect(), SmeltUnknown::Function(value) => SmeltRecord::from([(\"S\".to_owned(), SmeltUnknown::Function(value))]), _ => SmeltRecord::new() };",
       "occurrences": 192,
       "files": 21,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:91"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:92"
     },
     {
       "category": "legitimate-boundary",
@@ -387,10 +401,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (array.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 182,
-      "files": 10,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/differenceBy.rs:26"
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (source_value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 180,
+      "files": 3,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/merge.rs:94"
     },
     {
       "category": "legitimate-boundary",
@@ -401,10 +415,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = (get_value_by_nested_path)(closure_arg_N.clone(), { let smelt_src = (_smelt_tmp_N.get(&\"S\".to_owned()).unwrap_or(SmeltUnknown::Null).clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| value).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
       "occurrences": 176,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:269"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:283"
     },
     {
       "category": "avoidable-erasure",
@@ -450,17 +464,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (source_value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 168,
-      "files": 3,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/merge.rs:94"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 160,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:283"
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 165,
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flattenObject.rs:98"
     },
     {
       "category": "legitimate-boundary",
@@ -485,17 +492,31 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 154,
-      "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flattenObject.rs:98"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "_smelt_tmp_N = match closure_arg_N.clone().clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN };",
       "occurrences": 154,
       "files": 3,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_spec.rs:368"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N = { let smelt_callback = curry_N(SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| { let smelt_l = (smelt_callback)(match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) }) }, length: N.N, object: None }).clone(); let smelt_adapted: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| { let smelt_function = match smelt_callback.call(vec![(argN).into_smelt_unknown()]).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_function = match smelt_result.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_function = match smelt_result.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_src = (smelt_result).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } } } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } }); smelt_default_callback } } } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } }); smelt_default_callback } }); smelt_default_callback } } }); smelt_adapted };",
+      "occurrences": 147,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/curry_spec.rs:53"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N = { let smelt_callback = curry_right_N(SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| { let smelt_l = (smelt_callback)(match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) }) }, length: N.N, object: None }).clone(); let smelt_adapted: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| { let smelt_function = match smelt_callback.call(vec![(argN).into_smelt_unknown()]).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_function = match smelt_result.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_function = match smelt_result.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_src = (smelt_result).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } } } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } }); smelt_default_callback } } } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } }); smelt_default_callback } }); smelt_default_callback } } }); smelt_adapted };",
+      "occurrences": 147,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/curryRight_spec.rs:53"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltRecord<String, SmeltList<fN>> = match (merge_with_N({ let smelt_record = (targetN).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).collect())) }, { let smelt_record = (sourceN).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).collect())) }, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: String, argN: SmeltUnknown, argN: SmeltUnknown| (_smelt_adapted_callback)(argN, argN) })).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) }).collect(), _ => SmeltRecord::new() };",
+      "occurrences": 146,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/mergeWith_spec.rs:105"
     },
     {
       "category": "avoidable-erasure",
@@ -524,6 +545,20 @@
       "occurrences": 144,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/mergeWith_1.rs:342"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = ((*smelt_capture_recursive.borrow()))({ let smelt_src = (item.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }, _smelt_tmp_N.clone());",
+      "occurrences": 143,
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatten.rs:78"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltRecord<String, SmeltList<fN>> = match (to_merged({ let smelt_record = (target.clone()).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).collect())) }, { let smelt_record = (source).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).collect())) })?).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) }).collect(), _ => SmeltRecord::new() };",
+      "occurrences": 142,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toMerged_spec.rs:439"
     },
     {
       "category": "legitimate-boundary",
@@ -569,24 +604,24 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N = { let smelt_callback = curry_N(SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| { let smelt_l = (smelt_callback)(match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) }) }, length: N.N, object: None }).clone(); let smelt_adapted: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| { let smelt_function = match smelt_callback.call(vec![(argN).into_smelt_unknown()]).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_function = match smelt_result.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_function = match smelt_result.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_src = (smelt_result).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } } } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } }); smelt_default_callback } } } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } }); smelt_default_callback } }); smelt_default_callback } } }); smelt_adapted };",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
       "occurrences": 135,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/curry_spec.rs:53"
+      "files": 6,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_1.rs:150"
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N = { let smelt_callback = curry_right_N(SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| { let smelt_l = (smelt_callback)(match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) }) }, length: N.N, object: None }).clone(); let smelt_adapted: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| { let smelt_function = match smelt_callback.call(vec![(argN).into_smelt_unknown()]).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_function = match smelt_result.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_function = match smelt_result.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); { let smelt_src = (smelt_result).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } } } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } }); smelt_default_callback } } } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltList<fN>> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltList<fN> { SmeltList::new(Vec::<fN>::new()) }); smelt_default_callback } }); smelt_default_callback } }); smelt_default_callback } } }); smelt_adapted };",
-      "occurrences": 135,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/curryRight_spec.rs:53"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = ((*smelt_capture_recursive.borrow()))({ let smelt_src = (item.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }, _smelt_tmp_N.clone());",
-      "occurrences": 130,
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (buffer).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 132,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatten.rs:78"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_1.rs:222"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (cloned_buffer).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 132,
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_1.rs:225"
     },
     {
       "category": "legitimate-boundary",
@@ -594,6 +629,13 @@
       "occurrences": 130,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/reduceAsync_spec.rs:47"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (predicate.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| { let smelt_value = value.clone(); let smelt_function = match smelt_value.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_function)(smelt_args).unwrap_or_else(|error| panic!(\"S\", error))), length: N.N, object: match smelt_value { SmeltUnknown::Object(object) => Some(object), _ => None } } } else { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None } } }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| { let smelt_value = value.clone(); let smelt_function = match smelt_value.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_function)(smelt_args).unwrap_or_else(|error| panic!(\"S\", error))), length: N.N, object: match smelt_value { SmeltUnknown::Object(object) => Some(object), _ => None } } } else { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None } } }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| { let smelt_value = value.clone(); let smelt_function = match smelt_value.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_function)(smelt_args).unwrap_or_else(|error| panic!(\"S\", error))), length: N.N, object: match smelt_value { SmeltUnknown::Object(object) => Some(object), _ => None } } } else { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None } } }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 128,
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/overEvery.rs:60"
     },
     {
       "category": "avoidable-erasure",
@@ -608,13 +650,6 @@
       "occurrences": 128,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:617"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 126,
-      "files": 6,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_1.rs:150"
     },
     {
       "category": "legitimate-boundary",
@@ -639,6 +674,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltRecord<String, fN>> = { let smelt_src = (clone_deep_N({ let smelt_l = arr.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_record = (value).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, SmeltUnknown::Number(value as fN))).collect())) }).collect::<Vec<_>>())) })?).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
+      "occurrences": 125,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:120"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = xor_with_N(_smelt_tmp_N, _smelt_tmp_N, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown| (_smelt_adapted_callback)(match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) });",
       "occurrences": 125,
       "files": 1,
@@ -650,6 +692,20 @@
       "occurrences": 125,
       "files": 62,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/AbortError_spec.rs:61"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (item.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 121,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatten.rs:83"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (source.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 121,
+      "files": 4,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/filter.rs:78"
     },
     {
       "category": "legitimate-boundary",
@@ -712,7 +768,7 @@
       "shape": "let _smelt_tmp_N: bool = is_equal_with_N(SmeltUnknown::Array(_smelt_tmp_N.clone().into()), SmeltUnknown::Array(_smelt_tmp_N.clone().into()), Some(::std::rc::Rc::new({ let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: Option<SmeltUnknown>, argN: SmeltUnknown, argN: SmeltUnknown, argN: SmeltUnknown| { let smelt_optional_source = _smelt_adapted_callback.call({ let mut smelt_forwarded_args = Vec::new(); smelt_forwarded_args.push(argN); smelt_forwarded_args.push(argN); smelt_forwarded_args.push(argN.clone().map_or(SmeltUnknown::Undefined, |value| value)); smelt_forwarded_args.push(argN); smelt_forwarded_args.push(argN); smelt_forwarded_args.push(argN); Into::<SmeltList<_>>::into(smelt_forwarded_args) }); if smelt_unknown_is_nullish(&smelt_optional_source.clone()) { None } else { Some(match smelt_optional_source.clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true }) } } })));",
       "occurrences": 114,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:51"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:53"
     },
     {
       "category": "avoidable-erasure",
@@ -727,27 +783,6 @@
       "occurrences": 114,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_spec.rs:25"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (item.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 110,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatten.rs:83"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (source.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 110,
-      "files": 4,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/filter.rs:78"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltRecord<String, SmeltList<fN>> = match (merge_with_N({ let smelt_record = (targetN).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).collect())) }, { let smelt_record = (sourceN).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).collect())) }, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: String, argN: SmeltUnknown, argN: SmeltUnknown| (_smelt_adapted_callback)(argN, argN) })).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) }).collect(), _ => SmeltRecord::new() };",
-      "occurrences": 110,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/mergeWith_spec.rs:105"
     },
     {
       "category": "legitimate-boundary",
@@ -775,7 +810,7 @@
       "shape": "if matches!(value, SmeltUnknown::Number(_)) { return Self::MN(match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }); }",
       "occurrences": 108,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4956"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4970"
     },
     {
       "category": "legitimate-boundary",
@@ -800,10 +835,17 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltRecord<String, SmeltList<fN>> = match (to_merged({ let smelt_record = (target.clone()).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).collect())) }, { let smelt_record = (source).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).collect())) })?).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) }).collect(), _ => SmeltRecord::new() };",
-      "occurrences": 106,
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (value.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 105,
+      "files": 4,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatten.rs:472"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (value_to_clone.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 105,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toMerged_spec.rs:439"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:187"
     },
     {
       "category": "legitimate-boundary",
@@ -883,39 +925,11 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/ary_spec.rs:94"
     },
     {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (value.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 98,
-      "files": 4,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatten.rs:472"
-    },
-    {
       "category": "avoidable-erasure",
       "shape": "}.clone(), ::std::rc::Rc::new({ let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>| None::<bool> }));",
       "occurrences": 98,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_spec.rs:917"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (buffer).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 96,
-      "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_1.rs:222"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (cloned_buffer).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 96,
-      "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_1.rs:225"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (predicate.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| { let smelt_value = value.clone(); let smelt_function = match smelt_value.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_function)(smelt_args).unwrap_or_else(|error| panic!(\"S\", error))), length: N.N, object: match smelt_value { SmeltUnknown::Object(object) => Some(object), _ => None } } } else { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None } } }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| { let smelt_value = value.clone(); let smelt_function = match smelt_value.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_function)(smelt_args).unwrap_or_else(|error| panic!(\"S\", error))), length: N.N, object: match smelt_value { SmeltUnknown::Object(object) => Some(object), _ => None } } } else { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None } } }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 96,
-      "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/overEvery.rs:60"
     },
     {
       "category": "legitimate-boundary",
@@ -960,11 +974,53 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/after.rs:33"
     },
     {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (a.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 90,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:50"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (arr.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 90,
+      "files": 5,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/compact.rs:17"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (b.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 90,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:51"
+    },
+    {
       "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = SmeltUnknown::Number(N.N as fN);",
       "occurrences": 89,
       "files": 18,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/attempt_spec.rs:105"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (a.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 88,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_1.rs:1167"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (b.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 88,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_1.rs:1169"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (path.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| value).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 88,
+      "files": 6,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/get.rs:208"
     },
     {
       "category": "legitimate-boundary",
@@ -981,18 +1037,11 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/debounce_spec.rs:27"
     },
     {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltRecord<String, fN>> = { let smelt_src = (clone_deep_N({ let smelt_l = arr.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_record = (value).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, SmeltUnknown::Number(value as fN))).collect())) }).collect::<Vec<_>>())) })?).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect(), _ => SmeltRecord::new() }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
-      "occurrences": 87,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:120"
-    },
-    {
       "category": "runtime-prelude",
       "shape": "fn into_smelt_unknown(self) -> SmeltUnknown {",
       "occurrences": 86,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2811"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2812"
     },
     {
       "category": "avoidable-erasure",
@@ -1007,34 +1056,6 @@
       "occurrences": 86,
       "files": 14,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/differenceBy_spec.rs:66"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (a.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 84,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:48"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (arr.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 84,
-      "files": 5,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/compact.rs:17"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (b.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 84,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:49"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (value_to_clone.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 84,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:186"
     },
     {
       "category": "legitimate-boundary",
@@ -1119,13 +1140,6 @@
       "occurrences": 81,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_spec.rs:1063"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (path.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 80,
-      "files": 6,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/get.rs:208"
     },
     {
       "category": "legitimate-boundary",
@@ -1223,7 +1237,7 @@
       "shape": "_smelt_tmp_N = { let smelt_function = match match value_to_clone.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone().clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn() -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn() -> SmeltUnknown> = ::std::rc::Rc::new(move || -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn() -> SmeltUnknown> = ::std::rc::Rc::new(move || -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } };",
       "occurrences": 77,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:281"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:301"
     },
     {
       "category": "legitimate-boundary",
@@ -1269,6 +1283,20 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (name).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 75,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/bindAll.rs:73"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (source.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 75,
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:170"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "_smelt_tmp_N = { let smelt_function_value = _smelt_tmp_N.clone(); let smelt_call_args: Vec<SmeltUnknown> = Into::into(vec![func.clone().into_smelt_unknown()]); let smelt_callable = match smelt_function_value { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function.clone()), _ => None }, _ => None }; if let Some(smelt_function) = smelt_callable { (smelt_function)(smelt_call_args).unwrap_or_else(|error| panic!(\"S\", error)) } else { SmeltUnknown::Null } };",
       "occurrences": 75,
       "files": 2,
@@ -1307,7 +1335,7 @@
       "shape": "_smelt_tmp_N = match match value_to_clone.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone().clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() };",
       "occurrences": 72,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:358"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:378"
     },
     {
       "category": "legitimate-boundary",
@@ -1321,7 +1349,14 @@
       "shape": "let _smelt_tmp_N: SmeltErasedFunction = after_N(N.N, are_values_equal.clone().clone().map_or(SmeltUnknown::Undefined, |value| { let smelt_function_value = value; let smelt_function_origin = smelt_function_value.clone(); let smelt_erased_function: ::std::rc::Rc<dyn Fn(Vec<SmeltUnknown>) -> Result<SmeltUnknown, Box<dyn std::error::Error>>> = ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>((smelt_function_value)(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null), smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null), Some(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)), smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null), smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null), smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::Bool(value)))); smelt_register_function_origin(&smelt_erased_function, smelt_function_origin); SmeltUnknown::Function(smelt_erased_function) })).unwrap_or_else(|error| panic!(\"S\", error)).clone();",
       "occurrences": 72,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:50"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:52"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = Into::<SmeltList<_>>::into((_smelt_tmp_N)(closure_arg_N.get({ let len = closure_arg_N.len() as iN; let index = N as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone(), { let smelt_src = (closure_arg_N.get({ let len = closure_arg_N.len() as iN; let index = N as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }));",
+      "occurrences": 72,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/xorBy.rs:83"
     },
     {
       "category": "legitimate-boundary",
@@ -1360,20 +1395,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (name).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 70,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/bindAll.rs:73"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (source.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 70,
-      "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:169"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N = { let smelt_source_future = SmeltFuture::from_future(Box::pin(filter_async({ let smelt_l: SmeltList<_> = (arr).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>()) }, ::std::rc::Rc::new({ let _smelt_adapted_callback = predicate.clone(); move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| { let smelt_async_callback = _smelt_adapted_callback.clone(); SmeltFuture::from_future(Box::pin(async move { let smelt_async_output = (smelt_async_callback)(match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).await?; Ok::<_, Box<dyn std::error::Error>>(match smelt_async_output.clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true }) })) } }), None::<FilterAsyncOptions>))); SmeltFuture::from_future(Box::pin(async move { let smelt_future_value = smelt_source_future.await?; Ok::<_, Box<dyn std::error::Error>>({ let smelt_l: SmeltList<_> = (smelt_future_value).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>()) }) })) };",
       "occurrences": 70,
       "files": 1,
@@ -1399,13 +1420,6 @@
       "occurrences": 68,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/partial_spec.rs:568"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = Into::<SmeltList<_>>::into((_smelt_tmp_N)(closure_arg_N.get({ let len = closure_arg_N.len() as iN; let index = N as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone(), { let smelt_src = (closure_arg_N.get({ let len = closure_arg_N.len() as iN; let index = N as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }));",
-      "occurrences": 68,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/xorBy.rs:83"
     },
     {
       "category": "legitimate-boundary",
@@ -1447,7 +1461,7 @@
       "shape": "SmeltUnknown::Object(values) => values.get(&i_N.clone().to_string()).unwrap_or(SmeltUnknown::Null),",
       "occurrences": 66,
       "files": 3,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:309"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:329"
     },
     {
       "category": "avoidable-erasure",
@@ -1461,7 +1475,7 @@
       "shape": "_smelt_tmp_N = { let timestamp_ms = (_smelt_tmp_N) as fN; let timestamp_ms = if !timestamp_ms.is_finite() || timestamp_ms == iN::MIN as fN { fN::NAN } else { timestamp_ms }; SmeltUnknown::Object(SmeltObject::new(::std::collections::HashMap::from([(\"S\".to_owned(), SmeltUnknown::Number(timestamp_ms))]))) };",
       "occurrences": 66,
       "files": 13,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:222"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:223"
     },
     {
       "category": "avoidable-erasure",
@@ -1472,17 +1486,24 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (a.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into((*smelt_capture_orders.borrow()).clone().clone().map_or(SmeltList::new(Vec::<SmeltUnknown>::new()), |value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }));",
       "occurrences": 64,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_1.rs:1167"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:100"
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (b.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into((*smelt_capture_orders.borrow()).clone().clone().map_or(SmeltList::new(Vec::<String>::new()), |value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }));",
       "occurrences": 64,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_1.rs:1169"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:1493"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(criteria.clone().clone().map_or(SmeltList::new(Vec::<SmeltUnknown>::new()), |value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }));",
+      "occurrences": 64,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:575"
     },
     {
       "category": "legitimate-boundary",
@@ -1577,6 +1598,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N = { let smelt_function = match limit_async(SmeltUnknown::Function({ let smelt_callback = callback.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_future = (smelt_callback)((smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).into_smelt_unknown(), match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, { let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }); SmeltUnknown::Promise(SmeltPromise::from_future(Box::pin(async move { let smelt_value = smelt_future.await?; Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_l = smelt_value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }) }))) })) }), _smelt_tmp_N.clone().unwrap_or(N.N)).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltList<SmeltUnknown>>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltList<SmeltUnknown>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<SmeltList<SmeltUnknown>> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push(SmeltUnknown::Number(argN as fN)); smelt_call_args.push({ let smelt_l = argN; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); SmeltFuture::from_future(Box::pin(async move { Ok::<_, Box<dyn std::error::Error>>({ let smelt_src = (smelt_result).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) })) }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltList<SmeltUnknown>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<SmeltList<SmeltUnknown>> { SmeltFuture::resolved(SmeltList::new(Vec::<SmeltUnknown>::new())) }); smelt_default_callback } } };",
+      "occurrences": 61,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatMapAsync.rs:16"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "_smelt_tmp_N = !(match _smelt_tmp_N { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true });",
       "occurrences": 60,
       "files": 4,
@@ -1584,17 +1612,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into((*smelt_capture_orders.borrow()).clone().clone().map_or(SmeltList::new(Vec::<SmeltUnknown>::new()), |value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }));",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (target.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
       "occurrences": 60,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:100"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(criteria.clone().clone().map_or(SmeltList::new(Vec::<SmeltUnknown>::new()), |value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }));",
-      "occurrences": 60,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:575"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1078"
     },
     {
       "category": "legitimate-boundary",
@@ -1608,7 +1629,7 @@
       "shape": "_smelt_tmp_N = match _smelt_tmp_N.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() };",
       "occurrences": 60,
       "files": 4,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:441"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:461"
     },
     {
       "category": "legitimate-boundary",
@@ -1657,7 +1678,7 @@
       "shape": "}); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_object_value = (smelt_callback)(if smelt_args.get(N).is_some() { { let smelt_optional_source = smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null); if smelt_unknown_is_nullish(&smelt_optional_source.clone()) { None } else { Some(match smelt_optional_source.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) } } } else { None::<String> }, if smelt_args.get(N).is_some() { { let smelt_optional_source = smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null); if smelt_unknown_is_nullish(&smelt_optional_source.clone()) { None } else { Some(match (smelt_optional_source).into_smelt_unknown() { SmeltUnknown::Object(values) => { let smelt_record_map = SmeltRecord::with_id_from_entries(values.id, values.into_iter()); { let smelt_record_map = smelt_record_map.clone(); TemplateOptions { escape: smelt_record_map.get(\"S\").cloned().map(|value| match value.clone() { SmeltUnknown::Object(value) => SmeltRegExp::new(match value.get(\"S\") { Some(SmeltUnknown::String(source)) => source, _ => String::new() }, match value.get(\"S\") { Some(SmeltUnknown::String(flags)) => flags, _ => String::new() }), _ => SmeltRegExp::default() }), evaluate: smelt_record_map.get(\"S\").cloned().map(|value| match value.clone() { SmeltUnknown::Object(value) => SmeltRegExp::new(match value.get(\"S\") { Some(SmeltUnknown::String(source)) => source, _ => String::new() }, match value.get(\"S\") { Some(SmeltUnknown::String(flags)) => flags, _ => String::new() }), _ => SmeltRegExp::default() }), interpolate: smelt_record_map.get(\"S\").cloned().map(|value| match value.clone() { SmeltUnknown::Object(value) => SmeltRegExp::new(match value.get(\"S\") { Some(SmeltUnknown::String(source)) => source, _ => String::new() }, match value.get(\"S\") { Some(SmeltUnknown::String(flags)) => flags, _ => String::new() }), _ => SmeltRegExp::default() }), variable: smelt_record_map.get(\"S\").cloned().map(|value| match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }), imports: smelt_record_map.get(\"S\").cloned().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(value) => SmeltRecord::with_id_from_entries(value.id, value.into_iter()), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), value)).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| (index.to_string(), SmeltUnknown::String(ch.to_string()))).collect(), SmeltUnknown::Function(value) => SmeltRecord::from([(\"S\".to_owned(), SmeltUnknown::Function(value))]), _ => SmeltRecord::new() }), source_url: smelt_record_map.get(\"S\").or_else(|| smelt_record_map.get(\"S\")).cloned().map(|value| match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) } } }, _ => Default::default() }) } } } else { None::<TemplateOptions> }, if smelt_args.get(N).is_some() { Some(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)) } else { None::<SmeltUnknown> })?; let smelt_struct_value = smelt_object_value.clone(); let mut smelt_object_entries = ::std::collections::HashMap::new(); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::String(smelt_object_value.source)); smelt_object_entries.insert(\"S\".to_owned(), { let smelt_function_value = smelt_object_value.__smelt_call; let smelt_function_origin = smelt_function_value.clone(); let smelt_erased_function: ::std::rc::Rc<dyn Fn(Vec<SmeltUnknown>) -> Result<SmeltUnknown, Box<dyn std::error::Error>>> = ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::String((smelt_function_value)(if smelt_args.get(N).is_some() { Some(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)) } else { None::<SmeltUnknown> })))); smelt_register_function_origin(&smelt_erased_function, smelt_function_origin); SmeltUnknown::Function(smelt_erased_function) }); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); SmeltUnknown::Object(SmeltObject::new(smelt_object_entries)) })) })).clone())",
       "occurrences": 60,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5507"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5521"
     },
     {
       "category": "avoidable-erasure",
@@ -1678,21 +1699,14 @@
       "shape": "match &mut result_N { SmeltUnknown::Object(map) => { map.insert(\"S\".to_owned(), match value_to_clone.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone()); }, other => { let mut map = ::std::collections::HashMap::new(); map.insert(\"S\".to_owned(), match value_to_clone.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone()); *other = SmeltUnknown::Object(SmeltObject::new(map)); } }",
       "occurrences": 60,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:404"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N = { let smelt_function = match limit_async(SmeltUnknown::Function({ let smelt_callback = callback.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_future = (smelt_callback)((smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).into_smelt_unknown(), match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, { let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }); SmeltUnknown::Promise(SmeltPromise::from_future(Box::pin(async move { let smelt_value = smelt_future.await?; Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_l = smelt_value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }) }))) })) }), _smelt_tmp_N.clone().unwrap_or(N.N)).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltList<SmeltUnknown>>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltList<SmeltUnknown>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<SmeltList<SmeltUnknown>> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push(SmeltUnknown::Number(argN as fN)); smelt_call_args.push({ let smelt_l = argN; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); SmeltFuture::from_future(Box::pin(async move { Ok::<_, Box<dyn std::error::Error>>({ let smelt_src = (smelt_result).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) })) }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltList<SmeltUnknown>>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<SmeltList<SmeltUnknown>> { SmeltFuture::resolved(SmeltList::new(Vec::<SmeltUnknown>::new())) }); smelt_default_callback } } };",
-      "occurrences": 59,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatMapAsync.rs:16"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:424"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(SmeltObject::new(::std::collections::HashMap::from([",
       "occurrences": 57,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3534"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3548"
     },
     {
       "category": "legitimate-boundary",
@@ -1703,17 +1717,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into((*smelt_capture_orders.borrow()).clone().clone().map_or(SmeltList::new(Vec::<String>::new()), |value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }));",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = intersection_by_N({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }, { let smelt_l: SmeltList<_> = (closure_arg_N.clone()).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| value).collect::<Vec<_>>()) }, &|argN: SmeltUnknown| SmeltUnknown::Null);",
       "occurrences": 56,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:1493"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (target.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 56,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1072"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/xorBy.rs:80"
     },
     {
       "category": "legitimate-boundary",
@@ -1748,14 +1755,21 @@
       "shape": "let mut _smelt_tmp_N: SmeltRecord<String, SmeltUnknown>;",
       "occurrences": 56,
       "files": 24,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:644"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:665"
     },
     {
       "category": "runtime-prelude",
       "shape": "if matches!(value, SmeltUnknown::String(_)) { return Self::MN(match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }); }",
       "occurrences": 55,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4991"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5005"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (collection.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 55,
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/keyBy.rs:40"
     },
     {
       "category": "legitimate-boundary",
@@ -1793,6 +1807,13 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/partial_spec.rs:531"
     },
     {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N = { let smelt_function = match limit_async(SmeltUnknown::Function({ let smelt_callback = predicate.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_future = (smelt_callback)((smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).into_smelt_unknown(), match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, { let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }); SmeltUnknown::Promise(SmeltPromise::from_future(Box::pin(async move { let smelt_value = smelt_future.await?; Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::Bool(smelt_value)) }))) })) }), _smelt_tmp_N.clone().unwrap_or(N.N)).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<bool>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<bool>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<bool> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push(SmeltUnknown::Number(argN as fN)); smelt_call_args.push({ let smelt_l = argN; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); SmeltFuture::from_future(Box::pin(async move { Ok::<_, Box<dyn std::error::Error>>(match smelt_result.clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true }) })) }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<bool>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<bool> { SmeltFuture::resolved(false) }); smelt_default_callback } } };",
+      "occurrences": 54,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/filterAsync.rs:18"
+    },
+    {
       "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltUnknown> = vec![SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN)]; smelt_list_items }));",
       "occurrences": 54,
@@ -1826,13 +1847,6 @@
       "occurrences": 54,
       "files": 7,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/differenceWith.rs:15"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N = { let smelt_function = match limit_async(SmeltUnknown::Function({ let smelt_callback = predicate.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_future = (smelt_callback)((smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).into_smelt_unknown(), match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, { let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }); SmeltUnknown::Promise(SmeltPromise::from_future(Box::pin(async move { let smelt_value = smelt_future.await?; Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::Bool(smelt_value)) }))) })) }), _smelt_tmp_N.clone().unwrap_or(N.N)).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<bool>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<bool>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<bool> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push(SmeltUnknown::Number(argN as fN)); smelt_call_args.push({ let smelt_l = argN; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); SmeltFuture::from_future(Box::pin(async move { Ok::<_, Box<dyn std::error::Error>>(match smelt_result.clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true }) })) }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<bool>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<bool> { SmeltFuture::resolved(false) }); smelt_default_callback } } };",
-      "occurrences": 53,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/filterAsync.rs:18"
     },
     {
       "category": "avoidable-erasure",
@@ -1870,13 +1884,6 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/keyBy_spec.rs:23"
     },
     {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = intersection_by_N({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }, { let smelt_l: SmeltList<_> = (closure_arg_N.clone()).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| value).collect::<Vec<_>>()) }, &|argN: SmeltUnknown| SmeltUnknown::Null);",
-      "occurrences": 52,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/xorBy.rs:80"
-    },
-    {
       "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>>;",
       "occurrences": 52,
@@ -1888,7 +1895,7 @@
       "shape": "_smelt_tmp_N = { let smelt_function = match match _smelt_tmp_N.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone().clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, String) -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, String) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: String| -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(argN); smelt_call_args.push(SmeltUnknown::String(argN)); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, String) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: String| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } };",
       "occurrences": 51,
       "files": 3,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:672"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:693"
     },
     {
       "category": "legitimate-boundary",
@@ -1913,13 +1920,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (collection.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 50,
-      "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/keyBy.rs:40"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "_smelt_tmp_N = _smelt_tmp_N.clone().clone().map_or({ let smelt_default_callback: ::std::rc::Rc<dyn Fn(String, ::std::rc::Rc<dyn Fn() -> SmeltUnknown>, SmeltRecord<String, bool>) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: String, argN: ::std::rc::Rc<dyn Fn() -> SmeltUnknown>, argN: SmeltRecord<String, bool>| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback }, |value| { let smelt_function = match value.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(String, ::std::rc::Rc<dyn Fn() -> SmeltUnknown>, SmeltRecord<String, bool>) -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(String, ::std::rc::Rc<dyn Fn() -> SmeltUnknown>, SmeltRecord<String, bool>) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: String, argN: ::std::rc::Rc<dyn Fn() -> SmeltUnknown>, argN: SmeltRecord<String, bool>| -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(SmeltUnknown::String(argN)); smelt_call_args.push({ let smelt_function_value = argN; let smelt_function_origin = smelt_function_value.clone(); let smelt_erased_function: ::std::rc::Rc<dyn Fn(Vec<SmeltUnknown>) -> Result<SmeltUnknown, Box<dyn std::error::Error>>> = ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>((smelt_function_value)())); smelt_register_function_origin(&smelt_erased_function, smelt_function_origin); SmeltUnknown::Function(smelt_erased_function) }); smelt_call_args.push({ let smelt_record = (argN).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, SmeltUnknown::Bool(value))).collect())) }); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(String, ::std::rc::Rc<dyn Fn() -> SmeltUnknown>, SmeltRecord<String, bool>) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: String, argN: ::std::rc::Rc<dyn Fn() -> SmeltUnknown>, argN: SmeltRecord<String, bool>| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } });",
       "occurrences": 50,
       "files": 2,
@@ -1938,6 +1938,13 @@
       "occurrences": 50,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/retry_spec.rs:393"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N = SmeltFuture::from_future(Box::pin(flat_map_async({ let smelt_l: SmeltList<_> = (arr).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>()) }, ::std::rc::Rc::new({ let _smelt_adapted_callback = callback.clone(); move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| { let smelt_async_callback = _smelt_adapted_callback.clone(); SmeltFuture::from_future(Box::pin(async move { let smelt_async_output = (smelt_async_callback)(match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).await?; Ok::<_, Box<dyn std::error::Error>>({ let smelt_src = (smelt_async_output).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) })) } }), None::<FlatMapAsyncOptions>)));",
+      "occurrences": 50,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatMapAsync_spec.rs:229"
     },
     {
       "category": "legitimate-boundary",
@@ -1979,7 +1986,7 @@
       "shape": "let mut _smelt_tmp_N: SmeltUnknown = SmeltUnknown::Null;",
       "occurrences": 50,
       "files": 9,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:349"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:369"
     },
     {
       "category": "avoidable-erasure",
@@ -1990,10 +1997,17 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N = { let smelt_function = match limit_async(SmeltUnknown::Function({ let smelt_callback = callback.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_future = (smelt_callback)((smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).into_smelt_unknown(), match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, { let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }); SmeltUnknown::Promise(SmeltPromise::from_future(Box::pin(async move { let smelt_value = smelt_future.await?; Ok::<SmeltUnknown, Box<dyn std::error::Error>>((smelt_value).into_smelt_unknown()) }))) })) }), _smelt_tmp_N.clone().unwrap_or(N.N)).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltUnknown>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltUnknown>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<SmeltUnknown> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push(SmeltUnknown::Number(argN as fN)); smelt_call_args.push({ let smelt_l = argN; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); SmeltFuture::from_future(Box::pin(async move { Ok::<_, Box<dyn std::error::Error>>((smelt_result).into_smelt_unknown()) })) }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltUnknown>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<SmeltUnknown> { SmeltFuture::resolved(SmeltUnknown::Null) }); smelt_default_callback } } };",
+      "occurrences": 49,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/mapAsync.rs:14"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltRecord<String, SmeltUnknown> = match (source.clone()).into_smelt_unknown() { SmeltUnknown::Object(value) => SmeltRecord::with_id_from_entries(value.id, value.into_iter()), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), value)).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| (index.to_string(), SmeltUnknown::String(ch.to_string()))).collect(), SmeltUnknown::Function(value) => SmeltRecord::from([(\"S\".to_owned(), SmeltUnknown::Function(value))]), _ => SmeltRecord::new() };",
       "occurrences": 49,
       "files": 5,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:655"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:676"
     },
     {
       "category": "legitimate-boundary",
@@ -2046,20 +2060,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N = SmeltFuture::from_future(Box::pin(flat_map_async({ let smelt_l: SmeltList<_> = (arr).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>()) }, ::std::rc::Rc::new({ let _smelt_adapted_callback = callback.clone(); move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| { let smelt_async_callback = _smelt_adapted_callback.clone(); SmeltFuture::from_future(Box::pin(async move { let smelt_async_output = (smelt_async_callback)(match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).await?; Ok::<_, Box<dyn std::error::Error>>({ let smelt_src = (smelt_async_output).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) })) } }), None::<FlatMapAsyncOptions>)));",
-      "occurrences": 48,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatMapAsync_spec.rs:229"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N = { let smelt_function = match limit_async(SmeltUnknown::Function({ let smelt_callback = callback.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_future = (smelt_callback)((smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).into_smelt_unknown(), match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, { let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }); SmeltUnknown::Promise(SmeltPromise::from_future(Box::pin(async move { let smelt_value = smelt_future.await?; Ok::<SmeltUnknown, Box<dyn std::error::Error>>((smelt_value).into_smelt_unknown()) }))) })) }), _smelt_tmp_N.clone().unwrap_or(N.N)).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltUnknown>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltUnknown>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<SmeltUnknown> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push(SmeltUnknown::Number(argN as fN)); smelt_call_args.push({ let smelt_l = argN; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); SmeltFuture::from_future(Box::pin(async move { Ok::<_, Box<dyn std::error::Error>>((smelt_result).into_smelt_unknown()) })) }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<SmeltUnknown>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<SmeltUnknown> { SmeltFuture::resolved(SmeltUnknown::Null) }); smelt_default_callback } } };",
-      "occurrences": 48,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/mapAsync.rs:14"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N = { let smelt_function = match match _smelt_tmp_N.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone().clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(String) -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(String) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: String| -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(SmeltUnknown::String(argN)); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(String) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: String| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } };",
       "occurrences": 48,
       "files": 1,
@@ -2071,6 +2071,13 @@
       "occurrences": 48,
       "files": 2,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/flowRight_spec.rs:102"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_src = (merge_with_N(SmeltUnknown::Array(_smelt_tmp_N.clone().into()), SmeltUnknown::Array(_smelt_tmp_N.clone().into()), &*({ let smelt_function = match _smelt_tmp_N.clone().clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltUnknown, argN: String, argN: SmeltUnknown, argN: SmeltUnknown| -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(argN); smelt_call_args.push(argN); smelt_call_args.push(SmeltUnknown::String(argN)); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltUnknown, argN: String, argN: SmeltUnknown, argN: SmeltUnknown| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } }))).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
+      "occurrences": 48,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toMerged.rs:34"
     },
     {
       "category": "legitimate-boundary",
@@ -2095,10 +2102,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_src = (merge_with_N(SmeltUnknown::Array(_smelt_tmp_N.clone().into()), SmeltUnknown::Array(_smelt_tmp_N.clone().into()), &*({ let smelt_function = match _smelt_tmp_N.clone().clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltUnknown, argN: String, argN: SmeltUnknown, argN: SmeltUnknown| -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(argN); smelt_call_args.push(argN); smelt_call_args.push(SmeltUnknown::String(argN)); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltUnknown, argN: String, argN: SmeltUnknown, argN: SmeltUnknown| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } }))).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_src = (merge_with_N(_smelt_tmp_N.clone(), SmeltUnknown::Array(_smelt_tmp_N.clone().into()), &*({ let smelt_function = match _smelt_tmp_N.clone().clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltUnknown, argN: String, argN: SmeltUnknown, argN: SmeltUnknown| -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(argN); smelt_call_args.push(argN); smelt_call_args.push(SmeltUnknown::String(argN)); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltUnknown, argN: String, argN: SmeltUnknown, argN: SmeltUnknown| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } }))).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
       "occurrences": 47,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toMerged.rs:34"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toMerged.rs:41"
     },
     {
       "category": "legitimate-boundary",
@@ -2116,6 +2123,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N = SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) })) }, length: N.N, object: None };",
+      "occurrences": 46,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/memoize_spec.rs:98"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N = _smelt_tmp_N.clone().clone().map_or({ let smelt_default_callback: ::std::rc::Rc<dyn Fn(String, ::std::rc::Rc<dyn Fn() -> SmeltUnknown>) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: String, argN: ::std::rc::Rc<dyn Fn() -> SmeltUnknown>| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback }, |value| { let smelt_function = match value.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(String, ::std::rc::Rc<dyn Fn() -> SmeltUnknown>) -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(String, ::std::rc::Rc<dyn Fn() -> SmeltUnknown>) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: String, argN: ::std::rc::Rc<dyn Fn() -> SmeltUnknown>| -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(SmeltUnknown::String(argN)); smelt_call_args.push({ let smelt_function_value = argN; let smelt_function_origin = smelt_function_value.clone(); let smelt_erased_function: ::std::rc::Rc<dyn Fn(Vec<SmeltUnknown>) -> Result<SmeltUnknown, Box<dyn std::error::Error>>> = ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>((smelt_function_value)())); smelt_register_function_origin(&smelt_erased_function, smelt_function_origin); SmeltUnknown::Function(smelt_erased_function) }); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(String, ::std::rc::Rc<dyn Fn() -> SmeltUnknown>) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: String, argN: ::std::rc::Rc<dyn Fn() -> SmeltUnknown>| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } });",
       "occurrences": 46,
       "files": 2,
@@ -2130,10 +2144,31 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_src = (merge_with_N(_smelt_tmp_N.clone(), SmeltUnknown::Array(_smelt_tmp_N.clone().into()), &*({ let smelt_function = match _smelt_tmp_N.clone().clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltUnknown, argN: String, argN: SmeltUnknown, argN: SmeltUnknown| -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(argN); smelt_call_args.push(argN); smelt_call_args.push(SmeltUnknown::String(argN)); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, String, SmeltUnknown, SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltUnknown, argN: String, argN: SmeltUnknown, argN: SmeltUnknown| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } }))).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
+      "shape": "let _smelt_tmp_N: SmeltList<fN> = { let smelt_src = (clone_N({ let smelt_l = arr.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
       "occurrences": 46,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toMerged.rs:41"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_spec.rs:73"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<fN> = { let smelt_src = (clone_N({ let smelt_l = big_int_array.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
+      "occurrences": 46,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_spec.rs:536"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<fN> = { let smelt_src = (clone_N({ let smelt_l = typed_array.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
+      "occurrences": 46,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_spec.rs:512"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<fN> = { let smelt_src = (clone_deep_N({ let smelt_l = typed_array.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })?).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
+      "occurrences": 46,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:685"
     },
     {
       "category": "avoidable-erasure",
@@ -2141,6 +2176,20 @@
       "occurrences": 46,
       "files": 32,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/dropRightWhile_spec.rs:43"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "if matches!(value, SmeltUnknown::Array(_)) { return Self::MN({ let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }); }",
+      "occurrences": 45,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5185"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (collection.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 45,
+      "files": 3,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/countBy.rs:40"
     },
     {
       "category": "legitimate-boundary",
@@ -2171,11 +2220,11 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:187"
     },
     {
-      "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = is_equal_with_N({ let smelt_list_id = smelt_list_identity(&(setN) as *const _ as *const () as usize); let mut values = setN.clone().clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(SmeltArray::with_id(smelt_list_id, values)) }, { let smelt_list_id = smelt_list_identity(&(setN) as *const _ as *const () as usize); let mut values = setN.clone().clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(SmeltArray::with_id(smelt_list_id, values)) }, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>| None::<bool> });",
-      "occurrences": 45,
+      "category": "runtime-prelude",
+      "shape": "Self::MN({ let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) })",
+      "occurrences": 44,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_spec.rs:5447"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5146"
     },
     {
       "category": "legitimate-boundary",
@@ -2183,6 +2232,13 @@
       "occurrences": 44,
       "files": 3,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/omitBy_1.rs:59"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (cloned_array_buffer.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 44,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:656"
     },
     {
       "category": "legitimate-boundary",
@@ -2200,10 +2256,38 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N = { let smelt_function = match limit_async(SmeltUnknown::Function({ let smelt_callback = callback.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_future = (smelt_callback)((smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).into_smelt_unknown(), match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, { let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }); SmeltUnknown::Promise(SmeltPromise::from_future(Box::pin(async move { let smelt_value = smelt_future.await?; Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::Null) }))) })) }), _smelt_tmp_N.clone().unwrap_or(N.N)).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<()>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<()>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<()> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push(SmeltUnknown::Number(argN as fN)); smelt_call_args.push({ let smelt_l = argN; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); SmeltFuture::from_future(Box::pin(async move { Ok::<_, Box<dyn std::error::Error>>({ let _ = smelt_result.clone(); () }) })) }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<()>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<()> { SmeltFuture::resolved(()) }); smelt_default_callback } } };",
+      "occurrences": 44,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/forEachAsync.rs:15"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: CurriedFunctionN<SmeltUnknown, SmeltUnknown> = match (curry_N(SmeltErasedFunction { callback: { let smelt_callback = fn__N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_callback)()) }, length: N.N, object: None }, None::<fN>, None::<SmeltUnknown>)).into_smelt_unknown() { SmeltUnknown::Object(values) => { let smelt_record_map = SmeltRecord::with_id_from_entries(values.id, values.into_iter()); { let smelt_record_map = smelt_record_map.clone(); CurriedFunctionN { __smelt_call: smelt_record_map.get(\"S\").or_else(|| smelt_record_map.get(\"S\")).cloned().map_or({ let smelt_default_callback: ::std::rc::Rc<dyn Fn() -> CurriedFunctionN<SmeltUnknown, SmeltUnknown>> = ::std::rc::Rc::new(move || -> CurriedFunctionN<SmeltUnknown, SmeltUnknown> { Default::default() }); smelt_default_callback }, |value| { let smelt_function = match value.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn() -> CurriedFunctionN<SmeltUnknown, SmeltUnknown>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn() -> CurriedFunctionN<SmeltUnknown, SmeltUnknown>> = ::std::rc::Rc::new(move || -> CurriedFunctionN<SmeltUnknown, SmeltUnknown> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); Default::default() }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn() -> CurriedFunctionN<SmeltUnknown, SmeltUnknown>> = ::std::rc::Rc::new(move || -> CurriedFunctionN<SmeltUnknown, SmeltUnknown> { Default::default() }); smelt_default_callback } } }), _smelt_phantom: ::std::marker::PhantomData } } }, _ => Default::default() };",
       "occurrences": 44,
       "files": 2,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/partialRight_spec.rs:413"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<fN> = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 44,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isTypedArray_spec.rs:64"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<fN> = Into::<SmeltList<_>>::into({ let smelt_src = (array_buffer.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 44,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:642"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<fN> = last_N({ let smelt_l: SmeltList<_> = (nested_array).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| value.into_smelt_unknown()).collect::<Vec<_>>()) }).clone().map_or(SmeltList::new(Vec::<fN>::new()), |value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 44,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/last_spec.rs:105"
     },
     {
       "category": "legitimate-boundary",
@@ -2253,20 +2337,6 @@
       "occurrences": 44,
       "files": 4,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/add.rs:45"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N = { let smelt_function = match limit_async(SmeltUnknown::Function({ let smelt_callback = callback.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_future = (smelt_callback)((smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).into_smelt_unknown(), match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, { let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }); SmeltUnknown::Promise(SmeltPromise::from_future(Box::pin(async move { let smelt_value = smelt_future.await?; Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::Null) }))) })) }), _smelt_tmp_N.clone().unwrap_or(N.N)).clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<()>>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<()>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<()> { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push((argN).into_smelt_unknown()); smelt_call_args.push(SmeltUnknown::Number(argN as fN)); smelt_call_args.push({ let smelt_l = argN; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); SmeltFuture::from_future(Box::pin(async move { Ok::<_, Box<dyn std::error::Error>>({ let _ = smelt_result.clone(); () }) })) }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltList<SmeltUnknown>) -> SmeltFuture<()>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| -> SmeltFuture<()> { SmeltFuture::resolved(()) }); smelt_default_callback } } };",
-      "occurrences": 43,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/forEachAsync.rs:15"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (collection.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 42,
-      "files": 3,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/countBy.rs:40"
     },
     {
       "category": "legitimate-boundary",
@@ -2774,6 +2844,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: DebouncedFuncLeading<SmeltErasedFunction> = { let smelt_struct_value = throttle_N(func.clone().into_smelt_unknown(), throttle_ms.clone(), { let smelt_record_map = _smelt_tmp_N.clone(); ThrottleOptions { signal: smelt_record_map.get(\"S\").cloned().map(|value| value), edges: smelt_record_map.get(\"S\").cloned().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) } }).clone(); DebouncedFuncLeading { cancel: smelt_struct_value.cancel.clone().clone(), flush: { let smelt_callback = smelt_struct_value.flush.clone().clone(); let smelt_adapted: ::std::rc::Rc<dyn Fn() -> Option<SmeltUnknown>> = ::std::rc::Rc::new(move || None::<SmeltUnknown>); smelt_adapted }, __smelt_call: smelt_struct_value.__smelt_call.clone(), _smelt_phantom: ::std::marker::PhantomData } };",
+      "occurrences": 36,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/throttle_spec.rs:258"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltList<(fN, fN, fN)> = { let smelt_l: SmeltList<_> = (cartesian_product(_smelt_tmp_N)).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_tuple_values = value.clone(); (match smelt_tuple_values.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_tuple_values.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_tuple_values.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) }).collect::<Vec<_>>()) };",
       "occurrences": 36,
       "files": 1,
@@ -2785,6 +2862,13 @@
       "occurrences": 36,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/unzipWith_spec.rs:20"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_src = (for_each(_smelt_tmp_N, Some(_smelt_tmp_N.clone()))?).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
+      "occurrences": 36,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/transform.rs:60"
     },
     {
       "category": "legitimate-boundary",
@@ -2886,6 +2970,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: bool = is_equal_with_N((setN.clone()).clone().into_smelt_unknown(), (setN.clone()).clone().into_smelt_unknown(), &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>| None::<bool> });",
+      "occurrences": 35,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_spec.rs:5447"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "options = Some({ let smelt_record_map = _smelt_tmp_N.clone(); TemplateOptions { escape: smelt_record_map.get(\"S\").cloned().map(|value| match value.clone() { SmeltUnknown::Object(value) => SmeltRegExp::new(match value.get(\"S\") { Some(SmeltUnknown::String(source)) => source, _ => String::new() }, match value.get(\"S\") { Some(SmeltUnknown::String(flags)) => flags, _ => String::new() }), _ => SmeltRegExp::default() }), evaluate: smelt_record_map.get(\"S\").cloned().map(|value| match value.clone() { SmeltUnknown::Object(value) => SmeltRegExp::new(match value.get(\"S\") { Some(SmeltUnknown::String(source)) => source, _ => String::new() }, match value.get(\"S\") { Some(SmeltUnknown::String(flags)) => flags, _ => String::new() }), _ => SmeltRegExp::default() }), interpolate: smelt_record_map.get(\"S\").cloned().map(|value| match value.clone() { SmeltUnknown::Object(value) => SmeltRegExp::new(match value.get(\"S\") { Some(SmeltUnknown::String(source)) => source, _ => String::new() }, match value.get(\"S\") { Some(SmeltUnknown::String(flags)) => flags, _ => String::new() }), _ => SmeltRegExp::default() }), variable: smelt_record_map.get(\"S\").cloned().map(|value| match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }), imports: smelt_record_map.get(\"S\").cloned().map(|value| match (value).into_smelt_unknown() { SmeltUnknown::Object(value) => SmeltRecord::with_id_from_entries(value.id, value.into_iter()), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), value)).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| (index.to_string(), SmeltUnknown::String(ch.to_string()))).collect(), SmeltUnknown::Function(value) => SmeltRecord::from([(\"S\".to_owned(), SmeltUnknown::Function(value))]), _ => SmeltRecord::new() }), source_url: smelt_record_map.get(\"S\").or_else(|| smelt_record_map.get(\"S\")).cloned().map(|value| match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) } });",
       "occurrences": 35,
       "files": 1,
@@ -2910,14 +3001,14 @@
       "shape": "(\"S\".to_owned(), SmeltUnknown::Null),",
       "occurrences": 34,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3642"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3656"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => SmeltRecord::with_id_from_entries(values.id, values.into_iter().map(|(key, value)| (key, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }))), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| { let value = SmeltUnknown::String(ch.to_string()); (index.to_string(), match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) }).collect(), _ => SmeltRecord::new() })",
       "occurrences": 34,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5351"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5365"
     },
     {
       "category": "legitimate-boundary",
@@ -2928,6 +3019,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = SMELT_HOST_OVERRIDE_FILE.with(|slot| smelt_host_override_write(slot, SmeltUnknown::Function({ let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_object_value = (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }, Some(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null))); let smelt_struct_value = smelt_object_value.clone(); let mut smelt_object_entries = ::std::collections::HashMap::new(); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::String(smelt_object_value.name)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); SmeltUnknown::Object(SmeltObject::new(smelt_object_entries)) })) })));",
+      "occurrences": 34,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isBlob_spec.rs:87"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "_smelt_tmp_N = { let smelt_function = match match b.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone().clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(Option<SmeltUnknown>) -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(Option<SmeltUnknown>) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: Option<SmeltUnknown>| -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(argN.clone().map_or(SmeltUnknown::Undefined, |value| value)); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(Option<SmeltUnknown>) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: Option<SmeltUnknown>| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } };",
       "occurrences": 34,
       "files": 1,
@@ -2935,45 +3033,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N = SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) })) }, length: N.N, object: None };",
-      "occurrences": 34,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/memoize_spec.rs:98"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltList<(fN, String, bool)> = { let smelt_l: SmeltList<_> = (zip_N(_smelt_tmp_N)).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_tuple_values = value.clone(); (match smelt_tuple_values.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_tuple_values.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }, match smelt_tuple_values.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true }) }).collect::<Vec<_>>()) };",
       "occurrences": 34,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/zip_spec.rs:88"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<fN> = { let smelt_src = (clone_N({ let smelt_l = arr.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
-      "occurrences": 34,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_spec.rs:73"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<fN> = { let smelt_src = (clone_N({ let smelt_l = big_int_array.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
-      "occurrences": 34,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_spec.rs:536"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<fN> = { let smelt_src = (clone_N({ let smelt_l = typed_array.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
-      "occurrences": 34,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_spec.rs:512"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<fN> = { let smelt_src = (clone_deep_N({ let smelt_l = typed_array.clone(); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) })?).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
-      "occurrences": 34,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:685"
     },
     {
       "category": "legitimate-boundary",
@@ -3011,18 +3074,11 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/attemptAsync_spec.rs:32"
     },
     {
-      "category": "runtime-prelude",
-      "shape": "if matches!(value, SmeltUnknown::Array(_)) { return Self::MN({ let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }); }",
-      "occurrences": 33,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5171"
-    },
-    {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = SMELT_HOST_OVERRIDE_FILE.with(|slot| smelt_host_override_write(slot, SmeltUnknown::Function({ let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>({ let smelt_object_value = (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }, Some(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null))); let smelt_struct_value = smelt_object_value.clone(); let mut smelt_object_entries = ::std::collections::HashMap::new(); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::String(smelt_object_value.name)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); SmeltUnknown::Object(SmeltObject::new(smelt_object_entries)) })) })));",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_l: SmeltList<_> = (values.clone()).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
       "occurrences": 33,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isBlob_spec.rs:87"
+      "files": 3,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/differenceWith.rs:25"
     },
     {
       "category": "legitimate-boundary",
@@ -3037,13 +3093,6 @@
       "occurrences": 33,
       "files": 3,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/pickBy_1.rs:121"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_src = (for_each(_smelt_tmp_N, Some(_smelt_tmp_N.clone()))?).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
-      "occurrences": 33,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/transform.rs:60"
     },
     {
       "category": "legitimate-boundary",
@@ -3068,24 +3117,17 @@
     },
     {
       "category": "runtime-prelude",
-      "shape": "Self::MN({ let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) })",
+      "shape": "Self::MN({ let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) })",
       "occurrences": 32,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5132"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5111"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, R: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'",
       "occurrences": 32,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3796"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (cloned_array_buffer.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 32,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:656"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3810"
     },
     {
       "category": "legitimate-boundary",
@@ -3124,6 +3166,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N = { let smelt_source_future = SmeltFuture::from_future(Box::pin(reduce_async({ let smelt_l: SmeltList<_> = (arr).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::String(value)).collect::<Vec<_>>()) }, ::std::rc::Rc::new({ let _smelt_adapted_callback = reducer.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| { let smelt_async_callback = _smelt_adapted_callback.clone(); SmeltFuture::from_future(Box::pin(async move { let smelt_async_output = (smelt_async_callback)({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }, match argN.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }).await?; Ok::<_, Box<dyn std::error::Error>>(smelt_async_output) })) } }), Some({ let smelt_l = _smelt_tmp_N; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::String(value)).collect::<Vec<_>>())) })))); SmeltFuture::from_future(Box::pin(async move { let smelt_future_value = smelt_source_future.await?; Ok::<_, Box<dyn std::error::Error>>((smelt_future_value).into_smelt_unknown()) })) };",
+      "occurrences": 32,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/reduceAsync_spec.rs:389"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: DebouncedFunc<SmeltUnknown> = debounce_N(func.clone(), throttle_ms.clone(), { let smelt_record_map = _smelt_tmp_N.clone(); DebounceSettings { leading: smelt_record_map.get(\"S\").cloned().map(|value| match value.clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true }), max_wait: smelt_record_map.get(\"S\").or_else(|| smelt_record_map.get(\"S\")).cloned().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }), trailing: smelt_record_map.get(\"S\").cloned().map(|value| match value.clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true }) } });",
       "occurrences": 32,
       "files": 1,
@@ -3131,31 +3180,17 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: DebouncedFuncLeading<SmeltErasedFunction> = { let smelt_struct_value = throttle_N(func.clone().into_smelt_unknown(), throttle_ms.clone(), { let smelt_record_map = _smelt_tmp_N.clone(); ThrottleOptions { signal: smelt_record_map.get(\"S\").cloned().map(|value| value), edges: smelt_record_map.get(\"S\").cloned().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) } }).clone(); DebouncedFuncLeading { cancel: smelt_struct_value.cancel.clone().clone(), flush: { let smelt_callback = smelt_struct_value.flush.clone().clone(); let smelt_adapted: ::std::rc::Rc<dyn Fn() -> Option<SmeltUnknown>> = ::std::rc::Rc::new(move || None::<SmeltUnknown>); smelt_adapted }, __smelt_call: smelt_struct_value.__smelt_call.clone(), _smelt_phantom: ::std::marker::PhantomData } };",
+      "shape": "let _smelt_tmp_N: DebouncedFunction<SmeltErasedFunction> = { let smelt_struct_value = debounce_N(func.clone().into_smelt_unknown(), debounce_ms.clone(), { let smelt_record_map = _smelt_tmp_N.clone(); DebounceOptions { signal: smelt_record_map.get(\"S\").cloned().map(|value| value), edges: smelt_record_map.get(\"S\").cloned().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) } }).clone(); DebouncedFunction { schedule: smelt_struct_value.schedule.clone().clone(), cancel: smelt_struct_value.cancel.clone().clone(), flush: smelt_struct_value.flush.clone().clone(), __smelt_call: smelt_struct_value.__smelt_call.clone().clone(), _smelt_phantom: ::std::marker::PhantomData } };",
       "occurrences": 32,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/throttle_spec.rs:258"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/debounce_spec.rs:380"
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<fN> = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = Into::<SmeltList<_>>::into({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
       "occurrences": 32,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isTypedArray_spec.rs:64"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<fN> = Into::<SmeltList<_>>::into({ let smelt_src = (array_buffer.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 32,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:642"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<fN> = last_N({ let smelt_l: SmeltList<_> = (nested_array).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| value.into_smelt_unknown()).collect::<Vec<_>>()) }).clone().map_or(SmeltList::new(Vec::<fN>::new()), |value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 32,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/last_spec.rs:105"
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/memoize_spec.rs:101"
     },
     {
       "category": "legitimate-boundary",
@@ -3170,6 +3205,13 @@
       "occurrences": 32,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/assignWith.rs:27"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltUnknown = capped.call({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 32,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/ary_spec.rs:95"
     },
     {
       "category": "legitimate-boundary",
@@ -3246,7 +3288,7 @@
       "shape": "Self::MN(match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => { let smelt_record_map = SmeltRecord::with_id_from_entries(values.id, values.into_iter()); { let smelt_record_map = smelt_record_map.clone(); RetryOptions { delay: smelt_record_map.get(\"S\").cloned().map(|value| SmeltUnionN::from_smelt_unknown(value)), retries: smelt_record_map.get(\"S\").cloned().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }), signal: smelt_record_map.get(\"S\").cloned().map(|value| value), should_retry: smelt_record_map.get(\"S\").or_else(|| smelt_record_map.get(\"S\")).cloned().map(|value| { let smelt_function = match value.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, fN) -> bool>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN) -> bool> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN| -> bool { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(argN); smelt_call_args.push(SmeltUnknown::Number(argN as fN)); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); match smelt_result.clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN) -> bool> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN| -> bool { false }); smelt_default_callback } } }) } } }, _ => Default::default() })",
       "occurrences": 31,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5281"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5295"
     },
     {
       "category": "legitimate-boundary",
@@ -3264,10 +3306,24 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_l: SmeltList<_> = (values.clone()).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (obj.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
       "occurrences": 30,
-      "files": 3,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/differenceWith.rs:25"
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toCamelCaseKeys.rs:28"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (omission.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 30,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/truncate.rs:106"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (source_value.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 30,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/defaultsDeep.rs:219"
     },
     {
       "category": "legitimate-boundary",
@@ -3320,20 +3376,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N = { let smelt_source_future = SmeltFuture::from_future(Box::pin(reduce_async({ let smelt_l: SmeltList<_> = (arr).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::String(value)).collect::<Vec<_>>()) }, ::std::rc::Rc::new({ let _smelt_adapted_callback = reducer.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| { let smelt_async_callback = _smelt_adapted_callback.clone(); SmeltFuture::from_future(Box::pin(async move { let smelt_async_output = (smelt_async_callback)({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }, match argN.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }).await?; Ok::<_, Box<dyn std::error::Error>>(smelt_async_output) })) } }), Some({ let smelt_l = _smelt_tmp_N; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::String(value)).collect::<Vec<_>>())) })))); SmeltFuture::from_future(Box::pin(async move { let smelt_future_value = smelt_source_future.await?; Ok::<_, Box<dyn std::error::Error>>((smelt_future_value).into_smelt_unknown()) })) };",
-      "occurrences": 30,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/reduceAsync_spec.rs:389"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = Into::<SmeltList<_>>::into({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 30,
-      "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/memoize_spec.rs:101"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = uniq_by_N(_smelt_tmp_N, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| SmeltUnknown::Number((_smelt_adapted_callback)(match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) as fN) });",
       "occurrences": 30,
       "files": 1,
@@ -3345,13 +3387,6 @@
       "occurrences": 30,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/zipWith_spec.rs:51"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltUnknown = capped.call({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 30,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/ary_spec.rs:95"
     },
     {
       "category": "legitimate-boundary",
@@ -3403,39 +3438,11 @@
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/conformsTo.rs:12"
     },
     {
-      "category": "runtime-prelude",
-      "shape": "Self::MN({ let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) })",
-      "occurrences": 28,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5097"
-    },
-    {
       "category": "legitimate-boundary",
       "shape": "SmeltUnknown::Object(values) => values.get(&{ fn smelt_property_key(value: SmeltUnknown) -> String { match value { SmeltUnknown::String(value) => value, SmeltUnknown::Symbol(value) => format!(\"S\"), SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(values) => values.into_vec().into_iter().map(smelt_property_key).collect::<Vec<_>>().join(\"S\"), SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() } } smelt_property_key(args.get({ let len = args.len() as iN; let index = N.N as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone()) }).unwrap_or(SmeltUnknown::Null),",
       "occurrences": 28,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/random.rs:179"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (obj.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 28,
-      "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toCamelCaseKeys.rs:28"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (omission.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 28,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/truncate.rs:106"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (source_value.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 28,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/defaultsDeep.rs:219"
     },
     {
       "category": "legitimate-boundary",
@@ -3471,13 +3478,6 @@
       "occurrences": 28,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_spec.rs:824"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: DebouncedFunction<SmeltErasedFunction> = { let smelt_struct_value = debounce_N(func.clone().into_smelt_unknown(), debounce_ms.clone(), { let smelt_record_map = _smelt_tmp_N.clone(); DebounceOptions { signal: smelt_record_map.get(\"S\").cloned().map(|value| value), edges: smelt_record_map.get(\"S\").cloned().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) } }).clone(); DebouncedFunction { schedule: smelt_struct_value.schedule.clone().clone(), cancel: smelt_struct_value.cancel.clone().clone(), flush: smelt_struct_value.flush.clone().clone(), __smelt_call: smelt_struct_value.__smelt_call.clone().clone(), _smelt_phantom: ::std::marker::PhantomData } };",
-      "occurrences": 28,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/debounce_spec.rs:380"
     },
     {
       "category": "legitimate-boundary",
@@ -3603,7 +3603,7 @@
       "shape": "let mut _smelt_tmp_N: ::std::rc::Rc<dyn Fn(SmeltUnknown, String) -> SmeltUnknown> = { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, String) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: String| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback };",
       "occurrences": 28,
       "files": 4,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:646"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:667"
     },
     {
       "category": "avoidable-erasure",
@@ -3631,7 +3631,7 @@
       "shape": "_smelt_tmp_N = matches!(_smelt_tmp_N.clone(), SmeltUnknown::Function(_));",
       "occurrences": 27,
       "files": 6,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:348"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:368"
     },
     {
       "category": "legitimate-boundary",
@@ -3663,6 +3663,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: fN = mean_by_N(_smelt_tmp_N, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown| match _smelt_adapted_callback.call({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN } });",
+      "occurrences": 27,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/meanBy.rs:24"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| reduce_async({ let smelt_l: SmeltList<_> = (arr).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>()) }, ::std::rc::Rc::new({ let _smelt_adapted_callback = error_fn.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| { let smelt_async_callback = _smelt_adapted_callback.clone(); SmeltFuture::from_future(Box::pin(async move { let smelt_async_output = (smelt_async_callback)(match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).await?; Ok::<_, Box<dyn std::error::Error>>(smelt_async_output) })) } }), None::<SmeltUnknown>))) {",
       "occurrences": 27,
       "files": 1,
@@ -3680,7 +3687,7 @@
       "shape": "}); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::Number((smelt_callback)(match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }, if smelt_args.get(N).is_some() { match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN } } else { N.N }, if smelt_args.get(N).is_some() { Some(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)) } else { None::<SmeltUnknown> }) as fN))) })).clone())",
       "occurrences": 27,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5491"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5505"
     },
     {
       "category": "avoidable-erasure",
@@ -3873,24 +3880,17 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: fN = mean_by_N(_smelt_tmp_N, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown| match _smelt_adapted_callback.call({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN } });",
-      "occurrences": 26,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/meanBy.rs:24"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "result = Into::<SmeltList<_>>::into({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| if let SmeltUnknown::Array(smelt_tuple_values) = value.clone() { (match smelt_tuple_values.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }, smelt_tuple_values.get(N).cloned().unwrap_or(SmeltUnknown::Null)) } else { panic!(\"S\") }).collect::<Vec<_>>()) });",
       "occurrences": 26,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPairs.rs:41"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPairs.rs:50"
     },
     {
       "category": "legitimate-boundary",
       "shape": "}); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::Number((smelt_callback)(match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) as fN))) })).clone())",
       "occurrences": 26,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5523"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5537"
     },
     {
       "category": "avoidable-erasure",
@@ -3922,6 +3922,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N = SmeltFuture::from_future(Box::pin(flat_map_async({ let smelt_l: SmeltList<_> = (arr).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>()) }, ::std::rc::Rc::new({ let _smelt_adapted_callback = fn_.clone(); move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| { let smelt_async_callback = _smelt_adapted_callback.clone(); SmeltFuture::from_future(Box::pin(async move { let smelt_async_output = (smelt_async_callback)(match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).await?; Ok::<_, Box<dyn std::error::Error>>({ let smelt_src = (smelt_async_output).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) })) } }), None::<FlatMapAsyncOptions>)));",
+      "occurrences": 25,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatMapAsync_spec.rs:471"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltJsMap<fN, String> = key_by_N({ let smelt_l: SmeltList<_> = (items).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::String(value)).collect::<Vec<_>>()) }, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| SmeltUnknown::Number((_smelt_adapted_callback)(argN, argN) as fN) }).into_iter().map(|(key, value)| (match key.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect::<SmeltJsMap<fN, String>>();",
       "occurrences": 25,
       "files": 1,
@@ -3940,6 +3947,13 @@
       "occurrences": 25,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/invert_spec.rs:119"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| flat_map_async({ let smelt_l: SmeltList<_> = (arr).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>()) }, ::std::rc::Rc::new({ let _smelt_adapted_callback = error_fn.clone(); move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| { let smelt_async_callback = _smelt_adapted_callback.clone(); SmeltFuture::from_future(Box::pin(async move { let smelt_async_output = (smelt_async_callback)(match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).await?; Ok::<_, Box<dyn std::error::Error>>({ let smelt_src = (smelt_async_output).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) })) } }), None::<FlatMapAsyncOptions>))) {",
+      "occurrences": 25,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatMapAsync_spec.rs:302"
     },
     {
       "category": "avoidable-erasure",
@@ -3988,7 +4002,7 @@
       "shape": "_smelt_tmp_N = match match obj.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone().clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() };",
       "occurrences": 24,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:111"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:118"
     },
     {
       "category": "legitimate-boundary",
@@ -4017,13 +4031,6 @@
       "occurrences": 24,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/random_spec.rs:39"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N = SmeltFuture::from_future(Box::pin(flat_map_async({ let smelt_l: SmeltList<_> = (arr).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>()) }, ::std::rc::Rc::new({ let _smelt_adapted_callback = fn_.clone(); move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| { let smelt_async_callback = _smelt_adapted_callback.clone(); SmeltFuture::from_future(Box::pin(async move { let smelt_async_output = (smelt_async_callback)(match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).await?; Ok::<_, Box<dyn std::error::Error>>({ let smelt_src = (smelt_async_output).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) })) } }), None::<FlatMapAsyncOptions>)));",
-      "occurrences": 24,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatMapAsync_spec.rs:471"
     },
     {
       "category": "legitimate-boundary",
@@ -4111,13 +4118,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "match ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| flat_map_async({ let smelt_l: SmeltList<_> = (arr).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>()) }, ::std::rc::Rc::new({ let _smelt_adapted_callback = error_fn.clone(); move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| { let smelt_async_callback = _smelt_adapted_callback.clone(); SmeltFuture::from_future(Box::pin(async move { let smelt_async_output = (smelt_async_callback)(match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).await?; Ok::<_, Box<dyn std::error::Error>>({ let smelt_src = (smelt_async_output).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) })) } }), None::<FlatMapAsyncOptions>))) {",
-      "occurrences": 24,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatMapAsync_spec.rs:302"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "predicate = { let smelt_function = match _smelt_tmp_N.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltUnknown) -> bool>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltUnknown) -> bool> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltUnknown| -> bool { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(argN); smelt_call_args.push(SmeltUnknown::Number(argN as fN)); smelt_call_args.push(argN); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); match smelt_result.clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, fN, SmeltUnknown) -> bool> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: fN, argN: SmeltUnknown| -> bool { false }); smelt_default_callback } } };",
       "occurrences": 24,
       "files": 1,
@@ -4128,7 +4128,7 @@
       "shape": "}); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::String((smelt_callback)(match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }, if smelt_args.get(N).is_some() { { let smelt_optional_source = smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null); if smelt_unknown_is_nullish(&smelt_optional_source.clone()) { None } else { Some(match smelt_optional_source.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) } } } else { None::<String> })))) })).clone())",
       "occurrences": 24,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5531"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5545"
     },
     {
       "category": "avoidable-erasure",
@@ -4160,7 +4160,7 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_key = \"S\".to_owned(); match _smelt_tmp_N.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"S\") && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
+      "shape": "_smelt_tmp_N = { let smelt_key = \"S\".to_owned(); match _smelt_tmp_N.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"S\") || values.contains_key(\"S\")) && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
       "occurrences": 24,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:237"
@@ -4300,6 +4300,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = chunk_N({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }, match closure_arg_N.clone().clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).unwrap_or_else(|error| panic!(\"S\", error));",
+      "occurrences": 23,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/chunk_spec.rs:1622"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltRecord<String, String> = invert_N(if let SmeltUnknown::Object(values) = object.clone() { SmeltJsMap::from_iter(values.into_iter().map(|(key, value)| (SmeltUnknown::String(key), (value).into_smelt_unknown()))) } else { SmeltJsMap::new() }).into_iter().map(|(key, value)| ({ fn smelt_property_key(value: SmeltUnknown) -> String { match value { SmeltUnknown::String(value) => value, SmeltUnknown::Symbol(value) => format!(\"S\"), SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(values) => values.into_vec().into_iter().map(smelt_property_key).collect::<Vec<_>>().join(\"S\"), SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() } } smelt_property_key((key).into_smelt_unknown()) }, match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })).collect::<SmeltRecord<String, String>>();",
       "occurrences": 23,
       "files": 1,
@@ -4311,6 +4318,13 @@
       "occurrences": 22,
       "files": 2,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/fill_1.rs:36"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 22,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/every.rs:132"
     },
     {
       "category": "legitimate-boundary",
@@ -4426,13 +4440,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = chunk_N({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }, match closure_arg_N.clone().clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).unwrap_or_else(|error| panic!(\"S\", error));",
-      "occurrences": 22,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/chunk_spec.rs:1622"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltList<String> = { let smelt_l: SmeltList<_> = (times_N(Some(_smelt_tmp_N), Some(::std::rc::Rc::new({ let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: fN| SmeltUnknown::String((_smelt_adapted_callback)(argN)) })))).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }).collect::<Vec<_>>()) };",
       "occurrences": 22,
       "files": 2,
@@ -4507,6 +4514,13 @@
       "occurrences": 22,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/forEachRight_spec.rs:20"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "result = Into::<SmeltList<_>>::into({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
+      "occurrences": 22,
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cartesianProduct.rs:66"
     },
     {
       "category": "legitimate-boundary",
@@ -4611,7 +4625,7 @@
       "shape": "let _smelt_tmp_N: SmeltJsSet<SmeltUnknown>;",
       "occurrences": 21,
       "files": 13,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:75"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:76"
     },
     {
       "category": "avoidable-erasure",
@@ -4646,35 +4660,35 @@
       "shape": "Self::MN(match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() })",
       "occurrences": 20,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4957"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4971"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(value) => { let smelt_object_value = value; let smelt_struct_value = smelt_object_value.clone(); let mut smelt_object_entries = ::std::collections::HashMap::new(); if let Some(value) = smelt_object_value.delay.clone() { smelt_object_entries.insert(\"S\".to_owned(), value.into_smelt_unknown()); } if let Some(value) = smelt_object_value.retries.clone() { smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Number(value as fN)); } if let Some(value) = smelt_object_value.signal.clone() { smelt_object_entries.insert(\"S\".to_owned(), value); } if let Some(value) = smelt_object_value.should_retry.clone() { smelt_object_entries.insert(\"S\".to_owned(), { let smelt_function_value = value; let smelt_function_origin = smelt_function_value.clone(); let smelt_erased_function: ::std::rc::Rc<dyn Fn(Vec<SmeltUnknown>) -> Result<SmeltUnknown, Box<dyn std::error::Error>>> = ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::Bool((smelt_function_value)(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null), match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN })))); smelt_register_function_origin(&smelt_erased_function, smelt_function_origin); SmeltUnknown::Function(smelt_erased_function) }); } smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); SmeltUnknown::Object(SmeltObject::new(smelt_object_entries)) },",
       "occurrences": 20,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5274"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5288"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn js_strict_eq(&self, other: &Self) -> bool { match (self, other) { (SmeltUnknown::Null, SmeltUnknown::Null) => true, (SmeltUnknown::Undefined, SmeltUnknown::Undefined) => true, (SmeltUnknown::Bool(left), SmeltUnknown::Bool(right)) => left == right, (SmeltUnknown::Number(left), SmeltUnknown::Number(right)) => left == right, (SmeltUnknown::String(left), SmeltUnknown::String(right)) => left == right, (SmeltUnknown::Symbol(left), SmeltUnknown::Symbol(right)) => left == right, (SmeltUnknown::Array(left), SmeltUnknown::Array(right)) => left.id == right.id, (SmeltUnknown::Object(left), SmeltUnknown::Object(right)) => left.id == right.id, (SmeltUnknown::Function(left), SmeltUnknown::Function(right)) => ::std::rc::Rc::ptr_eq(left, right), (SmeltUnknown::Promise(left), SmeltUnknown::Promise(right)) => left.id == right.id, _ => false } }",
       "occurrences": 20,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2571"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2572"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<T: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'",
       "occurrences": 20,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3679"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3693"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, R: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'",
       "occurrences": 20,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3742"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3756"
     },
     {
       "category": "legitimate-boundary",
@@ -4696,13 +4710,6 @@
       "occurrences": 20,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/truncate.rs:162"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 20,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/every.rs:132"
     },
     {
       "category": "legitimate-boundary",
@@ -4772,7 +4779,7 @@
       "shape": "_smelt_tmp_N = match obj.clone().clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() };",
       "occurrences": 20,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:79"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:80"
     },
     {
       "category": "legitimate-boundary",
@@ -4793,7 +4800,7 @@
       "shape": "_smelt_tmp_N = match value_to_clone.clone().clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() };",
       "occurrences": 20,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:323"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:343"
     },
     {
       "category": "legitimate-boundary",
@@ -4842,7 +4849,7 @@
       "shape": "_smelt_tmp_N = { let smelt_function_value = constructor.clone(); let smelt_call_args: Vec<SmeltUnknown> = Into::into(vec![match obj.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone(), match obj.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone(), SmeltUnknown::Object(SmeltObject::from_unknown_record((_smelt_tmp_N).clone()))]); let smelt_callable = match smelt_function_value { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function.clone()), _ => None }, _ => None }; if let Some(smelt_function) = smelt_callable { (smelt_function)(smelt_call_args).unwrap_or_else(|error| panic!(\"S\", error)) } else { SmeltUnknown::Null } };",
       "occurrences": 20,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:122"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:129"
     },
     {
       "category": "legitimate-boundary",
@@ -4948,13 +4955,6 @@
       "occurrences": 20,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPath.rs:208"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "result = Into::<SmeltList<_>>::into({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
-      "occurrences": 20,
-      "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cartesianProduct.rs:66"
     },
     {
       "category": "legitimate-boundary",
@@ -5112,6 +5112,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = { let smelt_l: SmeltList<_> = (flat_map_depth(_smelt_tmp_N, Some(SmeltUnknown::Function({ let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>((smelt_callback)((smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).into_smelt_unknown()))) })), Some(N.N))?).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) };",
+      "occurrences": 19,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/union.rs:32"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltRecord<String, SmeltUnknown> = match (omit_by_N(SmeltUnknown::Object(SmeltObject::from_unknown_record((obj).clone())), &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: String| match (_smelt_adapted_callback)(argN).clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true } })).into_smelt_unknown() { SmeltUnknown::Object(value) => SmeltRecord::with_id_from_entries(value.id, value.into_iter()), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), value)).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| (index.to_string(), SmeltUnknown::String(ch.to_string()))).collect(), SmeltUnknown::Function(value) => SmeltRecord::from([(\"S\".to_owned(), SmeltUnknown::Function(value))]), _ => SmeltRecord::new() };",
       "occurrences": 19,
       "files": 1,
@@ -5154,6 +5161,13 @@
     },
     {
       "category": "avoidable-erasure",
+      "shape": "_smelt_tmp_N = matches!(value_to_clone.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
+      "occurrences": 19,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:220"
+    },
+    {
+      "category": "avoidable-erasure",
       "shape": "let mut _smelt_tmp_N: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, Option<SmeltUnknown>, Option<SmeltUnknown>, Option<SmeltUnknown>) -> SmeltUnknown> = { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, Option<SmeltUnknown>, Option<SmeltUnknown>, Option<SmeltUnknown>) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltUnknown, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback };",
       "occurrences": 19,
       "files": 1,
@@ -5185,7 +5199,7 @@
       "shape": "_smelt_tmp_N = { let smelt_function_value = _smelt_tmp_N.clone(); let smelt_call_args: Vec<SmeltUnknown> = Into::into(vec![SmeltUnknown::Array(_smelt_tmp_N.into()), match value_to_clone.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone(), SmeltUnknown::Object(SmeltObject::from_unknown_record((_smelt_tmp_N).clone()))]); let smelt_callable = match smelt_function_value { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function.clone()), _ => None }, _ => None }; if let Some(smelt_function) = smelt_callable { (smelt_function)(smelt_call_args).unwrap_or_else(|error| panic!(\"S\", error)) } else { SmeltUnknown::Null } };",
       "occurrences": 18,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:353"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:373"
     },
     {
       "category": "legitimate-boundary",
@@ -5199,7 +5213,7 @@
       "shape": "_smelt_tmp_N = { let smelt_function_value = constructor.clone(); let smelt_call_args: Vec<SmeltUnknown> = Into::into(vec![{ let smelt_l = _smelt_tmp_N; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }, match obj.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone(), SmeltUnknown::Object(SmeltObject::from_unknown_record((_smelt_tmp_N).clone()))]); let smelt_callable = match smelt_function_value { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function.clone()), _ => None }, _ => None }; if let Some(smelt_function) = smelt_callable { (smelt_function)(smelt_call_args).unwrap_or_else(|error| panic!(\"S\", error)) } else { SmeltUnknown::Null } };",
       "occurrences": 18,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:145"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:152"
     },
     {
       "category": "legitimate-boundary",
@@ -5217,17 +5231,17 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = { let smelt_l: SmeltList<_> = (flat_map_depth(_smelt_tmp_N, Some(SmeltUnknown::Function({ let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>((smelt_callback)((smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).into_smelt_unknown()))) })), Some(N.N))?).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) };",
-      "occurrences": 18,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/union.rs:32"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_l: SmeltList<_> = (flat_map_N({ let smelt_l: SmeltList<_> = (origin_arr).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>()) }, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: fN, argN: SmeltList<SmeltUnknown>| { let smelt_l = (_smelt_adapted_callback)(match argN.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) } }, None::<SmeltUnknown>)).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| value).collect::<Vec<_>>()) };",
       "occurrences": 18,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatMap_spec.rs:25"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_src = (merge_with_N(SmeltUnknown::Array(_smelt_tmp_N.into()), SmeltUnknown::Array(_smelt_tmp_N.into()), &*merge)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
+      "occurrences": 18,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/mergeWith.rs:100"
     },
     {
       "category": "legitimate-boundary",
@@ -5336,13 +5350,6 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = matches!(value_to_clone.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
-      "occurrences": 18,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:219"
-    },
-    {
-      "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltUnknown> = vec![SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN), SmeltUnknown::Number(N.N as fN)]; smelt_list_items }));",
       "occurrences": 18,
       "files": 1,
@@ -5444,7 +5451,14 @@
       "shape": "_smelt_tmp_N = (i_N.clone()) < (match match value_to_clone.clone() { SmeltUnknown::String(value) => SmeltUnknown::Number(value.chars().count() as fN), SmeltUnknown::Array(value) => SmeltUnknown::Number(value.len() as fN), SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Null }.clone().clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN });",
       "occurrences": 17,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:294"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:314"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (match _smelt_tmp_N.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 17,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/debounce_spec.rs:482"
     },
     {
       "category": "legitimate-boundary",
@@ -5490,10 +5504,17 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_src = (merge_with_N(SmeltUnknown::Array(_smelt_tmp_N.into()), SmeltUnknown::Array(_smelt_tmp_N.into()), &*merge)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_l: SmeltList<_> = (difference_by_N({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| value).collect::<Vec<_>>()) }, { let smelt_l: SmeltList<_> = (values).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>()) }, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown| _smelt_adapted_callback.call({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) })).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>()) };",
       "occurrences": 17,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/mergeWith.rs:100"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/differenceBy.rs:32"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_src = (clone_N(SmeltUnknown::Array(_smelt_tmp_N.clone().into()))).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
+      "occurrences": 17,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toMerged.rs:30"
     },
     {
       "category": "legitimate-boundary",
@@ -5528,7 +5549,7 @@
       "shape": "return match match target.clone() { SmeltUnknown::String(value) => SmeltUnknown::Number(value.chars().count() as fN), SmeltUnknown::Array(value) => SmeltUnknown::Number(value.len() as fN), SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Null }.clone().clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN };",
       "occurrences": 17,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/size.rs:19"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/size.rs:20"
     },
     {
       "category": "legitimate-boundary",
@@ -5563,14 +5584,49 @@
       "shape": "Self::MN(value) => { let smelt_function_value = value; let smelt_function_origin = smelt_function_value.clone(); let smelt_erased_function: ::std::rc::Rc<dyn Fn(Vec<SmeltUnknown>) -> Result<SmeltUnknown, Box<dyn std::error::Error>>> = ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::Number((smelt_function_value)(match smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }) as fN))); smelt_register_function_origin(&smelt_erased_function, smelt_function_origin); SmeltUnknown::Function(smelt_erased_function) },",
       "occurrences": 16,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5309"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5323"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_abort_method(object: SmeltObject, method: &str) -> SmeltUnknown { let method = method.to_owned(); SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { let signal = smelt_abort_signal_object(&object); match method.as_str() { \"S\" | \"S\" => { if let Some(signal) = signal { smelt_abort_signal_fire(&signal); } Ok(if method == \"S\" { SmeltUnknown::Bool(true) } else { SmeltUnknown::Undefined }) } \"S\" => { if let Some(signal) = signal { let event_type = match args.first() { Some(SmeltUnknown::String(value)) => value.clone(), _ => String::new() }; if event_type == \"S\" { if let Some(listener @ SmeltUnknown::Function(_)) = args.get(N).cloned() { let mut listeners = match signal.get(\"S\") { Some(SmeltUnknown::Array(values)) => values.into_vec(), _ => Vec::new() }; listeners.push(listener); signal.insert(\"S\".to_owned(), SmeltUnknown::Array(listeners.into())); } } } Ok(SmeltUnknown::Undefined) } \"S\" => { if let Some(signal) = signal { if let Some(target @ SmeltUnknown::Function(_)) = args.get(N).cloned() { let listeners: Vec<SmeltUnknown> = match signal.get(\"S\") { Some(SmeltUnknown::Array(values)) => values.into_vec(), _ => Vec::new() }.into_iter().filter(|listener| !listener.js_strict_eq(&target)).collect(); signal.insert(\"S\".to_owned(), SmeltUnknown::Array(listeners.into())); } } Ok(SmeltUnknown::Undefined) } _ => Ok(SmeltUnknown::Undefined) } })) }",
       "occurrences": 16,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2766"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2767"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = ::std::rc::Rc::new({ let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown| _smelt_adapted_callback.call({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) });",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/countBy.rs:51"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltErasedFunction> = vec![SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None }, SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).clone().map_or(SmeltUnknown::Undefined, |value| (value).into_smelt_unknown())) }, length: N.N, object: None }]; smelt_list_items }));",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flowRight_spec.rs:108"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltErasedFunction> = vec![SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None }, SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| { let smelt_l = (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }) }, length: N.N, object: None }]; smelt_list_items }));",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flow_spec.rs:172"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltErasedFunction> = vec![SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).clone().map_or(SmeltUnknown::Undefined, |value| (value).into_smelt_unknown())) }, length: N.N, object: None }, SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None }]; smelt_list_items }));",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flow_spec.rs:108"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltErasedFunction> = vec![SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| { let smelt_l = (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }) }, length: N.N, object: None }, SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None }]; smelt_list_items }));",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flowRight_spec.rs:172"
     },
     {
       "category": "legitimate-boundary",
@@ -5588,10 +5644,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (match _smelt_tmp_N.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(value.clone().clone().map_or(SmeltList::new(Vec::<SmeltUnknown>::new()), |value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }));",
       "occurrences": 16,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/debounce_spec.rs:482"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isArrayLike.rs:26"
     },
     {
       "category": "legitimate-boundary",
@@ -5619,7 +5675,7 @@
       "shape": "_smelt_tmp_N = { let smelt_function = match match target.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone().clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltUnknown>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltUnknown { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(argN); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); smelt_result }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback } } };",
       "occurrences": 16,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1009"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1015"
     },
     {
       "category": "legitimate-boundary",
@@ -5633,7 +5689,7 @@
       "shape": "_smelt_tmp_N = { let smelt_function_value = constructor.clone(); let smelt_call_args: Vec<SmeltUnknown> = Into::into(vec![match obj.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone(), SmeltUnknown::Object(SmeltObject::from_unknown_record((_smelt_tmp_N).clone()))]); let smelt_callable = match smelt_function_value { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function.clone()), _ => None }, _ => None }; if let Some(smelt_function) = smelt_callable { (smelt_function)(smelt_call_args).unwrap_or_else(|error| panic!(\"S\", error)) } else { SmeltUnknown::Null } };",
       "occurrences": 16,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:126"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:133"
     },
     {
       "category": "legitimate-boundary",
@@ -5672,10 +5728,45 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: DebouncedFunction<SmeltErasedFunction> = { let smelt_struct_value = debounce_N(_smelt_tmp_N.clone().into_smelt_unknown(), throttle_ms.clone(), { let smelt_record_map = _smelt_tmp_N.clone(); DebounceOptions { signal: smelt_record_map.get(\"S\").cloned().map(|value| value), edges: smelt_record_map.get(\"S\").cloned().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) } }).clone(); DebouncedFunction { schedule: smelt_struct_value.schedule.clone().clone(), cancel: smelt_struct_value.cancel.clone().clone(), flush: smelt_struct_value.flush.clone().clone(), __smelt_call: smelt_struct_value.__smelt_call.clone().clone(), _smelt_phantom: ::std::marker::PhantomData } };",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/throttle.rs:33"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: DebouncedFunction<SmeltErasedFunction> = { let smelt_struct_value = debounce_N(func.clone().into_smelt_unknown(), debounce_ms, { let smelt_record_map = _smelt_tmp_N.clone(); DebounceOptions { signal: smelt_record_map.get(\"S\").cloned().map(|value| value), edges: smelt_record_map.get(\"S\").cloned().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) } }).clone(); DebouncedFunction { schedule: smelt_struct_value.schedule.clone().clone(), cancel: smelt_struct_value.cancel.clone().clone(), flush: smelt_struct_value.flush.clone().clone(), __smelt_call: smelt_struct_value.__smelt_call.clone().clone(), _smelt_phantom: ::std::marker::PhantomData } };",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/debounce_spec.rs:471"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltJsMap<SmeltUnknown, SmeltUnknown> = if let SmeltUnknown::Object(values) = clone_deep_N(SmeltUnknown::Object(SmeltObject::new(obj.clone().into_iter().map(|(key, value)| ({ fn smelt_property_key(value: SmeltUnknown) -> String { match value { SmeltUnknown::String(value) => value, SmeltUnknown::Symbol(value) => format!(\"S\"), SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(values) => values.into_vec().into_iter().map(smelt_property_key).collect::<Vec<_>>().join(\"S\"), SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() } } smelt_property_key(key) }, value)).collect())))?.clone() { SmeltJsMap::from_iter(values.into_iter().map(|(key, value)| (SmeltUnknown::String(key), value))) } else { SmeltJsMap::new() };",
       "occurrences": 16,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeep_spec.rs:148"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = unzip_N({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/unzipWith.rs:48"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = unzip_N({ let smelt_l: SmeltList<_> = (zippedN).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/unzip_spec.rs:105"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = { let smelt_l: SmeltList<_> = (uniq_N({ let smelt_l: SmeltList<_> = (flattened).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| value.into_smelt_unknown()).collect::<Vec<_>>()) })).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) };",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/union.rs:34"
     },
     {
       "category": "legitimate-boundary",
@@ -5707,20 +5798,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_l: SmeltList<_> = (difference_by_N({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| value).collect::<Vec<_>>()) }, { let smelt_l: SmeltList<_> = (values).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>()) }, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown| _smelt_adapted_callback.call({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) })).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>()) };",
-      "occurrences": 16,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/differenceBy.rs:32"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = { let smelt_src = (clone_N(SmeltUnknown::Array(_smelt_tmp_N.clone().into()))).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
-      "occurrences": 16,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toMerged.rs:30"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: fN = mean_by_N({ let smelt_l: SmeltList<_> = (people).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_object_value = value; let smelt_struct_value = smelt_object_value.clone(); let mut smelt_object_entries = ::std::collections::HashMap::new(); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::String(smelt_object_value.name)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Number(smelt_object_value.age as fN)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); SmeltUnknown::Object(SmeltObject::new(smelt_object_entries)) }).collect::<Vec<_>>()) }, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown| match (_smelt_adapted_callback)(argN).clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN } });",
       "occurrences": 16,
       "files": 1,
@@ -5739,6 +5816,20 @@
       "occurrences": 16,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/sumBy_spec.rs:40"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "mapper = ::std::rc::Rc::new({ let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown| _smelt_adapted_callback.call({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) });",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/xorBy.rs:50"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "return ::std::rc::Rc::new({ let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown| _smelt_adapted_callback.call({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }) });",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/unary_1.rs:9"
     },
     {
       "category": "avoidable-erasure",
@@ -5802,6 +5893,13 @@
       "occurrences": 16,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/orderBy.rs:281"
+    },
+    {
+      "category": "avoidable-erasure",
+      "shape": "_smelt_tmp_N = matches!(obj.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
+      "occurrences": 16,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:74"
     },
     {
       "category": "avoidable-erasure",
@@ -5969,56 +6067,77 @@
       "shape": "Self::MN({ let smelt_function = match value.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { if let Some(smelt_original) = smelt_restore_function_origin::<::std::rc::Rc<dyn Fn(fN) -> fN>>(&smelt_function) { smelt_original } else { let smelt_callback: ::std::rc::Rc<dyn Fn(fN) -> fN> = ::std::rc::Rc::new(move |argN: fN| -> fN { let smelt_result = (smelt_function)({ let mut smelt_call_args = Vec::new(); smelt_call_args.push(SmeltUnknown::Number(argN as fN)); smelt_call_args }).unwrap_or_else(|error| panic!(\"S\", error)); match smelt_result.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN } }); smelt_callback } } else { { let smelt_default_callback: ::std::rc::Rc<dyn Fn(fN) -> fN> = ::std::rc::Rc::new(move |argN: fN| -> fN { N.N }); smelt_default_callback } } })",
       "occurrences": 15,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5316"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5330"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_prototype_sentinel(value: &SmeltUnknown) -> SmeltUnknown { match value { SmeltUnknown::Null => SmeltUnknown::Null, SmeltUnknown::Array(_) => SmeltUnknown::String(\"S\".to_owned()), SmeltUnknown::Promise(_) => SmeltUnknown::String(\"S\".to_owned()), SmeltUnknown::Object(map) if map.contains_key(\"S\") => SmeltUnknown::String(\"S\".to_owned()), SmeltUnknown::String(marker) if marker == \"S\" => SmeltUnknown::Null, SmeltUnknown::String(marker) if marker == \"S\" || marker == \"S\" || marker == \"S\" => SmeltUnknown::String(\"S\".to_owned()), _ => SmeltUnknown::String(\"S\".to_owned()) } }",
       "occurrences": 15,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2617"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2618"
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = ::std::rc::Rc::new({ let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown| _smelt_adapted_callback.call({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) });",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
       "occurrences": 15,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/countBy.rs:51"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/unzip_1.rs:45"
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltErasedFunction> = vec![SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None }, SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).clone().map_or(SmeltUnknown::Undefined, |value| (value).into_smelt_unknown())) }, length: N.N, object: None }]; smelt_list_items }));",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (array).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
       "occurrences": 15,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flowRight_spec.rs:108"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/intersection.rs:54"
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltErasedFunction> = vec![SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None }, SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| { let smelt_l = (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }) }, length: N.N, object: None }]; smelt_list_items }));",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (deep_key.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
       "occurrences": 15,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flow_spec.rs:172"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPath.rs:61"
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltErasedFunction> = vec![SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).clone().map_or(SmeltUnknown::Undefined, |value| (value).into_smelt_unknown())) }, length: N.N, object: None }, SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None }]; smelt_list_items }));",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (keys).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
       "occurrences": 15,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flow_spec.rs:108"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/pick_1.rs:60"
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltErasedFunction> = vec![SmeltErasedFunction { callback: { let smelt_callback = _smelt_tmp_N.clone(); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| { let smelt_l = (smelt_callback)({ let smelt_src = (smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }); SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>())) }) }, length: N.N, object: None }, SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None }]; smelt_list_items }));",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (keys.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
       "occurrences": 15,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flowRight_spec.rs:172"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/zipObjectDeep.rs:40"
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(value.clone().clone().map_or(SmeltList::new(Vec::<SmeltUnknown>::new()), |value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }));",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (path.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
       "occurrences": 15,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isArrayLike.rs:26"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/invokeMap.rs:93"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (target_value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 15,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/mergeWith.rs:98"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (values.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 15,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/zipObjectDeep.rs:41"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (values_to_remove.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 15,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/pullAllBy.rs:31"
     },
     {
       "category": "legitimate-boundary",
@@ -6078,24 +6197,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = unzip_N({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltFuture<SmeltUnknown>> = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| SmeltFuture::resolved(SmeltUnknown::Null)).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| SmeltFuture::resolved(SmeltUnknown::Null)).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| SmeltFuture::resolved(SmeltUnknown::Null)).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
       "occurrences": 15,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/unzipWith.rs:48"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = unzip_N({ let smelt_l: SmeltList<_> = (zippedN).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
-      "occurrences": 15,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/unzip_spec.rs:105"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = { let smelt_l: SmeltList<_> = (uniq_N({ let smelt_l: SmeltList<_> = (flattened).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| value.into_smelt_unknown()).collect::<Vec<_>>()) })).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) };",
-      "occurrences": 15,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/union.rs:34"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/allKeyed.rs:65"
     },
     {
       "category": "legitimate-boundary",
@@ -6155,17 +6260,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "mapper = ::std::rc::Rc::new({ let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown| _smelt_adapted_callback.call({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) });",
+      "shape": "return { let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) };",
       "occurrences": 15,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/xorBy.rs:50"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "return ::std::rc::Rc::new({ let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown| _smelt_adapted_callback.call({ let smelt_src = (argN).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) });",
-      "occurrences": 15,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/unary_1.rs:9"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flattenDeep.rs:11"
     },
     {
       "category": "legitimate-boundary",
@@ -6176,7 +6274,7 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_key = key.clone(); match object.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"S\") && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
+      "shape": "_smelt_tmp_N = { let smelt_key = key.clone(); match object.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"S\") || values.contains_key(\"S\")) && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
       "occurrences": 15,
       "files": 5,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/assign.rs:42"
@@ -6235,77 +6333,14 @@
       "shape": "fn from_smelt_unknown(value: SmeltUnknown) -> Self {",
       "occurrences": 14,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4955"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4969"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl IntoSmeltUnknown for SmeltUnionN {",
       "occurrences": 14,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4946"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/unzip_1.rs:45"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (array).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/intersection.rs:54"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (deep_key.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPath.rs:61"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (keys).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/pick_1.rs:60"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (keys.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/zipObjectDeep.rs:40"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (path.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/invokeMap.rs:93"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (target_value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/mergeWith.rs:98"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (values.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/zipObjectDeep.rs:41"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (values_to_remove.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/pullAllBy.rs:31"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4960"
     },
     {
       "category": "legitimate-boundary",
@@ -6354,7 +6389,7 @@
       "shape": "_smelt_tmp_N = { let smelt_function_value = _smelt_tmp_N.clone(); let smelt_call_args: Vec<SmeltUnknown> = Into::into(vec![SmeltUnknown::Array(_smelt_tmp_N.into()), SmeltUnknown::Object(SmeltObject::from_unknown_record((_smelt_tmp_N).clone()))]); let smelt_callable = match smelt_function_value { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function.clone()), _ => None }, _ => None }; if let Some(smelt_function) = smelt_callable { (smelt_function)(smelt_call_args).unwrap_or_else(|error| panic!(\"S\", error)) } else { SmeltUnknown::Null } };",
       "occurrences": 14,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:384"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:404"
     },
     {
       "category": "legitimate-boundary",
@@ -6449,20 +6484,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: DebouncedFunction<SmeltErasedFunction> = { let smelt_struct_value = debounce_N(_smelt_tmp_N.clone().into_smelt_unknown(), throttle_ms.clone(), { let smelt_record_map = _smelt_tmp_N.clone(); DebounceOptions { signal: smelt_record_map.get(\"S\").cloned().map(|value| value), edges: smelt_record_map.get(\"S\").cloned().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) } }).clone(); DebouncedFunction { schedule: smelt_struct_value.schedule.clone().clone(), cancel: smelt_struct_value.cancel.clone().clone(), flush: smelt_struct_value.flush.clone().clone(), __smelt_call: smelt_struct_value.__smelt_call.clone().clone(), _smelt_phantom: ::std::marker::PhantomData } };",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/throttle.rs:33"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: DebouncedFunction<SmeltErasedFunction> = { let smelt_struct_value = debounce_N(func.clone().into_smelt_unknown(), debounce_ms, { let smelt_record_map = _smelt_tmp_N.clone(); DebounceOptions { signal: smelt_record_map.get(\"S\").cloned().map(|value| value), edges: smelt_record_map.get(\"S\").cloned().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value { value } else { value.to_string() }).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }) } }).clone(); DebouncedFunction { schedule: smelt_struct_value.schedule.clone().clone(), cancel: smelt_struct_value.cancel.clone().clone(), flush: smelt_struct_value.flush.clone().clone(), __smelt_call: smelt_struct_value.__smelt_call.clone().clone(), _smelt_phantom: ::std::marker::PhantomData } };",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/debounce_spec.rs:471"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: Option<String> = find_key_N(obj.clone().clone().map_or(SmeltUnknown::Undefined, |value| (value).into_smelt_unknown()), &mut { let _smelt_adapted_callback = iteratee.clone(); move |argN: SmeltUnknown, argN: String, argN: SmeltUnknown| match _smelt_adapted_callback.call({ let mut smelt_forwarded_args = Vec::new(); smelt_forwarded_args.push(argN); smelt_forwarded_args.push(SmeltUnknown::String(argN)); smelt_forwarded_args.push((argN).into_smelt_unknown()); Into::<SmeltList<_>>::into(smelt_forwarded_args) }).clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true } });",
       "occurrences": 14,
       "files": 1,
@@ -6547,13 +6568,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "return { let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) };",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flattenDeep.rs:11"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "{ let smelt_assign_index = { let len = tuple.len() as iN; let index = i_N.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }; if smelt_assign_index >= tuple.len() { tuple.resize(smelt_assign_index.saturating_add(N), SmeltUnknown::Null); } tuple[smelt_assign_index] = arr.get({ let len = arr.len() as iN; let index = match indices.get({ let len = indices.len() as iN; let index = i_N.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone().clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN } as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone(); }",
       "occurrences": 14,
       "files": 1,
@@ -6572,13 +6586,6 @@
       "occurrences": 14,
       "files": 6,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/add.rs:44"
-    },
-    {
-      "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = matches!(obj.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
-      "occurrences": 14,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:73"
     },
     {
       "category": "avoidable-erasure",
@@ -6760,7 +6767,7 @@
       "shape": "_smelt_tmp_N = { let smelt_function_value = match _smelt_tmp_N.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone().clone(); let smelt_call_args: Vec<SmeltUnknown> = Into::into(vec![match value_to_clone.clone() { SmeltUnknown::String(value) => SmeltUnknown::Number(value.chars().count() as fN), SmeltUnknown::Array(value) => SmeltUnknown::Number(value.len() as fN), SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Null }.clone()]); let smelt_callable = match smelt_function_value { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function.clone()), _ => None }, _ => None }; if let Some(smelt_function) = smelt_callable { (smelt_function)(smelt_call_args).unwrap_or_else(|error| panic!(\"S\", error)) } else { SmeltUnknown::Null } };",
       "occurrences": 13,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:289"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:309"
     },
     {
       "category": "legitimate-boundary",
@@ -6792,10 +6799,10 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltFuture<SmeltUnknown>> = Into::<SmeltList<_>>::into({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| SmeltFuture::resolved(SmeltUnknown::Null)).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| SmeltFuture::resolved(SmeltUnknown::Null)).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = fill_N(&mut { let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| value).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }, value.clone(), start.clone(), Some(SmeltUnknown::Number(_smelt_tmp_N as fN)));",
       "occurrences": 13,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/allKeyed.rs:65"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/fill.rs:60"
     },
     {
       "category": "legitimate-boundary",
@@ -6914,7 +6921,7 @@
       "shape": "return match match target.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone().clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN };",
       "occurrences": 13,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/size.rs:24"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/size.rs:31"
     },
     {
       "category": "legitimate-boundary",
@@ -6928,7 +6935,7 @@
       "shape": "}); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::String((smelt_callback)(if smelt_args.get(N).is_some() { { let smelt_optional_source = smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null); if smelt_unknown_is_nullish(&smelt_optional_source.clone()) { None } else { Some(match smelt_optional_source.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) } } } else { None::<String> })))) })).clone())",
       "occurrences": 13,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5499"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5513"
     },
     {
       "category": "avoidable-erasure",
@@ -6942,7 +6949,7 @@
       "shape": "_smelt_tmp_N = SmeltUnknown::Array(_smelt_tmp_N.into());",
       "occurrences": 13,
       "files": 7,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:357"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:377"
     },
     {
       "category": "avoidable-erasure",
@@ -7005,14 +7012,14 @@
       "shape": "Self::MN(if let SmeltUnknown::Array(smelt_tuple_values) = value.clone() { (match smelt_tuple_values.get(N).cloned().unwrap_or(SmeltUnknown::Null).clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() },) } else { panic!(\"S\") })",
       "occurrences": 12,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4992"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5006"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_object_to_string_tag(value: &SmeltUnknown) -> String { match value { SmeltUnknown::Null => \"S\".to_owned(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Bool(_) => \"S\".to_owned(), SmeltUnknown::Number(_) => \"S\".to_owned(), SmeltUnknown::String(_) => \"S\".to_owned(), SmeltUnknown::Symbol(_) => \"S\".to_owned(), SmeltUnknown::Array(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned(), SmeltUnknown::Object(map) => { if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { return \"S\".to_owned(); } if map.contains_key(\"S\") { if let Some(SmeltUnknown::String(name)) = map.get(\"S\") { return format!(\"S\"); } } \"S\".to_owned() } } }",
       "occurrences": 12,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2628"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2629"
     },
     {
       "category": "legitimate-boundary",
@@ -7041,6 +7048,13 @@
       "occurrences": 12,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/xorWith.rs:61"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (other_arrs.get({ let len = other_arrs.len() as iN; let index = i.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 12,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/intersectionWith.rs:68"
     },
     {
       "category": "legitimate-boundary",
@@ -7082,14 +7096,14 @@
       "shape": "_smelt_tmp_N = match (new_error.clone()).into_smelt_unknown() { SmeltUnknown::Object(value) => SmeltRecord::with_id_from_entries(value.id, value.into_iter()), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), value)).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| (index.to_string(), SmeltUnknown::String(ch.to_string()))).collect(), SmeltUnknown::Function(value) => SmeltRecord::from([(\"S\".to_owned(), SmeltUnknown::Function(value))]), _ => SmeltRecord::new() };",
       "occurrences": 12,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:130"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:137"
     },
     {
       "category": "legitimate-boundary",
       "shape": "_smelt_tmp_N = match (prototype).into_smelt_unknown() { SmeltUnknown::Object(value) => SmeltRecord::with_id_from_entries(value.id, value.into_iter()), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), value)).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| (index.to_string(), SmeltUnknown::String(ch.to_string()))).collect(), SmeltUnknown::Function(value) => SmeltRecord::from([(\"S\".to_owned(), SmeltUnknown::Function(value))]), _ => SmeltRecord::new() };",
       "occurrences": 12,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:152"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:159"
     },
     {
       "category": "legitimate-boundary",
@@ -7110,7 +7124,7 @@
       "shape": "_smelt_tmp_N = match match descriptor.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone().clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true };",
       "occurrences": 12,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:711"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:732"
     },
     {
       "category": "legitimate-boundary",
@@ -7124,7 +7138,7 @@
       "shape": "_smelt_tmp_N = matches!(obj.clone(), SmeltUnknown::Object(_) | SmeltUnknown::Array(_) | SmeltUnknown::Null | SmeltUnknown::Promise(_));",
       "occurrences": 12,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:149"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:156"
     },
     {
       "category": "legitimate-boundary",
@@ -7145,7 +7159,7 @@
       "shape": "_smelt_tmp_N = { _smelt_tmp_N.extend(match IntoSmeltUnknown::into_smelt_unknown(obj.clone().clone()) { SmeltUnknown::Object(map) => SmeltRecord::with_id_from_entries(map.id, map.into_iter().map(|(key, value)| (key, value))), _ => SmeltRecord::new() }.iter().map(|(key, value)| (key.clone(), value.clone()))); _smelt_tmp_N.clone() };",
       "occurrences": 12,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:92"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:93"
     },
     {
       "category": "legitimate-boundary",
@@ -7159,7 +7173,7 @@
       "shape": "_smelt_tmp_N = { let smelt_function_value = constructor.clone(); let smelt_call_args: Vec<SmeltUnknown> = Into::into(vec![SmeltUnknown::String(_smelt_tmp_N)]); let smelt_callable = match smelt_function_value { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function.clone()), _ => None }, _ => None }; if let Some(smelt_function) = smelt_callable { (smelt_function)(smelt_call_args).unwrap_or_else(|error| panic!(\"S\", error)) } else { SmeltUnknown::Null } };",
       "occurrences": 12,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:113"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:120"
     },
     {
       "category": "legitimate-boundary",
@@ -7174,6 +7188,13 @@
       "occurrences": 12,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/intersectionWith.rs:52"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "iteratees = Into::<SmeltList<_>>::into({ let smelt_src = (iteratees.get({ let len = iteratees.len() as iN; let index = N.N as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| value).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 12,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/over.rs:24"
     },
     {
       "category": "legitimate-boundary",
@@ -7226,6 +7247,20 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltList<SmeltUnknown>>> = { let smelt_l: SmeltList<_> = (windowed_N({ let smelt_l: SmeltList<_> = (arrays).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| value.into_smelt_unknown()).collect::<Vec<_>>()) }, N.N, None::<fN>, Default::default())?).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_l: SmeltList<_> = (value).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) }).collect::<Vec<_>>()) };",
+      "occurrences": 12,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/xorWith.rs:65"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = zip_N({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
+      "occurrences": 12,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/zip_spec.rs:130"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "let _smelt_tmp_N: SmeltList<SmeltList<fN>> = { let smelt_l: SmeltList<_> = (cartesian_product({ let smelt_l: SmeltList<_> = (inputs).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_l: SmeltList<_> = (value).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>()) }).collect::<Vec<_>>()) })).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_l: SmeltList<_> = (value).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| match value.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }).collect::<Vec<_>>()) }).collect::<Vec<_>>()) };",
       "occurrences": 12,
       "files": 1,
@@ -7233,10 +7268,24 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = fill_N(&mut { let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }, value.clone(), start.clone(), Some(SmeltUnknown::Number(_smelt_tmp_N as fN)));",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = flatten_array_like({ let smelt_l: SmeltList<_> = (_values.clone()).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
       "occurrences": 12,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/fill.rs:60"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/differenceBy.rs:22"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = shuffle_N({ let smelt_src = (collection.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 12,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/shuffle.rs:19"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = to_array_N({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 12,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/sample.rs:22"
     },
     {
       "category": "legitimate-boundary",
@@ -7492,7 +7541,7 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_key = \"S\".to_owned(); match result.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"S\") && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
+      "shape": "_smelt_tmp_N = { let smelt_key = \"S\".to_owned(); match result.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"S\") || values.contains_key(\"S\")) && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
       "occurrences": 12,
       "files": 2,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/toCamelCaseKeys_spec.rs:219"
@@ -7523,7 +7572,7 @@
       "shape": "let _smelt_tmp_N = are_values_equal.clone().clone().unwrap_or({ let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown, Option<SmeltUnknown>, SmeltUnknown, SmeltUnknown, SmeltUnknown) -> Option<bool>> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltUnknown, argN: Option<SmeltUnknown>, argN: SmeltUnknown, argN: SmeltUnknown, argN: SmeltUnknown| -> Option<bool> { None::<bool> }); smelt_default_callback });",
       "occurrences": 12,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:34"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:36"
     },
     {
       "category": "avoidable-erasure",
@@ -7726,7 +7775,7 @@
       "shape": "match &mut new_error { SmeltUnknown::Object(map) => { map.insert(\"S\".to_owned(), match obj.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone()); }, other => { let mut map = ::std::collections::HashMap::new(); map.insert(\"S\".to_owned(), match obj.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone()); *other = SmeltUnknown::Object(SmeltObject::new(map)); } }",
       "occurrences": 12,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:129"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:136"
     },
     {
       "category": "avoidable-erasure",
@@ -7775,7 +7824,7 @@
       "shape": "pub(crate) fn is_map_match(target: SmeltUnknown, source: SmeltJsMap<SmeltUnknown, SmeltUnknown>, compare: &dyn Fn(SmeltUnknown, SmeltUnknown, SmeltUnknown, SmeltUnknown, SmeltUnknown, Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>) -> Option<bool>, stack: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>) -> bool {",
       "occurrences": 12,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:970"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:976"
     },
     {
       "category": "avoidable-erasure",
@@ -7810,42 +7859,49 @@
       "shape": "Self::MN(match (value).into_smelt_unknown() { SmeltUnknown::Object(values) => { let smelt_record_map = SmeltRecord::with_id_from_entries(values.id, values.into_iter()); { let smelt_record_map = smelt_record_map.clone(); File { name: smelt_record_map.get(\"S\").cloned().map_or(String::new(), |value| match value.clone() { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }) } } }, _ => Default::default() })",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5421"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5435"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(SmeltObject::new(self.into_iter().map(|(key, value)| { let key = match key.into_smelt_unknown() { SmeltUnknown::String(value) => value, SmeltUnknown::Symbol(value) => format!(\"S\"), SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => \"S\".to_owned(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }; (key, value.into_smelt_unknown()) }).collect()))",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3483"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3497"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(SmeltObject::with_id(self.id, self.iter().into_iter().map(|(key, value)| { let key = match key.into_smelt_unknown() { SmeltUnknown::String(value) => value, SmeltUnknown::Symbol(value) => format!(\"S\"), SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => \"S\".to_owned(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }; (key, value.into_smelt_unknown()) }).collect()))",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3489"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3503"
     },
     {
       "category": "runtime-prelude",
       "shape": "if matches!(value, SmeltUnknown::Bool(_)) { return Self::MN(match value.clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true }); }",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5061"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5075"
     },
     {
       "category": "runtime-prelude",
       "shape": "match value { SmeltUnknown::Number(value) => value as iN, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value as iN, _ => N_iN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN) as iN, SmeltUnknown::Bool(value) => if value { N_iN } else { N_iN }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => N_iN }",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3382"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3394"
     },
     {
       "category": "runtime-prelude",
       "shape": "match value { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN }",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3376"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3388"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = ((*smelt_capture_recursive.borrow()))({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }, N.N);",
+      "occurrences": 11,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatten.rs:474"
     },
     {
       "category": "legitimate-boundary",
@@ -7926,10 +7982,31 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (other_arrs.get({ let len = other_arrs.len() as iN; let index = i.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/intersectionWith.rs:68"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/xorWith.rs:59"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_l: SmeltList<_> = (combine.clone()).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
+      "occurrences": 11,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/zipWith.rs:36"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 11,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/chunk_spec.rs:1625"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (keys).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| value).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) });",
+      "occurrences": 11,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/omit_1.rs:47"
     },
     {
       "category": "legitimate-boundary",
@@ -7937,6 +8014,13 @@
       "occurrences": 11,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/throttle_spec.rs:424"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = Some({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
+      "occurrences": 11,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/unzip.rs:41"
     },
     {
       "category": "legitimate-boundary",
@@ -8020,7 +8104,7 @@
       "shape": "_smelt_tmp_N = match value_to_clone.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN };",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:221"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:222"
     },
     {
       "category": "legitimate-boundary",
@@ -8101,13 +8185,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "iteratees = Into::<SmeltList<_>>::into({ let smelt_src = (iteratees.get({ let len = iteratees.len() as iN; let index = N.N as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 11,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/over.rs:24"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "length = match _smelt_tmp_N.clone() { SmeltUnknown::Number(value) => value, SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN }, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN };",
       "occurrences": 11,
       "files": 1,
@@ -8147,41 +8224,6 @@
       "occurrences": 11,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/filterAsync_spec.rs:237"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltList<SmeltUnknown>>> = { let smelt_l: SmeltList<_> = (windowed_N({ let smelt_l: SmeltList<_> = (arrays).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| value.into_smelt_unknown()).collect::<Vec<_>>()) }, N.N, None::<fN>, Default::default())?).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_l: SmeltList<_> = (value).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) }).collect::<Vec<_>>()) };",
-      "occurrences": 11,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/xorWith.rs:65"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltList<SmeltUnknown>> = zip_N({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
-      "occurrences": 11,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/zip_spec.rs:130"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = flatten_array_like({ let smelt_l: SmeltList<_> = (_values.clone()).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
-      "occurrences": 11,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/differenceBy.rs:22"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = shuffle_N({ let smelt_src = (collection.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 11,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/shuffle.rs:19"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = to_array_N({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 11,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/sample.rs:22"
     },
     {
       "category": "legitimate-boundary",
@@ -8244,7 +8286,7 @@
       "shape": "let _smelt_tmp_N: bool = is_equal_with_N(a.clone(), b.clone(), &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>| (_smelt_adapted_callback)({ let mut smelt_forwarded_args = Vec::new(); smelt_forwarded_args.push(argN); smelt_forwarded_args.push(argN); smelt_forwarded_args.push(argN.clone().map_or(SmeltUnknown::Undefined, |value| value)); smelt_forwarded_args.push(argN.clone().map_or(SmeltUnknown::Undefined, |value| value)); smelt_forwarded_args.push(argN.clone().map_or(SmeltUnknown::Undefined, |value| value)); smelt_forwarded_args.push(argN.clone().map_or(SmeltUnknown::Undefined, |value| (value).clone().into_smelt_unknown())); Into::<SmeltList<_>>::into(smelt_forwarded_args) }).unwrap_or_else(|error| panic!(\"S\", error)) });",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:115"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:121"
     },
     {
       "category": "legitimate-boundary",
@@ -8325,6 +8367,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "return { let smelt_l: SmeltList<_> = (result).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"S\") { members.into_vec().into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>() } else { match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") } }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) };",
+      "occurrences": 11,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/zip_1.rs:65"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "{ let smelt_key = { fn smelt_property_key(value: SmeltUnknown) -> String { match value { SmeltUnknown::String(value) => value, SmeltUnknown::Symbol(value) => format!(\"S\"), SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(values) => values.into_vec().into_iter().map(smelt_property_key).collect::<Vec<_>>().join(\"S\"), SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() } } smelt_property_key((key.clone()).into_smelt_unknown()) }; let smelt_value = match obj.clone() {",
       "occurrences": 11,
       "files": 1,
@@ -8356,7 +8405,7 @@
       "shape": "_smelt_tmp_N = SmeltRecord::from([(\"S\".to_owned(), SmeltUnknown::Bool(true))]);",
       "occurrences": 11,
       "files": 8,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:330"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:350"
     },
     {
       "category": "avoidable-erasure",
@@ -8370,7 +8419,7 @@
       "shape": "fn __smelt_fn_value_N() -> SmeltUnknown {",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5446"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5460"
     },
     {
       "category": "avoidable-erasure",
@@ -8468,14 +8517,14 @@
       "shape": "pub(crate) fn copy_properties(mut target: SmeltUnknown, source: SmeltUnknown, object_to_clone: Option<SmeltUnknown>, stack: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>, clone_value: Option<::std::rc::Rc<dyn Fn(SmeltUnknown, Option<SmeltUnknown>, SmeltUnknown, SmeltJsMap<SmeltUnknown, SmeltUnknown>) -> SmeltUnknown>>) -> Result<(), Box<dyn std::error::Error>> {",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:634"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:655"
     },
     {
       "category": "avoidable-erasure",
       "shape": "pub(crate) fn is_array_match(target: SmeltUnknown, source: SmeltList<SmeltUnknown>, compare: &dyn Fn(SmeltUnknown, SmeltUnknown, SmeltUnknown, SmeltUnknown, SmeltUnknown, Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>) -> Option<bool>, stack: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>) -> bool {",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1025"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1031"
     },
     {
       "category": "avoidable-erasure",
@@ -8496,42 +8545,42 @@
       "shape": "pub(crate) fn is_set_match(target: SmeltUnknown, source: SmeltJsSet<SmeltUnknown>, compare: &dyn Fn(SmeltUnknown, SmeltUnknown, SmeltUnknown, SmeltUnknown, SmeltUnknown, Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>) -> Option<bool>, stack: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>) -> bool {",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1125"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1131"
     },
     {
       "category": "avoidable-erasure",
       "shape": "thread_local! { static SMELT_FN_VALUE: ::std::cell::OnceCell<SmeltUnknown> = ::std::cell::OnceCell::new(); }",
       "occurrences": 11,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5447"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5461"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(match value.clone() { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true })",
       "occurrences": 10,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5027"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5041"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn same_js_key(&self, other: &Self) -> bool { match (self, other) { (SmeltUnknown::Number(left), SmeltUnknown::Number(right)) if left.is_nan() && right.is_nan() => true, (SmeltUnknown::Array(left), SmeltUnknown::Array(right)) => left.id == right.id, (SmeltUnknown::Object(left), SmeltUnknown::Object(right)) => left.id == right.id, (SmeltUnknown::Function(left), SmeltUnknown::Function(right)) => ::std::rc::Rc::ptr_eq(left, right), (SmeltUnknown::Promise(left), SmeltUnknown::Promise(right)) => left.id == right.id, _ => self == other } }",
       "occurrences": 10,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2558"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2559"
     },
     {
       "category": "runtime-prelude",
       "shape": "match value { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true }",
       "occurrences": 10,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3370"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3382"
     },
     {
       "category": "runtime-prelude",
       "shape": "match value { SmeltUnknown::String(value) | SmeltUnknown::Symbol(value) => value, SmeltUnknown::Number(value) => value.to_string(), SmeltUnknown::Bool(value) => value.to_string(), SmeltUnknown::Null => String::new(), SmeltUnknown::Undefined => \"S\".to_owned(), SmeltUnknown::Array(_) | SmeltUnknown::Object(_) => \"S\".to_owned(), SmeltUnknown::Function(_) => \"S\".to_owned(), SmeltUnknown::Promise(_) => \"S\".to_owned() }",
       "occurrences": 10,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3388"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3400"
     },
     {
       "category": "legitimate-boundary",
@@ -8563,13 +8612,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = ((*smelt_capture_recursive.borrow()))({ let smelt_src = (_smelt_tmp_N).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }, N.N);",
-      "occurrences": 10,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/flatten.rs:474"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltUnknown> = vec![SmeltUnknown::Number(N.N as fN), _smelt_tmp_N.clone(), SmeltUnknown::String(\"S\".to_owned()), (_smelt_tmp_N.clone()).clone().into_smelt_unknown(), match _smelt_tmp_N.clone().clone() { SmeltUnknown::Object(value) if value.contains_key(\"S\") => SmeltUnknown::Object(value), SmeltUnknown::Number(value) => SmeltUnknown::Object(SmeltObject::new(::std::collections::HashMap::from([(\"S\".to_owned(), SmeltUnknown::Number(value))]))), value => value }, _smelt_tmp_N.clone(), { let smelt_record = (_smelt_tmp_N.clone()).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, SmeltUnknown::Number(value as fN))).collect())) }]; smelt_list_items }));",
       "occurrences": 10,
       "files": 1,
@@ -8588,41 +8630,6 @@
       "occurrences": 10,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPath.rs:70"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
-      "occurrences": 10,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/xorWith.rs:59"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_l: SmeltList<_> = (combine.clone()).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
-      "occurrences": 10,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/zipWith.rs:36"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (closure_arg_N.clone()).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 10,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/chunk_spec.rs:1625"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into({ let smelt_src = (keys).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| value).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) });",
-      "occurrences": 10,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/omit_1.rs:47"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "_smelt_tmp_N = Some({ let smelt_l: SmeltList<_> = (_smelt_tmp_N).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) });",
-      "occurrences": 10,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/unzip.rs:41"
     },
     {
       "category": "legitimate-boundary",
@@ -8776,7 +8783,7 @@
       "shape": "_smelt_tmp_N = { let smelt_function_value = constructor.clone(); let smelt_call_args: Vec<SmeltUnknown> = Into::into(vec![obj.clone()]); let smelt_callable = match smelt_function_value { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function.clone()), _ => None }, _ => None }; if let Some(smelt_function) = smelt_callable { (smelt_function)(smelt_call_args).unwrap_or_else(|error| panic!(\"S\", error)) } else { SmeltUnknown::Null } };",
       "occurrences": 10,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:106"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:113"
     },
     {
       "category": "legitimate-boundary",
@@ -8983,13 +8990,6 @@
     },
     {
       "category": "legitimate-boundary",
-      "shape": "return { let smelt_l: SmeltList<_> = (result).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_src = (value).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src { value.id } else { smelt_next_object_id() }; SmeltList::with_id(smelt_id, match smelt_src { SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) { SmeltUnknown::Array(values) => values.into_iter().map(|value| (value).into_smelt_unknown()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"S\") }, _ => panic!(\"S\") }, _ => panic!(\"S\") }) }).collect::<Vec<_>>()) };",
-      "occurrences": 10,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/zip_1.rs:65"
-    },
-    {
-      "category": "legitimate-boundary",
       "shape": "}); let smelt_array = sub_array; smelt_array.iter().enumerate().find_map(|(index, item)| if match ((smelt_callback)(item.clone(), index as iN, smelt_array.clone())) { SmeltUnknown::Null | SmeltUnknown::Undefined => false, SmeltUnknown::Bool(value) => value, SmeltUnknown::Number(value) => value != N.N && !value.is_nan(), SmeltUnknown::String(value) => !value.is_empty(), SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Object(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => true } { Some(index as fN) } else { None }).unwrap_or(-N.N) };",
       "occurrences": 10,
       "files": 1,
@@ -9112,7 +9112,7 @@
       "shape": "_smelt_tmp_N = match _smelt_tmp_N.clone() { SmeltUnknown::Object(value) if value.contains_key(\"S\") => SmeltUnknown::Object(value), SmeltUnknown::Number(value) => SmeltUnknown::Object(SmeltObject::new(::std::collections::HashMap::from([(\"S\".to_owned(), SmeltUnknown::Number(value))]))), value => value };",
       "occurrences": 10,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:223"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:224"
     },
     {
       "category": "avoidable-erasure",
@@ -9322,7 +9322,7 @@
       "shape": "let mut _smelt_tmp_N: SmeltJsSet<SmeltUnknown>;",
       "occurrences": 10,
       "files": 6,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:81"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:82"
     },
     {
       "category": "avoidable-erasure",
@@ -9357,21 +9357,21 @@
       "shape": "Self::MN(value) => SmeltUnknown::Number(value as fN),",
       "occurrences": 9,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4949"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4963"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_array_sort_method(values: SmeltArray) -> SmeltUnknown { SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { let mut sorted = values.clone().into_vec(); if let Some(SmeltUnknown::Function(compare)) = args.get(N).cloned() { sorted.sort_by(|left, right| { let result = compare(vec![left.clone(), right.clone()]).unwrap_or(SmeltUnknown::Number(N.N)); let ordering = match result { SmeltUnknown::Number(value) => value, SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(N.N), SmeltUnknown::Bool(value) => if value { N.N } else { N.N }, _ => N.N }; if ordering < N.N { ::std::cmp::Ordering::Less } else if ordering > N.N { ::std::cmp::Ordering::Greater } else { ::std::cmp::Ordering::Equal } }); } else { sorted.sort_by(|left, right| left.to_string().cmp(&right.to_string())); } Ok(SmeltUnknown::Array(sorted.into())) })) }",
       "occurrences": 9,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2756"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2757"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_function_method(receiver: SmeltUnknown, method: &str) -> SmeltUnknown { match receiver { SmeltUnknown::Function(function) => { let method = method.to_owned(); SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { let forwarded: Vec<SmeltUnknown> = if method == \"S\" { match args.get(N) { Some(SmeltUnknown::Array(values)) => values.clone().into_vec(), _ => Vec::new() } } else { args.into_iter().skip(N).collect() }; function(forwarded) })) } SmeltUnknown::Object(map) => smelt_get_object_field(&map, method), _ => SmeltUnknown::Undefined } }",
       "occurrences": 9,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2759"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2760"
     },
     {
       "category": "legitimate-boundary",
@@ -9529,14 +9529,14 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_key = \"S\".to_owned(); match _smelt_tmp_N.clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"S\") && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
+      "shape": "_smelt_tmp_N = { let smelt_key = \"S\".to_owned(); match _smelt_tmp_N.clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"S\") || values.contains_key(\"S\")) && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
       "occurrences": 9,
       "files": 2,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/bindAll.rs:85"
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_key = _smelt_tmp_N; match object.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"S\") && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
+      "shape": "_smelt_tmp_N = { let smelt_key = _smelt_tmp_N; match object.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"S\") || values.contains_key(\"S\")) && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
       "occurrences": 9,
       "files": 3,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/get.rs:76"
@@ -9704,13 +9704,6 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = is_equal_with_N({ let smelt_list_id = smelt_list_identity(&(setN) as *const _ as *const () as usize); let mut values = setN.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(SmeltArray::with_id(smelt_list_id, values)) }, { let smelt_list_id = smelt_list_identity(&(setN) as *const _ as *const () as usize); let mut values = setN.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(SmeltArray::with_id(smelt_list_id, values)) }, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>| None::<bool> });",
-      "occurrences": 9,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_spec.rs:5550"
-    },
-    {
-      "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: bool = is_equal_with_N({ let smelt_record = (object).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, SmeltUnknown::Number(value as fN))).collect())) }, _smelt_tmp_N, &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>| None::<bool> });",
       "occurrences": 9,
       "files": 1,
@@ -9805,21 +9798,21 @@
       "shape": "(\"S\".to_owned(), self.concurrency.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::Number(value as fN))),",
       "occurrences": 8,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3535"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3549"
     },
     {
       "category": "runtime-prelude",
       "shape": "__smelt_call: SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None },",
       "occurrences": 8,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3629"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3643"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<F: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'",
       "occurrences": 8,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3623"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3637"
     },
     {
       "category": "legitimate-boundary",
@@ -9861,7 +9854,7 @@
       "shape": "_smelt_tmp_N = matches!(value_to_clone.clone(), SmeltUnknown::Object(_) | SmeltUnknown::Array(_) | SmeltUnknown::Null | SmeltUnknown::Promise(_));",
       "occurrences": 8,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:448"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:468"
     },
     {
       "category": "legitimate-boundary",
@@ -9890,13 +9883,6 @@
       "occurrences": 8,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/zipWith_1.rs:25"
-    },
-    {
-      "category": "legitimate-boundary",
-      "shape": "let _smelt_tmp_N: SmeltRecord<String, SmeltUnknown> = SmeltRecord::from([(\"S\".to_owned(), match date.clone().clone() { SmeltUnknown::Object(value) if value.contains_key(\"S\") => SmeltUnknown::Object(value), SmeltUnknown::Number(value) => SmeltUnknown::Object(SmeltObject::new(::std::collections::HashMap::from([(\"S\".to_owned(), SmeltUnknown::Number(value))]))), value => value }), (\"S\".to_owned(), (map.clone()).clone().into_smelt_unknown()), (\"S\".to_owned(), { let smelt_list_id = smelt_list_identity(&(set) as *const _ as *const () as usize); let mut values = set.clone().clone().into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(SmeltArray::with_id(smelt_list_id, values)) })]);",
-      "occurrences": 8,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toCamelCaseKeys_spec.rs:341"
     },
     {
       "category": "legitimate-boundary",
@@ -10190,7 +10176,7 @@
       "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltUnknown> = vec![value_to_clone.clone()]; smelt_list_items }));",
       "occurrences": 8,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:351"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:371"
     },
     {
       "category": "avoidable-erasure",
@@ -10246,21 +10232,21 @@
       "shape": "_smelt_tmp_N = SmeltRecord::from([(\"S\".to_owned(), match obj.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone()), (\"S\".to_owned(), match obj.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone())]);",
       "occurrences": 8,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:144"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:151"
     },
     {
       "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = SmeltRecord::from([(\"S\".to_owned(), match obj.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone())]);",
       "occurrences": 8,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:121"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:128"
     },
     {
       "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = SmeltRecord::from([(\"S\".to_owned(), match value_to_clone.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone())]);",
       "occurrences": 8,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:352"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:372"
     },
     {
       "category": "avoidable-erasure",
@@ -10715,7 +10701,7 @@
       "shape": "let mut _smelt_tmp_N: Option<SmeltUnknown> = None::<SmeltUnknown>;",
       "occurrences": 8,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:214"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:220"
     },
     {
       "category": "avoidable-erasure",
@@ -10799,7 +10785,7 @@
       "shape": "match &mut result { SmeltUnknown::Object(map) => { map.insert(\"S\".to_owned(), SmeltUnknown::Null); }, other => { let mut map = ::std::collections::HashMap::new(); map.insert(\"S\".to_owned(), SmeltUnknown::Null); *other = SmeltUnknown::Object(SmeltObject::new(map)); } }",
       "occurrences": 8,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:206"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:207"
     },
     {
       "category": "avoidable-erasure",
@@ -10897,21 +10883,21 @@
       "shape": "}.clone(), SmeltUnknown::String(key.clone()), target.clone(), source.clone(), stack.clone());",
       "occurrences": 8,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:380"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:386"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(value) => SmeltUnknown::String(value),",
       "occurrences": 7,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4950"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4964"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_abort_signal_fire(signal: &SmeltObject) { if matches!(signal.get(\"S\"), Some(SmeltUnknown::Bool(true))) { return; } signal.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); let listeners = match signal.get(\"S\") { Some(SmeltUnknown::Array(values)) => values.clone().into_vec(), _ => Vec::new() }; signal.insert(\"S\".to_owned(), SmeltUnknown::Array(Vec::new().into())); for listener in listeners { if let SmeltUnknown::Function(callback) = listener { let event = SmeltObject::new(::std::collections::HashMap::from([(\"S\".to_owned(), SmeltUnknown::String(\"S\".to_owned()))])); let _ = callback(vec![SmeltUnknown::Object(event)]); } } }",
       "occurrences": 7,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2764"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2765"
     },
     {
       "category": "runtime-prelude",
@@ -10925,21 +10911,21 @@
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> IntoSmeltUnknown for CurriedFunctionN<TN, TN, TN, TN, TN, R> {",
       "occurrences": 7,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3836"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3850"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> IntoSmeltUnknown for RightCurriedFunctionN<TN, TN, TN, TN, TN, R> {",
       "occurrences": 7,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3971"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3985"
     },
     {
       "category": "runtime-prelude",
       "shape": "set: { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown, argN: SmeltUnknown| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback },",
       "occurrences": 7,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4093"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4107"
     },
     {
       "category": "legitimate-boundary",
@@ -11146,6 +11132,13 @@
     },
     {
       "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: bool = is_equal_with_N((setN).clone().into_smelt_unknown(), (setN).clone().into_smelt_unknown(), &mut { let _smelt_adapted_callback = _smelt_tmp_N.clone(); move |argN: SmeltUnknown, argN: SmeltUnknown, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltUnknown>, argN: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>| None::<bool> });",
+      "occurrences": 7,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_spec.rs:5550"
+    },
+    {
+      "category": "legitimate-boundary",
       "shape": "return Ok({ let smelt_value = _smelt_tmp_N.clone(); let smelt_function = match smelt_value.clone() { SmeltUnknown::Function(smelt_function) => Some(smelt_function), SmeltUnknown::Object(smelt_object) => match smelt_object.get(\"S\") { Some(SmeltUnknown::Function(smelt_function)) => Some(smelt_function), _ => None }, _ => None }; if let Some(smelt_function) = smelt_function { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| (smelt_function)(smelt_args).unwrap_or_else(|error| panic!(\"S\", error))), length: N.N, object: match smelt_value { SmeltUnknown::Object(object) => Some(object), _ => None } } } else { SmeltErasedFunction { callback: ::std::rc::Rc::new(move |_smelt_args: Vec<SmeltUnknown>| SmeltUnknown::Null), length: N.N, object: None } } });",
       "occurrences": 7,
       "files": 1,
@@ -11205,7 +11198,7 @@
       "shape": "_smelt_tmp_N = match _smelt_tmp_N.clone() { SmeltUnknown::String(value) => SmeltUnknown::Number(value.chars().count() as fN), SmeltUnknown::Array(value) => SmeltUnknown::Number(value.len() as fN), SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Null }.clone().js_strict_eq(&SmeltUnknown::Number(N.N as fN));",
       "occurrences": 7,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEmpty.rs:95"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEmpty.rs:97"
     },
     {
       "category": "avoidable-erasure",
@@ -11412,6 +11405,13 @@
     },
     {
       "category": "avoidable-erasure",
+      "shape": "let _smelt_tmp_N: bool = matches!(value.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
+      "occurrences": 7,
+      "files": 7,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isArrayBuffer_1.rs:8"
+    },
+    {
+      "category": "avoidable-erasure",
       "shape": "let error: Option<SmeltUnknown>;",
       "occurrences": 7,
       "files": 2,
@@ -11576,84 +11576,91 @@
       "shape": "return SmeltUnknown::Object(SmeltObject::from_unknown_record((_smelt_tmp_N).clone()));",
       "occurrences": 7,
       "files": 4,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:93"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:94"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.edges.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::Array(value.into_iter().map(|value| SmeltUnknown::String(value)).collect()))),",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3609"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3623"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.signal.map_or(SmeltUnknown::Undefined, |value| (value).into_smelt_unknown())),",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3547"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3561"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.trailing.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::Bool(value))),",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3990"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4004"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(match value.clone() { SmeltUnknown::Object(value) => SmeltRegExp::new(match value.get(\"S\") { Some(SmeltUnknown::String(source)) => source, _ => String::new() }, match value.get(\"S\") { Some(SmeltUnknown::String(flags)) => flags, _ => String::new() }), _ => SmeltRegExp::default() })",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5208"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5222"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Null | SmeltUnknown::Undefined | SmeltUnknown::Symbol(_) | SmeltUnknown::Array(_) | SmeltUnknown::Function(_) | SmeltUnknown::Promise(_) => fN::NAN,",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3312"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3324"
     },
     {
       "category": "runtime-prelude",
       "shape": "flush: { let smelt_default_callback: ::std::rc::Rc<dyn Fn() -> Option<SmeltUnknown>> = ::std::rc::Rc::new(move || -> Option<SmeltUnknown> { None::<SmeltUnknown> }); smelt_default_callback },",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4023"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4037"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl<T: IntoSmeltUnknown + Clone> IntoSmeltUnknown for SmeltJsSet<T> { fn into_smelt_unknown(self) -> SmeltUnknown { let id = self.id; let mut members = self.entries.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>(); members.sort_by_key(smelt_unknown_stable_hash_key); let mut object = ::std::collections::HashMap::new(); object.insert(\"S\".to_owned(), SmeltUnknown::Array(SmeltArray::with_id(smelt_next_object_id(), members))); SmeltUnknown::Object(SmeltObject::with_id(id, object)) } }",
+      "occurrences": 6,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2552"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> ::std::fmt::Debug for CurriedFunctionN<TN, TN, TN, TN, TN, R> {",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3831"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3845"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> ::std::fmt::Debug for RightCurriedFunctionN<TN, TN, TN, TN, TN, R> {",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3966"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3980"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> Default for CurriedFunctionN<TN, TN, TN, TN, TN, R> {",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3823"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3837"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> Default for RightCurriedFunctionN<TN, TN, TN, TN, TN, R> {",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3958"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3972"
     },
     {
       "category": "runtime-prelude",
       "shape": "signal: Option<SmeltUnknown>,",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3542"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3556"
     },
     {
       "category": "legitimate-boundary",
@@ -11744,7 +11751,7 @@
       "shape": "_smelt_tmp_N = match (target.clone()).into_smelt_unknown() { SmeltUnknown::Object(value) => SmeltRecord::with_id_from_entries(value.id, value.into_iter()), SmeltUnknown::Array(values) => values.into_iter().enumerate().map(|(index, value)| (index.to_string(), value)).collect(), SmeltUnknown::String(value) => value.chars().enumerate().map(|(index, ch)| (index.to_string(), SmeltUnknown::String(ch.to_string()))).collect(), SmeltUnknown::Function(value) => SmeltRecord::from([(\"S\".to_owned(), SmeltUnknown::Function(value))]), _ => SmeltRecord::new() };",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/size.rs:26"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/size.rs:33"
     },
     {
       "category": "legitimate-boundary",
@@ -11870,7 +11877,7 @@
       "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = map_to_entries(<SmeltJsMap<SmeltUnknown, SmeltUnknown> as SmeltFromUnknown>::smelt_from_unknown((_smelt_tmp_N).into_smelt_unknown()));",
       "occurrences": 6,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPairs.rs:34"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPairs.rs:43"
     },
     {
       "category": "legitimate-boundary",
@@ -11906,6 +11913,13 @@
       "occurrences": 6,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/mergeWith_spec.rs:283"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltRecord<String, SmeltUnknown> = SmeltRecord::from([(\"S\".to_owned(), match date.clone().clone() { SmeltUnknown::Object(value) if value.contains_key(\"S\") => SmeltUnknown::Object(value), SmeltUnknown::Number(value) => SmeltUnknown::Object(SmeltObject::new(::std::collections::HashMap::from([(\"S\".to_owned(), SmeltUnknown::Number(value))]))), value => value }), (\"S\".to_owned(), (map.clone()).clone().into_smelt_unknown()), (\"S\".to_owned(), (set.clone()).clone().into_smelt_unknown())]);",
+      "occurrences": 6,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toCamelCaseKeys_spec.rs:341"
     },
     {
       "category": "legitimate-boundary",
@@ -12234,7 +12248,7 @@
       "shape": "_smelt_tmp_N = SmeltUnknown::Object(SmeltObject::new(::std::collections::HashMap::from([])));",
       "occurrences": 6,
       "files": 5,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:90"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:91"
     },
     {
       "category": "avoidable-erasure",
@@ -12273,6 +12287,13 @@
     },
     {
       "category": "avoidable-erasure",
+      "shape": "_smelt_tmp_N = matches!(_smelt_tmp_N.clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
+      "occurrences": 6,
+      "files": 3,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEmpty.rs:113"
+    },
+    {
+      "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = matches!(smelt_unknown_js_relational_ordering(&(index.clone()), &(match object.clone() { SmeltUnknown::String(value) => SmeltUnknown::Number(value.chars().count() as fN), SmeltUnknown::Array(value) => SmeltUnknown::Number(value.len() as fN), SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Null }.clone())), Some(::std::cmp::Ordering::Less));",
       "occurrences": 6,
       "files": 1,
@@ -12301,14 +12322,14 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_key = key.clone(); match source.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"S\") && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
+      "shape": "_smelt_tmp_N = { let smelt_key = key.clone(); match source.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"S\") || values.contains_key(\"S\")) && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
       "occurrences": 6,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_1.rs:478"
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_key = key.clone(); match target.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"S\") && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
+      "shape": "_smelt_tmp_N = { let smelt_key = key.clone(); match target.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"S\") || values.contains_key(\"S\")) && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
       "occurrences": 6,
       "files": 2,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/defaultsDeep.rs:128"
@@ -12423,7 +12444,7 @@
       "shape": "let _smelt_tmp_N: Option<bool> = (_smelt_tmp_N)(SmeltUnknown::Null, SmeltUnknown::Null, None::<SmeltUnknown>, SmeltUnknown::Null, SmeltUnknown::Null, SmeltUnknown::Null);",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:35"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:37"
     },
     {
       "category": "avoidable-erasure",
@@ -12766,7 +12787,7 @@
       "shape": "let _smelt_tmp_N: SmeltUnknown = toolkit_N(closure_arg_N.clone());",
       "occurrences": 6,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5481"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5495"
     },
     {
       "category": "avoidable-erasure",
@@ -12830,13 +12851,6 @@
       "occurrences": 6,
       "files": 6,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/compareValues_1.rs:9"
-    },
-    {
-      "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = matches!(value.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
-      "occurrences": 6,
-      "files": 6,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isArrayBuffer_1.rs:8"
     },
     {
       "category": "avoidable-erasure",
@@ -13074,77 +13088,84 @@
       "shape": "}); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>((smelt_callback)(if smelt_args.get(N).is_some() { Some(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)) } else { None::<SmeltUnknown> }))) })).clone())",
       "occurrences": 6,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5459"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5473"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "\"S\" => { let members = members.clone(); let receiver = SmeltUnknown::Object(map.clone()); return SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { if let Some(SmeltUnknown::Function(callback)) = args.into_iter().next() { for member in members.clone() { callback(vec![member.clone(), member.clone(), receiver.clone()])?; } } Ok(SmeltUnknown::Undefined) })); }",
+      "occurrences": 5,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2904"
     },
     {
       "category": "runtime-prelude",
       "shape": "cause: SmeltUnknown,",
       "occurrences": 5,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4621"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4635"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_from_unknown(value: SmeltUnknown) -> Self {",
       "occurrences": 5,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3363"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3375"
     },
     {
       "category": "runtime-prelude",
       "shape": "get: { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltUnknown> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> SmeltUnknown { SmeltUnknown::Null }); smelt_default_callback },",
       "occurrences": 5,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4091"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4105"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<K: SmeltFromUnknown + SmeltJsKeyEq + Clone, V: SmeltFromUnknown + Clone> SmeltFromUnknown for SmeltJsMap<K, V> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Object(object) => { if let Some(SmeltUnknown::Array(pairs)) = object.get(\"S\") { let mut map = SmeltJsMap { id: object.id, entries: Vec::new() }; for pair in pairs.into_vec() { if let SmeltUnknown::Array(entry) = pair { let mut entry = entry.into_vec().into_iter(); if let (Some(key), Some(value)) = (entry.next(), entry.next()) { map.insert(K::smelt_from_unknown(key), V::smelt_from_unknown(value)); } } } map } else { object.iter().map(|(key, value)| (K::smelt_from_unknown(SmeltUnknown::String(key)), V::smelt_from_unknown(value))).collect() } }, _ => SmeltJsMap::default() } } }",
       "occurrences": 5,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3396"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl<T: IntoSmeltUnknown> IntoSmeltUnknown for SmeltJsSet<T> { fn into_smelt_unknown(self) -> SmeltUnknown { let mut values = self.entries.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) } }",
-      "occurrences": 5,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2551"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3408"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<T: IntoSmeltUnknown> IntoSmeltUnknown for SmeltList<T> { fn into_smelt_unknown(self) -> SmeltUnknown { SmeltUnknown::Array(SmeltArray::with_id(self.id, self.values.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect())) } }",
       "occurrences": 5,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3356"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3368"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl<T: SmeltFromUnknown + Clone + IntoSmeltUnknown> SmeltFromUnknown for SmeltJsSet<T> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Object(object) => { if let Some(SmeltUnknown::Array(members)) = object.get(\"S\") { let mut set = SmeltJsSet { id: object.id, entries: Vec::new() }; for member in members.into_vec() { set.insert(T::smelt_from_unknown(member)); } set } else { SmeltJsSet::default() } }, SmeltUnknown::Array(members) => { let mut set = SmeltJsSet::new(); for member in members.into_vec() { set.insert(T::smelt_from_unknown(member)); } set }, _ => SmeltJsSet::default() } } }",
+      "occurrences": 5,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3410"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> IntoSmeltUnknown for CurriedFunctionN<TN, TN, TN, R> {",
       "occurrences": 5,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3782"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3796"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> IntoSmeltUnknown for RightCurriedFunctionN<TN, TN, TN, R> {",
       "occurrences": 5,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3917"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3931"
     },
     {
       "category": "runtime-prelude",
       "shape": "message: SmeltUnknown,",
       "occurrences": 5,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4619"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4633"
     },
     {
       "category": "runtime-prelude",
       "shape": "stack: SmeltUnknown,",
       "occurrences": 5,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4620"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4634"
     },
     {
       "category": "legitimate-boundary",
@@ -13424,14 +13445,14 @@
       "shape": "_smelt_tmp_N = matches!(target.clone(), SmeltUnknown::Null);",
       "occurrences": 5,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:181"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:187"
     },
     {
       "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = matches!(target.clone(), SmeltUnknown::Undefined);",
       "occurrences": 5,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:182"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:188"
     },
     {
       "category": "avoidable-erasure",
@@ -14026,7 +14047,7 @@
       "shape": "}); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::Array((smelt_callback)(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null), if smelt_args.get(N).is_some() { Some(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)) } else { None::<SmeltUnknown> })?.into()))) })).clone())",
       "occurrences": 5,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5467"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5481"
     },
     {
       "category": "avoidable-erasure",
@@ -14044,80 +14065,94 @@
     },
     {
       "category": "runtime-prelude",
+      "shape": "\"S\" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |_args: Vec<SmeltUnknown>| Ok(SmeltUnknown::Array(members.clone().into_iter().map(|value| SmeltUnknown::Array(vec![value.clone(), value].into())).collect::<Vec<_>>().into())))); }",
+      "occurrences": 4,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2902"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "\"S\" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { let needle = args.into_iter().next().unwrap_or(SmeltUnknown::Undefined); Ok(SmeltUnknown::Bool(members.iter().any(|member| member.same_js_key(&needle)))) })); }",
+      "occurrences": 4,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2903"
+    },
+    {
+      "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.leading.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::Bool(value))),",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3988"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4002"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.max_wait.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::Number(value as fN))),",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3989"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4003"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(value) => { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>())) },",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5125"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5139"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(value) => { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::String(value)).collect::<Vec<_>>())) },",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5090"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5104"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(value) => { let smelt_object_value = value; let smelt_struct_value = smelt_object_value.clone(); let mut smelt_object_entries = ::std::collections::HashMap::new(); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::String(smelt_object_value.name)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); SmeltUnknown::Object(SmeltObject::new(smelt_object_entries)) },",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5414"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5428"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(value) => { let smelt_record = (value).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_record = (value).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, SmeltUnknown::Number(value as fN))).collect())) }).collect::<Vec<_>>())) })).collect())) },",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5379"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5393"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(value) => { let smelt_record = (value).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, { let smelt_l = value; SmeltUnknown::Array(SmeltArray::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| { let smelt_record = (value).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, SmeltUnknown::String(value))).collect())) }).collect::<Vec<_>>())) })).collect())) },",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5378"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5392"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> ::std::fmt::Debug for CurriedFunctionN<TN, TN, TN, R> {",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3777"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3791"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> ::std::fmt::Debug for RightCurriedFunctionN<TN, TN, TN, R> {",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3912"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3926"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> Default for CurriedFunctionN<TN, TN, TN, R> {",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3769"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3783"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static, TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> Default for RightCurriedFunctionN<TN, TN, TN, R> {",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3904"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3918"
     },
     {
       "category": "runtime-prelude",
@@ -14131,28 +14166,28 @@
       "shape": "name: SmeltUnknown,",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4618"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4632"
     },
     {
       "category": "legitimate-boundary",
       "shape": "SMELT_FN_VALUE.with(|cell| cell.get_or_init(|| SmeltUnknown::Function({ let smelt_callback = ::std::rc::Rc::new(|closure_arg_N: Option<SmeltUnknown>| {",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5456"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5470"
     },
     {
       "category": "legitimate-boundary",
       "shape": "SMELT_FN_VALUE.with(|cell| cell.get_or_init(|| SmeltUnknown::Function({ let smelt_callback = ::std::rc::Rc::new(|closure_arg_N: SmeltUnknown, closure_arg_N: Option<SmeltUnknown>| -> Result<SmeltList<SmeltUnknown>, Box<dyn std::error::Error>> {",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5464"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5478"
     },
     {
       "category": "legitimate-boundary",
       "shape": "SMELT_FN_VALUE.with(|cell| cell.get_or_init(|| SmeltUnknown::Function({ let smelt_callback = ::std::rc::Rc::new(|closure_arg_N: SmeltUnknown| {",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5448"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5462"
     },
     {
       "category": "legitimate-boundary",
@@ -14307,6 +14342,13 @@
       "occurrences": 4,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/toFilled_spec.rs:53"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: SmeltList<SmeltUnknown> = set_to_entries(<SmeltJsSet<SmeltUnknown> as SmeltFromUnknown>::smelt_from_unknown((_smelt_tmp_N).into_smelt_unknown()));",
+      "occurrences": 4,
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPairs.rs:36"
     },
     {
       "category": "legitimate-boundary",
@@ -14894,7 +14936,7 @@
       "shape": "_smelt_tmp_N = SmeltRecord::from([(\"S\".to_owned(), SmeltUnknown::Bool(true)), (\"S\".to_owned(), _smelt_tmp_N)]);",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:417"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:437"
     },
     {
       "category": "avoidable-erasure",
@@ -15115,6 +15157,13 @@
     },
     {
       "category": "avoidable-erasure",
+      "shape": "_smelt_tmp_N = matches!(target.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
+      "occurrences": 4,
+      "files": 2,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:999"
+    },
+    {
+      "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = max_result.clone().as_ref().map_or(true, |value| matches!(value, SmeltUnknown::Undefined));",
       "occurrences": 4,
       "files": 1,
@@ -15181,7 +15230,7 @@
       "shape": "constructor = match prototype.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone();",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:95"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:96"
     },
     {
       "category": "avoidable-erasure",
@@ -15202,7 +15251,7 @@
       "shape": "let _ = { println!(\"S\", { let smelt_object_value = self.clone(); let smelt_struct_value = smelt_object_value.clone(); let mut smelt_object_entries = ::std::collections::HashMap::new(); smelt_object_entries.insert(\"S\".to_owned(), { let smelt_record = (smelt_object_value.props).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, SmeltUnknown::String(value))).collect())) }); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); SmeltUnknown::Object(SmeltObject::new(smelt_object_entries)) }); };",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5750"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5764"
     },
     {
       "category": "avoidable-erasure",
@@ -15601,7 +15650,7 @@
       "shape": "let _smelt_tmp_N: SmeltUnknown = SmeltUnknown::Bool(is_cloneable_object_N(value_to_clone.clone()));",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:450"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:470"
     },
     {
       "category": "avoidable-erasure",
@@ -15972,7 +16021,7 @@
       "shape": "let mut _smelt_tmp_N: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>> = None::<SmeltJsMap<SmeltUnknown, SmeltUnknown>>;",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:227"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:233"
     },
     {
       "category": "avoidable-erasure",
@@ -16077,14 +16126,14 @@
       "shape": "let mut this: Self = FetcherError { name: SmeltUnknown::Null, message: SmeltUnknown::Null, stack: SmeltUnknown::Null, cause: SmeltUnknown::Null, inner_error: Default::default() };",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5766"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5780"
     },
     {
       "category": "avoidable-erasure",
       "shape": "let mut this: Self = HttpError { name: SmeltUnknown::Null, message: SmeltUnknown::Null, stack: SmeltUnknown::Null, cause: SmeltUnknown::Null, code: N.N };",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5757"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5771"
     },
     {
       "category": "avoidable-erasure",
@@ -16196,14 +16245,14 @@
       "shape": "let this: Self = AbortError { name: SmeltUnknown::Null, message: SmeltUnknown::Null, stack: SmeltUnknown::Null, cause: SmeltUnknown::Null };",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5591"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5605"
     },
     {
       "category": "avoidable-erasure",
       "shape": "let this: Self = TimeoutError { name: SmeltUnknown::Null, message: SmeltUnknown::Null, stack: SmeltUnknown::Null, cause: SmeltUnknown::Null };",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5598"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5612"
     },
     {
       "category": "avoidable-erasure",
@@ -16588,14 +16637,14 @@
       "shape": "return { let smelt_l: SmeltList<_> = (result).clone().into(); SmeltList::with_id(smelt_l.id(), smelt_l.into_iter().map(|value| SmeltUnknown::Array(vec![SmeltUnknown::String(value.N.clone()), value.N.clone()].into())).collect::<Vec<_>>()) };",
       "occurrences": 4,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPairs.rs:74"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPairs.rs:83"
     },
     {
       "category": "avoidable-erasure",
       "shape": "return { let smelt_object_value = self.clone(); let smelt_struct_value = smelt_object_value.clone(); let mut smelt_object_entries = ::std::collections::HashMap::new(); smelt_object_entries.insert(\"S\".to_owned(), { let smelt_record = (smelt_object_value.props).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, SmeltUnknown::String(value))).collect())) }); smelt_object_entries.insert(\"S\".to_owned(), SmeltUnknown::Bool(true)); SmeltUnknown::Object(SmeltObject::new(smelt_object_entries)) };",
       "occurrences": 4,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5751"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5765"
     },
     {
       "category": "avoidable-erasure",
@@ -16662,66 +16711,73 @@
     },
     {
       "category": "runtime-prelude",
+      "shape": "\"S\" | \"S\" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |_args: Vec<SmeltUnknown>| Ok(SmeltUnknown::Array(members.clone().into())))); }",
+      "occurrences": 3,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2901"
+    },
+    {
+      "category": "runtime-prelude",
       "shape": "fn smelt_unknown_is_nullish(value: &SmeltUnknown) -> bool { matches!(value, SmeltUnknown::Null | SmeltUnknown::Undefined) }",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2907"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2919"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<A: IntoSmeltUnknown, B: IntoSmeltUnknown> IntoSmeltUnknown for (A, B) {",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3475"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3489"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<K, T> IntoSmeltUnknown for ::std::collections::HashMap<K, T> where K: IntoSmeltUnknown + Eq + ::std::hash::Hash, T: IntoSmeltUnknown {",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3481"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3495"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<K, T> IntoSmeltUnknown for SmeltRecord<K, T> where K: IntoSmeltUnknown + Eq + ::std::hash::Hash + Clone, T: IntoSmeltUnknown + Clone {",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3487"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3501"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<K: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> IntoSmeltUnknown for MemoizeCache<K, V> {",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4239"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4253"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<K: SmeltFromUnknown + Eq + ::std::hash::Hash + Clone, V: SmeltFromUnknown + Clone> SmeltFromUnknown for SmeltRecord<K, V> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Object(object) => SmeltRecord::with_id_from_entries(object.id, object.iter().map(|(key, value)| (K::smelt_from_unknown(SmeltUnknown::String(key)), V::smelt_from_unknown(value)))), _ => SmeltRecord::with_id_from_entries(smelt_next_object_id(), ::std::iter::empty()) } } }",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3394"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3406"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> IntoSmeltUnknown for CurriedFunctionN<TN, R> {",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3728"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3742"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> IntoSmeltUnknown for RightCurriedFunctionN<TN, R> {",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3863"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3877"
     },
     {
       "category": "runtime-prelude",
       "shape": "set: ::std::rc::Rc<dyn Fn(SmeltUnknown, SmeltUnknown) -> SmeltUnknown>,",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4084"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4098"
     },
     {
       "category": "legitimate-boundary",
@@ -16749,7 +16805,7 @@
       "shape": "_smelt_tmp_N = matches!(match _smelt_tmp_N.clone() { SmeltUnknown::Object(map) => smelt_get_object_field(&map, \"S\"), _ => SmeltUnknown::Undefined }.clone(), SmeltUnknown::Function(_));",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEmpty.rs:56"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEmpty.rs:58"
     },
     {
       "category": "legitimate-boundary",
@@ -17400,7 +17456,7 @@
       "shape": "_smelt_tmp_N = compare(target_item, source_item.clone(), SmeltUnknown::Number(i.clone() as fN), SmeltUnknown::Array(_smelt_tmp_N.into()), SmeltUnknown::Array(source.clone().into()), stack.clone());",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1086"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1092"
     },
     {
       "category": "avoidable-erasure",
@@ -17439,10 +17495,17 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = matches!(_smelt_tmp_N.clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
+      "shape": "_smelt_tmp_N = matches!(a.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
       "occurrences": 3,
-      "files": 3,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEmpty.rs:111"
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:45"
+    },
+    {
+      "category": "avoidable-erasure",
+      "shape": "_smelt_tmp_N = matches!(b.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
+      "occurrences": 3,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:47"
     },
     {
       "category": "avoidable-erasure",
@@ -17481,28 +17544,28 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_key = _smelt_tmp_N; match obj.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"S\") && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
+      "shape": "_smelt_tmp_N = { let smelt_key = _smelt_tmp_N; match obj.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"S\") || values.contains_key(\"S\")) && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
       "occurrences": 3,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/pick.rs:25"
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_key = i.clone().to_string(); match arr.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"S\") && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
+      "shape": "_smelt_tmp_N = { let smelt_key = i.clone().to_string(); match arr.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"S\") || values.contains_key(\"S\")) && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
       "occurrences": 3,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/pullAllBy.rs:77"
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_key = key; match _smelt_tmp_N.clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"S\") && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
+      "shape": "_smelt_tmp_N = { let smelt_key = key; match _smelt_tmp_N.clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"S\") || values.contains_key(\"S\")) && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
       "occurrences": 3,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/conformsTo.rs:77"
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_key = prop_key.clone(); match b.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"S\") && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
+      "shape": "_smelt_tmp_N = { let smelt_key = prop_key.clone(); match b.clone().clone() { SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"S\") || values.contains_key(\"S\")) && smelt_key == \"S\"), SmeltUnknown::Array(values) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"S\" || smelt_key == \"S\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false } };",
       "occurrences": 3,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_1.rs:1280"
@@ -17995,7 +18058,7 @@
       "shape": "let _smelt_tmp_N: SmeltUnknown = clone_deep_with_impl(_smelt_tmp_N.get({ let len = _smelt_tmp_N.len() as iN; let index = i.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone(), Some(SmeltUnknown::Number(i.clone() as fN)), object_to_clone.clone(), stack.clone(), clone_value.clone())?;",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:195"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:196"
     },
     {
       "category": "avoidable-erasure",
@@ -18387,7 +18450,7 @@
       "shape": "let mut this: Self = CustomError(::std::rc::Rc::new(::std::cell::RefCell::new(CustomErrorInner { message: SmeltUnknown::Null, stack: SmeltUnknown::Null, cause: SmeltUnknown::Null, name: String::new(), custom: None::<String> })));",
       "occurrences": 3,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5712"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5726"
     },
     {
       "category": "avoidable-erasure",
@@ -19143,301 +19206,301 @@
       "shape": "(\"S\".to_owned(), SmeltUnknown::Bool(true)),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2869"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2870"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::Object(SmeltObject::new(self.props.into_iter().map(|(key, value)| (key, SmeltUnknown::String(value))).collect()))),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4830"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4844"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::String(self.name)),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4742"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4756"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::String(self.source)),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4204"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4218"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), __smelt_inner.custom.clone().map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::String(value))),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4787"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4801"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.delimiter.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::String(value))),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4340"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4354"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.imports.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::Object(SmeltObject::new(value.into_iter().map(|(key, value)| (key, (value).into_smelt_unknown())).collect())))),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4176"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4190"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.partial_windows.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::Bool(value))),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3595"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3609"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.retries.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::Number(value as fN))),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4279"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4293"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.should_retry.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::Null)),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4281"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4295"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.source_url.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::String(value))),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4177"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4191"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.variable.map_or(SmeltUnknown::Undefined, |value| SmeltUnknown::String(value))),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4175"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4189"
     },
     {
       "category": "runtime-prelude",
       "shape": "(SmeltUnknown::Array(left), SmeltUnknown::Array(right)) => left.len() == right.len() && left.iter().zip(right.iter()).all(|(left, right)| smelt_unknown_structural_eq(left, right, seen)),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2920"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2932"
     },
     {
       "category": "runtime-prelude",
       "shape": "(SmeltUnknown::Bool(left), SmeltUnknown::Bool(right)) => left == right,",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2916"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2928"
     },
     {
       "category": "runtime-prelude",
       "shape": "(SmeltUnknown::Function(left), SmeltUnknown::Function(right)) => ::std::rc::Rc::ptr_eq(left, right),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2922"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2934"
     },
     {
       "category": "runtime-prelude",
       "shape": "(SmeltUnknown::Null, SmeltUnknown::Null) => true,",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2914"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2926"
     },
     {
       "category": "runtime-prelude",
       "shape": "(SmeltUnknown::Number(left), SmeltUnknown::Number(right)) => left == right || (left.is_nan() && right.is_nan()),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2917"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2929"
     },
     {
       "category": "runtime-prelude",
       "shape": "(SmeltUnknown::Object(left), SmeltUnknown::Object(right)) => smelt_object_structural_eq(left, right, seen),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2921"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2933"
     },
     {
       "category": "runtime-prelude",
       "shape": "(SmeltUnknown::Promise(left), SmeltUnknown::Promise(right)) => left.id == right.id,",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2923"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2935"
     },
     {
       "category": "runtime-prelude",
       "shape": "(SmeltUnknown::String(left), SmeltUnknown::String(right)) => Some(left.cmp(right)),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3301"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3313"
     },
     {
       "category": "runtime-prelude",
       "shape": "(SmeltUnknown::String(left), SmeltUnknown::String(right)) => left == right,",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2918"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2930"
     },
     {
       "category": "runtime-prelude",
       "shape": "(SmeltUnknown::Symbol(left), SmeltUnknown::Symbol(right)) => left == right,",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2919"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2931"
     },
     {
       "category": "runtime-prelude",
       "shape": "(SmeltUnknown::Undefined, SmeltUnknown::Undefined) => true,",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2915"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2927"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(value) => SmeltUnknown::Array(vec![SmeltUnknown::String(value.N.clone())].into()),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4985"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4999"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(value) => SmeltUnknown::Bool(value),",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5020"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5034"
     },
     {
       "category": "runtime-prelude",
       "shape": "Self::MN(value) => { let smelt_record = (value).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, SmeltUnknown::String(value))).collect())) },",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5344"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5358"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Array(self.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect())",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3425"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3439"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Number(id as fN)",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3057"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3069"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(object) => match object.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN },",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3279"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3291"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(value) => match value.get(\"S\") { Some(SmeltUnknown::Number(value)) => value, _ => fN::NAN },",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3309"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3321"
     },
     {
       "category": "runtime-prelude",
       "shape": "__smelt_call: { let smelt_default_callback: ::std::rc::Rc<dyn Fn(Option<SmeltUnknown>) -> String> = ::std::rc::Rc::new(move |argN: Option<SmeltUnknown>| -> String { String::new() }); smelt_default_callback },",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4192"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4206"
     },
     {
       "category": "runtime-prelude",
       "shape": "a: SmeltUnknown,",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4889"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4903"
     },
     {
       "category": "runtime-prelude",
       "shape": "callback: ::std::rc::Rc<dyn Fn(Vec<SmeltUnknown>) -> SmeltUnknown>,",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2800"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2801"
     },
     {
       "category": "runtime-prelude",
       "shape": "delete: { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> bool> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> bool { false }); smelt_default_callback },",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4090"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4104"
     },
     {
       "category": "runtime-prelude",
       "shape": "flush: ::std::rc::Rc<dyn Fn() -> Option<SmeltUnknown>>,",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4015"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4029"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn call(&self, args: impl Into<Vec<SmeltUnknown>>) -> SmeltUnknown {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2807"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2808"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn concat(mut self, other: Vec<SmeltUnknown>) -> Vec<SmeltUnknown> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3457"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3471"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn concat(self, other: Vec<SmeltUnknown>) -> Vec<SmeltUnknown>;",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3452"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3466"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn eq(&self, other: &SmeltUnknown) -> bool {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3243"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3255"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn insert(&self, key: String, value: SmeltUnknown) -> Option<SmeltUnknown> { if !self.values.borrow().contains_key(&key) { self.order.borrow_mut().push(key.clone()); } self.values.borrow_mut().insert(key, value) }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2593"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2594"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn partial_cmp(&self, other: &SmeltUnknown) -> Option<::std::cmp::Ordering> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3260"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3272"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn set_index(&mut self, index: usize, value: SmeltUnknown) { if index >= self.values.len() { self.values.resize(index.saturating_add(N), SmeltUnknown::Undefined); } self.values[index] = value; }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2650"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2651"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_blob_record_from_parts(parts: SmeltUnknown, blob_type: String, file_name: Option<String>, last_modified: Option<fN>) -> SmeltUnknown {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2855"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2856"
     },
     {
       "category": "runtime-prelude",
@@ -19451,231 +19514,238 @@
       "shape": "fn smelt_index_assign(target: &mut SmeltUnknown, key: String, value: SmeltUnknown) {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2883"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2884"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_missing_index_value() -> SmeltUnknown { SmeltUnknown::Undefined }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2910"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2922"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_missing_property_value() -> SmeltUnknown { SmeltUnknown::Undefined }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2909"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2921"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_unknown_is_undefined(value: &SmeltUnknown) -> bool { matches!(value, SmeltUnknown::Undefined) }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2908"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2920"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_unknown_js_relational_ordering(left: &SmeltUnknown, right: &SmeltUnknown) -> Option<::std::cmp::Ordering> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3299"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3311"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_unknown_structural_eq(left: &SmeltUnknown, right: &SmeltUnknown, seen: &mut ::std::collections::HashSet<(usize, usize)>) -> bool {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2912"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2924"
     },
     {
       "category": "runtime-prelude",
       "shape": "for (index, value) in self.groups.iter().enumerate() { object.insert(index.to_string(), value.clone().map_or(SmeltUnknown::Undefined, SmeltUnknown::String)); }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4555"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4569"
     },
     {
       "category": "runtime-prelude",
       "shape": "get: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> SmeltUnknown>,",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4082"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4096"
     },
     {
       "category": "runtime-prelude",
       "shape": "has: { let smelt_default_callback: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> bool> = ::std::rc::Rc::new(move |argN: SmeltUnknown| -> bool { false }); smelt_default_callback },",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4092"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4106"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "if field == \"S\" && let Some(SmeltUnknown::Array(members)) = map.get(\"S\") { return SmeltUnknown::Number(members.len() as fN); }",
+      "occurrences": 2,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2897"
     },
     {
       "category": "runtime-prelude",
       "shape": "if field == \"S\" && let Some(SmeltUnknown::Array(pairs)) = map.get(\"S\") { return SmeltUnknown::Number(pairs.len() as fN); }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2895"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2896"
     },
     {
       "category": "runtime-prelude",
       "shape": "if left.contains_key(\"S\") || right.contains_key(\"S\") { let left_date = smelt_unknown_date_value(&SmeltUnknown::Object(left.clone())); let right_date = smelt_unknown_date_value(&SmeltUnknown::Object(right.clone())); return left_date == right_date || (left_date.is_nan() && right_date.is_nan()); }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2929"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2941"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl ::std::iter::FromIterator<SmeltUnknown> for SmeltArray { fn from_iter<T: IntoIterator<Item = SmeltUnknown>>(iter: T) -> Self { Self::new(iter.into_iter().collect()) } }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2653"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2654"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl From<SmeltList<SmeltUnknown>> for SmeltArray { fn from(list: SmeltList<SmeltUnknown>) -> Self { SmeltArray::with_id(list.id, list.values) } }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2657"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2658"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl From<Vec<SmeltUnknown>> for SmeltArray { fn from(values: Vec<SmeltUnknown>) -> Self { Self::new(values) } }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2652"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2653"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl IntoIterator for SmeltArray { type Item = SmeltUnknown; type IntoIter = ::std::vec::IntoIter<SmeltUnknown>; fn into_iter(self) -> Self::IntoIter { self.values.into_iter() } }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2655"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2656"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl IntoIterator for SmeltObject { type Item = (String, SmeltUnknown); type IntoIter = ::std::vec::IntoIter<(String, SmeltUnknown)>; fn into_iter(self) -> Self::IntoIter { self.iter() } }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2633"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2634"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl IntoSmeltUnknown for SmeltUnknown {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3320"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3332"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl PartialEq<SmeltUnknown> for Option<SmeltUnknown> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3265"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3277"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl PartialOrd<SmeltUnknown> for Option<SmeltUnknown> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3271"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3283"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl SmeltUnknownArrayExt for Vec<SmeltUnknown> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3455"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3469"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<K: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> ::std::fmt::Debug for MemoizeCache<K, V> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4234"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4248"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<K: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> Default for MemoizeCache<K, V> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4221"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4235"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<T: IntoSmeltUnknown + Eq + ::std::hash::Hash> IntoSmeltUnknown for ::std::collections::HashSet<T> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3429"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3443"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<T: IntoSmeltUnknown> IntoSmeltUnknown for Option<T> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3417"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3431"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<T: IntoSmeltUnknown> IntoSmeltUnknown for Vec<T> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3423"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3437"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<T: SmeltFromUnknown> SmeltFromUnknown for SmeltList<T> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Array(array) => SmeltList::with_id(array.id, array.values.into_iter().map(T::smelt_from_unknown).collect()), _ => SmeltList::new(Vec::new()) } } }",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3392"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3404"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> ::std::fmt::Debug for CurriedFunctionN<TN, R> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3723"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3737"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> ::std::fmt::Debug for RightCurriedFunctionN<TN, R> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3858"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3872"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> Default for CurriedFunctionN<TN, R> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3715"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3729"
     },
     {
       "category": "runtime-prelude",
       "shape": "impl<TN: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'static> Default for RightCurriedFunctionN<TN, R> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3850"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3864"
     },
     {
       "category": "runtime-prelude",
       "shape": "let callable = SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>((callback)(args))));",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2834"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2835"
     },
     {
       "category": "runtime-prelude",
       "shape": "let callable: ::std::rc::Rc<dyn Fn(Vec<SmeltUnknown>) -> Result<SmeltUnknown, Box<dyn std::error::Error>>> = ::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>((callback)(args)));",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2829"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2830"
     },
     {
       "category": "runtime-prelude",
       "shape": "let groups = self.named.into_iter().map(|(name, value)| (name, value.map_or(SmeltUnknown::Undefined, SmeltUnknown::String))).collect::<::std::collections::HashMap<_, _>>();",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4556"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4570"
     },
     {
       "category": "runtime-prelude",
@@ -19689,35 +19759,35 @@
       "shape": "return SmeltUnknown::Function(callable);",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2826"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2827"
     },
     {
       "category": "runtime-prelude",
       "shape": "self.iter().position(|value| value == &needle).map_or(SmeltUnknown::Number(-N.N), |index| SmeltUnknown::Number(index as fN))",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3446"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3460"
     },
     {
       "category": "runtime-prelude",
       "shape": "self.map_or(SmeltUnknown::Undefined, IntoSmeltUnknown::into_smelt_unknown)",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3419"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3433"
     },
     {
       "category": "legitimate-boundary",
       "shape": "SMELT_FN_VALUE.with(|cell| cell.get_or_init(|| SmeltUnknown::Function({ let smelt_callback = ::std::rc::Rc::new(|closure_arg_N: Option<String>, closure_arg_N: Option<TemplateOptions>, closure_arg_N: Option<SmeltUnknown>| -> Result<TemplateExecutor, Box<dyn std::error::Error>> {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5504"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5518"
     },
     {
       "category": "legitimate-boundary",
       "shape": "SMELT_FN_VALUE.with(|cell| cell.get_or_init(|| SmeltUnknown::Function({ let smelt_callback = ::std::rc::Rc::new(|closure_arg_N: String, closure_arg_N: fN, closure_arg_N: Option<SmeltUnknown>| {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5488"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5502"
     },
     {
       "category": "legitimate-boundary",
@@ -20123,7 +20193,7 @@
       "shape": "let _smelt_tmp_N: bool = is_map_match(target.clone(), <SmeltJsMap<SmeltUnknown, SmeltUnknown> as SmeltFromUnknown>::smelt_from_unknown((source.clone()).into_smelt_unknown()), &*compare, stack.clone());",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:175"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:176"
     },
     {
       "category": "legitimate-boundary",
@@ -20186,7 +20256,7 @@
       "shape": "}); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>(((smelt_callback)((smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)).into_smelt_unknown())).into_smelt_unknown())) })).clone())",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5451"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5465"
     },
     {
       "category": "legitimate-boundary",
@@ -20312,14 +20382,14 @@
       "shape": "__smelt_for_item = _smelt_tmp_N.get({ let len = _smelt_tmp_N.len() as iN; let index = _smelt_tmp_N.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or((SmeltUnknown::Null, SmeltUnknown::Null)).clone();",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1004"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1010"
     },
     {
       "category": "avoidable-erasure",
       "shape": "__smelt_for_item = _smelt_tmp_N.get({ let len = _smelt_tmp_N.len() as iN; let index = _smelt_tmp_N.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone();",
       "occurrences": 2,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:237"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:238"
     },
     {
       "category": "avoidable-erasure",
@@ -20753,7 +20823,7 @@
       "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(SmeltList::from({ let smelt_list_items: Vec<SmeltUnknown> = vec![obj.clone()]; smelt_list_items }));",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:143"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:150"
     },
     {
       "category": "avoidable-erasure",
@@ -20858,7 +20928,7 @@
       "shape": "_smelt_tmp_N = None::<SmeltJsMap<SmeltUnknown, SmeltUnknown>>;",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:233"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:239"
     },
     {
       "category": "avoidable-erasure",
@@ -21152,7 +21222,7 @@
       "shape": "_smelt_tmp_N = matches!(_smelt_tmp_N, SmeltUnknown::String(_));",
       "occurrences": 2,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEmpty.rs:61"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEmpty.rs:63"
     },
     {
       "category": "avoidable-erasure",
@@ -21194,21 +21264,21 @@
       "shape": "_smelt_tmp_N = matches!(prototype.clone(), SmeltUnknown::Null);",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:86"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:87"
     },
     {
       "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = matches!(prototype.clone(), SmeltUnknown::Undefined);",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:87"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:88"
     },
     {
       "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = matches!(source.clone(), SmeltUnknown::Array(_));",
       "occurrences": 2,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:167"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:168"
     },
     {
       "category": "avoidable-erasure",
@@ -21226,10 +21296,10 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = matches!(target.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
+      "shape": "_smelt_tmp_N = matches!(source.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
       "occurrences": 2,
-      "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:993"
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:174"
     },
     {
       "category": "avoidable-erasure",
@@ -21317,13 +21387,6 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_list_id = smelt_list_identity(&(set) as *const _ as *const () as usize); let mut values = set.clone().into_iter().map(|value| SmeltUnknown::Number(value as fN)).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(SmeltArray::with_id(smelt_list_id, values)) };",
-      "occurrences": 2,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toCamelCaseKeys_spec.rs:355"
-    },
-    {
-      "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = { let smelt_push_item = SmeltUnknown::Array(arrayN.clone().into()); arrayN.push(smelt_push_item); arrayN.len() as fN };",
       "occurrences": 2,
       "files": 1,
@@ -21356,13 +21419,6 @@
       "occurrences": 2,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/toMerged_spec.rs:258"
-    },
-    {
-      "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { setN.insert({ let smelt_list_id = smelt_list_identity(&(setN) as *const _ as *const () as usize); let mut values = setN.clone().clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(SmeltArray::with_id(smelt_list_id, values)) }); setN.clone() };",
-      "occurrences": 2,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith_spec.rs:5533"
     },
     {
       "category": "avoidable-erasure",
@@ -21460,7 +21516,7 @@
       "shape": "fn new(chunks: SmeltList<SmeltUnknown>, filename: String, options: Option<SmeltUnknown>) -> Self {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5773"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5787"
     },
     {
       "category": "avoidable-erasure",
@@ -22181,7 +22237,7 @@
       "shape": "let _smelt_tmp_N: SmeltUnknown = clone_deep_with_impl(match source.clone() {",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:681"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:702"
     },
     {
       "category": "avoidable-erasure",
@@ -22195,7 +22251,14 @@
       "shape": "let _smelt_tmp_N: SmeltUnknown = clone_deep_with_impl(value.clone().map_or(SmeltUnknown::Undefined, |value| value), key.clone().map(|value| value), object_to_clone.clone(), stack.clone(), clone_value.clone())?;",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:272"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:273"
+    },
+    {
+      "category": "avoidable-erasure",
+      "shape": "let _smelt_tmp_N: SmeltUnknown = clone_deep_with_impl(value_N, None::<SmeltUnknown>, object_to_clone.clone(), stack.clone(), clone_value.clone())?;",
+      "occurrences": 2,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:292"
     },
     {
       "category": "avoidable-erasure",
@@ -23252,7 +23315,7 @@
       "shape": "let mut __smelt_for_item: (SmeltUnknown, SmeltUnknown);",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:971"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:977"
     },
     {
       "category": "avoidable-erasure",
@@ -23266,7 +23329,7 @@
       "shape": "let mut _smelt_tmp_N: (String, SmeltUnknown);",
       "occurrences": 2,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPairs.rs:23"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPairs.rs:25"
     },
     {
       "category": "avoidable-erasure",
@@ -23287,7 +23350,7 @@
       "shape": "let mut _smelt_tmp_N: Option<SmeltJsMap<SmeltUnknown, SmeltUnknown>>;",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:136"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:137"
     },
     {
       "category": "avoidable-erasure",
@@ -23854,7 +23917,7 @@
       "shape": "new_error = SmeltUnknown::Undefined;",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:118"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:125"
     },
     {
       "category": "avoidable-erasure",
@@ -24246,7 +24309,7 @@
       "shape": "pub(crate) fn is_cloneable_object_N(object: SmeltUnknown) -> bool {",
       "occurrences": 2,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:747"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:768"
     },
     {
       "category": "avoidable-erasure",
@@ -24869,7 +24932,7 @@
       "shape": "return SmeltUnknown::String(_smelt_tmp_N);",
       "occurrences": 2,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5706"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5720"
     },
     {
       "category": "avoidable-erasure",
@@ -24883,7 +24946,7 @@
       "shape": "return { let smelt_record = (self.props.clone()).clone(); SmeltUnknown::Object(SmeltObject::with_id(smelt_record.id, smelt_record.iter().map(|(key, value)| (key, SmeltUnknown::String(value))).collect())) };",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5744"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5758"
     },
     {
       "category": "avoidable-erasure",
@@ -24911,7 +24974,7 @@
       "shape": "this.a = SmeltUnknown::Number(N.N as fN);",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5783"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5797"
     },
     {
       "category": "avoidable-erasure",
@@ -24974,7 +25037,7 @@
       "shape": "{ let smelt_assign_index = { let len = result.len() as iN; let index = i.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }; if smelt_assign_index >= result.len() { result.resize(smelt_assign_index.saturating_add(N), (String::new(), SmeltUnknown::Null)); } result[smelt_assign_index] = _smelt_tmp_N; }",
       "occurrences": 2,
       "files": 2,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPairs.rs:70"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/toPairs.rs:79"
     },
     {
       "category": "avoidable-erasure",
@@ -25051,14 +25114,14 @@
       "shape": "}); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| Ok::<SmeltUnknown, Box<dyn std::error::Error>>((smelt_callback)(smelt_args.get(N).cloned().unwrap_or(SmeltUnknown::Null)))) })).clone())",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5483"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5497"
     },
     {
       "category": "avoidable-erasure",
       "shape": "}); ::std::rc::Rc::new(move |smelt_args: Vec<SmeltUnknown>| { (smelt_callback)(); Ok::<SmeltUnknown, Box<dyn std::error::Error>>(SmeltUnknown::Null) }) })).clone())",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5475"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5489"
     },
     {
       "category": "avoidable-erasure",
@@ -25079,7 +25142,7 @@
       "shape": "}.clone(), Some(SmeltUnknown::String(key.clone())), object_to_clone_N.clone(), stack.clone().clone().unwrap_or(SmeltJsMap::new()), clone_value.clone())?;",
       "occurrences": 2,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:700"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:721"
     },
     {
       "category": "avoidable-erasure",
@@ -25114,581 +25177,581 @@
       "shape": "(\"S\".to_owned(), SmeltUnknown::Bool(self.leading)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4004"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4018"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::Number(__smelt_inner.available.clone() as fN)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4611"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4625"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::Number(__smelt_inner.capacity.clone() as fN)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4610"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4624"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::Number(content.len() as fN)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2871"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2872"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::Number(self.age as fN)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4743"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4757"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::Number(self.code as fN)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4850"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4864"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::Number(self.length as fN)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3682"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3696"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::Number(self.size as fN)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4242"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4256"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::Number(self.value as fN)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4799"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4813"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::String(__smelt_inner.name.clone())),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4786"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4800"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::String(blob_type)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2870"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2871"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::String(content)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2872"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2873"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), SmeltUnknown::String(self.flags)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4451"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4465"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.delay.map_or(SmeltUnknown::Undefined, |value| (value).into_smelt_unknown())),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4278"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4292"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.escape.map_or(SmeltUnknown::Undefined, |value| (value).into_smelt_unknown())),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4172"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4186"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.evaluate.map_or(SmeltUnknown::Undefined, |value| (value).into_smelt_unknown())),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4173"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4187"
     },
     {
       "category": "runtime-prelude",
       "shape": "(\"S\".to_owned(), self.interpolate.map_or(SmeltUnknown::Undefined, |value| (value).into_smelt_unknown())),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4174"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4188"
     },
     {
       "category": "runtime-prelude",
       "shape": "// Erasing the SAME callback twice must yield `SmeltUnknown::Function`",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2812"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2813"
     },
     {
       "category": "runtime-prelude",
       "shape": "// both erasures resolve to one `SmeltUnknown::Function` while both are",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2818"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2819"
     },
     {
       "category": "runtime-prelude",
       "shape": "/// Cache the OUTER `SmeltUnknown::Function` `Rc` derived from each erased",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2840"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2841"
     },
     {
       "category": "runtime-prelude",
       "shape": "/// Erase a concrete match into a `SmeltUnknown` at a dynamic boundary.",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4546"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4560"
     },
     {
       "category": "runtime-prelude",
       "shape": "/// named groups, `index`, `input`) instead of an erased `SmeltUnknown`",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4419"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4433"
     },
     {
       "category": "runtime-prelude",
       "shape": "Function(::std::rc::Rc<dyn Fn(Vec<SmeltUnknown>) -> Result<SmeltUnknown, Box<dyn std::error::Error>>>),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2777"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2778"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Array(_) => N,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3292"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3304"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Array(array) => {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2886"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2887"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Array(values) => { N_uN.hash(state); values.len().hash(state); for value in values.iter() { smelt_unknown_structural_hash(value, state, seen); } }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2947"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2959"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Array(values.into())",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3434"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3448"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Array(vec![self.N.into_smelt_unknown(), self.N.into_smelt_unknown()].into())",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3477"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3491"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Bool(_) => N,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3288"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3300"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Bool(self)",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3328"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3340"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Bool(value) => if *value { N.N } else { N.N },",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3311"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3323"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Bool(value) => { N_uN.hash(state); value.hash(state); }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2943"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2955"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Function(_) => N,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3294"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3306"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Function(function) => { N_uN.hash(state); ::std::rc::Rc::as_ptr(function).hash(state); }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2949"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2961"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Null",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3352"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3364"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Null => N,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3286"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3298"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Null => N_uN.hash(state),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2941"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2953"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Number(_) => N,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3289"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3301"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Number(self as fN)",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3340"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3352"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Number(self)",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3334"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3346"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Number(value) => *value,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3308"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3320"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Number(value) => value,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3411"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3425"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Number(value) => { N_uN.hash(state); if value.is_nan() { fN::NAN.to_bits().hash(state); } else { value.to_bits().hash(state); } }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2944"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2956"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(SmeltObject::with_id(self.id, ::std::collections::HashMap::from([",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4449"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4463"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(SmeltObject::with_id(self.id, object))",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4560"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4574"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(_) => N,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3293"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3305"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(getter) if getter.contains_key(\"S\") => match getter.get(\"S\") {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2899"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2911"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(map) => { map.insert(key, value); }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2885"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2886"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(map) if map.contains_key(\"S\") => {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2861"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2862"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(record)",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2880"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2881"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Object(values) => { N_uN.hash(state); smelt_object_structural_hash(values, state, seen); }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2948"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2960"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Promise(_) => N,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3295"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3307"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Promise(promise) => { N_uN.hash(state); promise.id.hash(state); }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2950"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2962"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::String(_) => N,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3290"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3302"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::String(self)",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3346"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3358"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::String(text) => content.push_str(text),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2860"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2861"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::String(value) => value.parse::<fN>().unwrap_or(fN::NAN),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3310"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3322"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::String(value) => { N_uN.hash(state); value.hash(state); }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2945"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2957"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Symbol(_) => N,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3291"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3303"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Symbol(value) => { N_uN.hash(state); value.hash(state); }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2946"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2958"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Undefined => N,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3287"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3299"
     },
     {
       "category": "runtime-prelude",
       "shape": "SmeltUnknown::Undefined => N_uN.hash(state),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2942"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2954"
     },
     {
       "category": "runtime-prelude",
       "shape": "Some(SmeltUnknown::Function(smelt_getter)) => (smelt_getter)(Vec::new()).unwrap_or_else(|error| panic!(\"S\", error)),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2900"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2912"
     },
     {
       "category": "runtime-prelude",
       "shape": "_ => SmeltUnknown::Null,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2901"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2913"
     },
     {
       "category": "runtime-prelude",
       "shape": "__data__: SmeltJsMap<SmeltUnknown, String>,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4668"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4682"
     },
     {
       "category": "runtime-prelude",
       "shape": "__smelt_call: ::std::rc::Rc<dyn Fn(Option<SmeltUnknown>) -> String>,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4186"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4200"
     },
     {
       "category": "runtime-prelude",
       "shape": "async fn smelt_await_flatten(value: SmeltUnknown) -> Result<SmeltUnknown, Box<dyn std::error::Error>> {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2699"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2700"
     },
     {
       "category": "runtime-prelude",
       "shape": "delete: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> bool>,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4081"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4095"
     },
     {
       "category": "runtime-prelude",
       "shape": "else { let mut map = ::std::collections::HashMap::new(); map.insert(key, value); *target = SmeltUnknown::Object(SmeltObject::new(map)); }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2888"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2889"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn from_unknown_record(record: SmeltRecord<String, SmeltUnknown>) -> Self { Self { id: record.id, values: record.values, order: record.order } }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2589"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2590"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn get(&self, key: &str) -> Option<SmeltUnknown> { self.values.borrow().get(key).cloned() }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2592"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2593"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn index_of(&self, needle: T) -> SmeltUnknown where T: PartialEq {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3445"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3459"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn index_of(&self, needle: T) -> SmeltUnknown where T: PartialEq;",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3440"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3454"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn into_smelt_unknown(self) -> SmeltUnknown;",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3317"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3329"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn into_vec(self) -> Vec<SmeltUnknown> { self.values }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2648"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2649"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn iter(&self) -> ::std::vec::IntoIter<(String, SmeltUnknown)> { let values = self.values.borrow(); self.order.borrow().iter().filter_map(|key| values.get(key).map(|value| (key.clone(), value.clone()))).collect::<Vec<_>>().into_iter() }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2595"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2596"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn new(values: ::std::collections::HashMap<String, SmeltUnknown>) -> Self { let mut order = values.keys().cloned().collect::<Vec<_>>(); order.sort(); Self { id: smelt_next_object_id(), values: ::std::rc::Rc::new(::std::cell::RefCell::new(values)), order: ::std::rc::Rc::new(::std::cell::RefCell::new(order)) } }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2587"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2588"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn new(values: Vec<SmeltUnknown>) -> Self { Self { id: smelt_next_object_id(), values } }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2644"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2645"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn remove(&self, key: &str) -> Option<SmeltUnknown> { let removed = self.values.borrow_mut().remove(key); if removed.is_some() { self.order.borrow_mut().retain(|existing| existing != key); } removed }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2594"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2595"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn resolved(value: SmeltUnknown) -> Self { Self { id: smelt_next_object_id(), state: ::std::rc::Rc::new(::std::cell::RefCell::new(Some(Ok(value)))), future: ::std::rc::Rc::new(::std::cell::RefCell::new(None)) } }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2675"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2676"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_abort_signal_object(object: &SmeltObject) -> Option<SmeltObject> { if object.contains_key(\"S\") { return Some(object.clone()); } match object.get(\"S\") { Some(SmeltUnknown::Object(signal)) if signal.contains_key(\"S\") => Some(signal), _ => None } }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2762"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2763"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_clear_interval<T: IntoSmeltUnknown>(handle: T) { smelt_clear_timeout(handle) }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3076"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3088"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_clear_timeout<T: IntoSmeltUnknown>(handle: T) {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3070"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3082"
     },
     {
       "category": "runtime-prelude",
@@ -25702,14 +25765,14 @@
       "shape": "fn smelt_from_unknown(value: SmeltUnknown) -> Self;",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3359"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3371"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_get_object_field(map: &SmeltObject, field: &str) -> SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2894"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2895"
     },
     {
       "category": "runtime-prelude",
@@ -25737,847 +25800,861 @@
       "shape": "fn smelt_set_interval(callback: ::std::rc::Rc<::std::cell::RefCell<dyn FnMut() -> Result<(), Box<dyn std::error::Error>>>>, period_ms: fN) -> SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3060"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3072"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_set_timeout(callback: ::std::rc::Rc<::std::cell::RefCell<dyn FnMut() -> Result<(), Box<dyn std::error::Error>>>>, delay_ms: fN) -> SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3052"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3064"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_unknown_date_value(value: &SmeltUnknown) -> fN {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3277"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3289"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_unknown_from_json_value(value: serde_json::Value) -> SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3517"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3531"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_unknown_rank(value: &SmeltUnknown) -> uN {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3284"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3296"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_unknown_stable_hash_key(value: &SmeltUnknown) -> uN {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2954"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2966"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_unknown_structural_hash<H: ::std::hash::Hasher>(value: &SmeltUnknown, state: &mut H, seen: &mut ::std::collections::HashSet<usize>) {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2939"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2951"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn smelt_unknown_to_number(value: &SmeltUnknown) -> fN {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3306"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3318"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn values(&self) -> Vec<SmeltUnknown> { let values = self.values.borrow(); self.order.borrow().iter().filter_map(|key| values.get(key).cloned()).collect() }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2597"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2598"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn with_id(id: usize, values: ::std::collections::HashMap<String, SmeltUnknown>) -> Self { let mut order = values.keys().cloned().collect::<Vec<_>>(); order.sort(); Self { id, values: ::std::rc::Rc::new(::std::cell::RefCell::new(values)), order: ::std::rc::Rc::new(::std::cell::RefCell::new(order)) } }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2588"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2589"
     },
     {
       "category": "runtime-prelude",
       "shape": "fn with_id(id: usize, values: Vec<SmeltUnknown>) -> Self { Self { id, values } }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2646"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2647"
     },
     {
       "category": "runtime-prelude",
       "shape": "has: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> bool>,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4083"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4097"
     },
     {
       "category": "runtime-prelude",
       "shape": "if let SmeltUnknown::Array(items) = parts {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2857"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2858"
     },
     {
       "category": "runtime-prelude",
-      "shape": "if let Some(SmeltUnknown::String(text)) = map.get(\"S\") { content.push_str(&text); }",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2862"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "if let Some(object) = self.object { object.insert(\"S\".to_owned(), callable); SmeltUnknown::Object(object) } else { callable }",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2835"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl ::std::fmt::Debug for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2969"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl ::std::fmt::Display for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3198"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl ::std::hash::Hash for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3216"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl ::std::ops::Deref for SmeltArray { type Target = [SmeltUnknown]; fn deref(&self) -> &Self::Target { &self.values } }",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2654"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl Clone for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2781"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl Default for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2993"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl Eq for SmeltUnknown {}",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3214"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for () {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3350"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for A {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4827"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for AbortError {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4623"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for Bar {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4903"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for Cls {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4924"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for CustomCache {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4690"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for CustomClass {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4796"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for CustomError {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4779"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for DebounceOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3605"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for DebounceSettings {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3985"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for DebounceSettingsLeading {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4001"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for DelayOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3544"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for FetcherError {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4863"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for File {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4879"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for FilterAsyncOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3532"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for FlatMapAsyncOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3556"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for FlattenObjectOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4337"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for Foo {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4891"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for ForEachAsyncOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3568"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for HttpError {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4843"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for MapAsyncOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3580"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for MapCache {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4102"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for MapCacheConstructor {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4117"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for MemoizedFunction {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4128"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for Mutex {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4656"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for ObjectConstructor {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4914"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for Person {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4739"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for RetryOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4275"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for Semaphore {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4606"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for SmeltMatch {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4552"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for SmeltRegExp {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4447"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for String {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3344"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for TemplateExecutor {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4201"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for TemplateOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4169"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for ThrottleOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4291"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for ThrottleSettings {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4151"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for TimeoutError {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4641"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for TimeoutOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3654"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for Toolkit {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4139"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for WindowedOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3592"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for WithTimeoutOptions {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3666"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for __smelt_anon_class_N {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4934"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for bool {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3326"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for fN {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3332"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl IntoSmeltUnknown for iN {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3338"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl PartialEq for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2986"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl PartialEq<SmeltUnknown> for fN {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3242"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl PartialEq<fN> for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3236"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl PartialOrd for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3223"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl PartialOrd<SmeltUnknown> for fN {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3259"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl PartialOrd<fN> for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3248"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl SmeltFromUnknown for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3362"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl SmeltIntoFN for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3408"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl SmeltJsKeyEq for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2557"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl SmeltJsStrictEq for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2570"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3131"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl serde::Serialize for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3493"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl<'C'de> for SmeltUnknown {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3510"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl<T: Clone + IntoSmeltUnknown, const N: usize> From<[T; N]> for SmeltJsSet<T> { fn from(values: [T; N]) -> Self { values.into_iter().collect() } }",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2546"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl<T: Clone + IntoSmeltUnknown> ::std::iter::FromIterator<T> for SmeltJsSet<T> { fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self { let mut set = Self::new(); set.extend(iter); set } }",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2547"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl<T: Clone + IntoSmeltUnknown> PartialEq for SmeltJsSet<T> { fn eq(&self, other: &Self) -> bool { self.entries.len() == other.entries.len() && self.entries.iter().all(|value| other.contains(value)) } }",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2550"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "impl<T: Clone + IntoSmeltUnknown> SmeltJsSet<T> {",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2526"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "imports: Option<SmeltRecord<String, SmeltUnknown>>,",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4166"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "inner_error: SmeltUnknown,",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4861"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "let SmeltUnknown::Number(id) = handle.into_smelt_unknown() else { return; };",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3071"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "let SmeltUnknown::String(haystack) = haystack.into_smelt_unknown() else { return false; };",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3182"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "let mut values = self.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>();",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3432"
-    },
-    {
-      "category": "runtime-prelude",
-      "shape": "match map.get(field).unwrap_or(SmeltUnknown::Undefined) {",
+      "shape": "if let Some(SmeltUnknown::Array(members)) = map.get(\"S\") {",
       "occurrences": 1,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2898"
     },
     {
       "category": "runtime-prelude",
-      "shape": "object.insert(\"S\".to_owned(), SmeltUnknown::Number(self.match_index as fN));",
+      "shape": "if let Some(SmeltUnknown::String(text)) = map.get(\"S\") { content.push_str(&text); }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4558"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2863"
     },
     {
       "category": "runtime-prelude",
-      "shape": "object.insert(\"S\".to_owned(), SmeltUnknown::Object(SmeltObject::new(groups)));",
+      "shape": "if let Some(object) = self.object { object.insert(\"S\".to_owned(), callable); SmeltUnknown::Object(object) } else { callable }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4557"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2836"
     },
     {
       "category": "runtime-prelude",
-      "shape": "object.insert(\"S\".to_owned(), SmeltUnknown::String(self.input));",
+      "shape": "impl ::std::fmt::Debug for SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4559"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2981"
     },
     {
       "category": "runtime-prelude",
-      "shape": "other => { let mut map = ::std::collections::HashMap::new(); map.insert(key, value); *other = SmeltUnknown::Object(SmeltObject::new(map)); }",
+      "shape": "impl ::std::fmt::Display for SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2890"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3210"
     },
     {
       "category": "runtime-prelude",
-      "shape": "pub enum SmeltUnknown {",
+      "shape": "impl ::std::hash::Hash for SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2768"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3228"
     },
     {
       "category": "runtime-prelude",
-      "shape": "pub fn includes<T: IntoSmeltUnknown>(&self, needle: T) -> bool {",
+      "shape": "impl ::std::ops::Deref for SmeltArray { type Target = [SmeltUnknown]; fn deref(&self) -> &Self::Target { &self.values } }",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3172"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2655"
     },
     {
       "category": "runtime-prelude",
-      "shape": "pub fn test<T: IntoSmeltUnknown>(&self, haystack: T) -> bool {",
+      "shape": "impl Clone for SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3181"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2782"
     },
     {
       "category": "runtime-prelude",
-      "shape": "pub trait IntoSmeltUnknown {",
+      "shape": "impl Default for SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3316"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3005"
     },
     {
       "category": "runtime-prelude",
-      "shape": "record.insert(\"S\".to_owned(), SmeltUnknown::Bool(true));",
+      "shape": "impl Eq for SmeltUnknown {}",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2876"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3226"
     },
     {
       "category": "runtime-prelude",
-      "shape": "record.insert(\"S\".to_owned(), SmeltUnknown::Number(last_modified.unwrap_or(N.N)));",
+      "shape": "impl IntoSmeltUnknown for () {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2878"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3362"
     },
     {
       "category": "runtime-prelude",
-      "shape": "record.insert(\"S\".to_owned(), SmeltUnknown::String(name));",
+      "shape": "impl IntoSmeltUnknown for A {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2877"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4841"
     },
     {
       "category": "runtime-prelude",
-      "shape": "serde_json::Value::Array(values) => SmeltUnknown::Array(values.into_iter().map(smelt_unknown_from_json_value).collect()),",
+      "shape": "impl IntoSmeltUnknown for AbortError {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3523"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4637"
     },
     {
       "category": "runtime-prelude",
-      "shape": "serde_json::Value::Bool(value) => SmeltUnknown::Bool(value),",
+      "shape": "impl IntoSmeltUnknown for Bar {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3520"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4917"
     },
     {
       "category": "runtime-prelude",
-      "shape": "serde_json::Value::Null => SmeltUnknown::Null,",
+      "shape": "impl IntoSmeltUnknown for Cls {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3519"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4938"
     },
     {
       "category": "runtime-prelude",
-      "shape": "serde_json::Value::Number(value) => SmeltUnknown::Number(value.as_fN().unwrap_or_default()),",
+      "shape": "impl IntoSmeltUnknown for CustomCache {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3521"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4704"
     },
     {
       "category": "runtime-prelude",
-      "shape": "serde_json::Value::Object(values) => SmeltUnknown::Object(SmeltObject::new(values.into_iter().map(|(key, value)| (key, smelt_unknown_from_json_value(value))).collect())),",
+      "shape": "impl IntoSmeltUnknown for CustomClass {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4810"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for CustomError {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4793"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for DebounceOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3619"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for DebounceSettings {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3999"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for DebounceSettingsLeading {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4015"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for DelayOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3558"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for FetcherError {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4877"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for File {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4893"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for FilterAsyncOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3546"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for FlatMapAsyncOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3570"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for FlattenObjectOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4351"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for Foo {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4905"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for ForEachAsyncOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3582"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for HttpError {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4857"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for MapAsyncOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3594"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for MapCache {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4116"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for MapCacheConstructor {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4131"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for MemoizedFunction {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4142"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for Mutex {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4670"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for ObjectConstructor {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4928"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for Person {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4753"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for RetryOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4289"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for Semaphore {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4620"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for SmeltMatch {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4566"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for SmeltRegExp {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4461"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for String {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3356"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for TemplateExecutor {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4215"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for TemplateOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4183"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for ThrottleOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4305"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for ThrottleSettings {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4165"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for TimeoutError {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4655"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for TimeoutOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3668"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for Toolkit {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4153"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for WindowedOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3606"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for WithTimeoutOptions {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3680"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for __smelt_anon_class_N {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4948"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for bool {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3338"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for fN {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3344"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl IntoSmeltUnknown for iN {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3350"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl PartialEq for SmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2998"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl PartialEq<SmeltUnknown> for fN {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3254"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl PartialEq<fN> for SmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3248"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl PartialOrd for SmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3235"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl PartialOrd<SmeltUnknown> for fN {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3271"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl PartialOrd<fN> for SmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3260"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl SmeltFromUnknown for SmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3374"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl SmeltIntoFN for SmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3422"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl SmeltJsKeyEq for SmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2558"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl SmeltJsStrictEq for SmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2571"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl SmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3143"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl serde::Serialize for SmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3507"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl<'C'de> for SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3524"
     },
     {
       "category": "runtime-prelude",
+      "shape": "impl<T: Clone + IntoSmeltUnknown, const N: usize> From<[T; N]> for SmeltJsSet<T> { fn from(values: [T; N]) -> Self { values.into_iter().collect() } }",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2547"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl<T: Clone + IntoSmeltUnknown> ::std::iter::FromIterator<T> for SmeltJsSet<T> { fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self { let mut set = Self::new(); set.extend(iter); set } }",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2548"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl<T: Clone + IntoSmeltUnknown> PartialEq for SmeltJsSet<T> { fn eq(&self, other: &Self) -> bool { self.entries.len() == other.entries.len() && self.entries.iter().all(|value| other.contains(value)) } }",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2551"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "impl<T: Clone + IntoSmeltUnknown> SmeltJsSet<T> {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2527"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "imports: Option<SmeltRecord<String, SmeltUnknown>>,",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4180"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "inner_error: SmeltUnknown,",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4875"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "let SmeltUnknown::Number(id) = handle.into_smelt_unknown() else { return; };",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3083"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "let SmeltUnknown::String(haystack) = haystack.into_smelt_unknown() else { return false; };",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3194"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "let mut values = self.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>();",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3446"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "match map.get(field).unwrap_or(SmeltUnknown::Undefined) {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2910"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "object.insert(\"S\".to_owned(), SmeltUnknown::Number(self.match_index as fN));",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4572"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "object.insert(\"S\".to_owned(), SmeltUnknown::Object(SmeltObject::new(groups)));",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4571"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "object.insert(\"S\".to_owned(), SmeltUnknown::String(self.input));",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4573"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "other => { let mut map = ::std::collections::HashMap::new(); map.insert(key, value); *other = SmeltUnknown::Object(SmeltObject::new(map)); }",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2891"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "pub enum SmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2769"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "pub fn includes<T: IntoSmeltUnknown>(&self, needle: T) -> bool {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3184"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "pub fn test<T: IntoSmeltUnknown>(&self, haystack: T) -> bool {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3193"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "pub trait IntoSmeltUnknown {",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3328"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "record.insert(\"S\".to_owned(), SmeltUnknown::Bool(true));",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2877"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "record.insert(\"S\".to_owned(), SmeltUnknown::Number(last_modified.unwrap_or(N.N)));",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2879"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "record.insert(\"S\".to_owned(), SmeltUnknown::String(name));",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2878"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "serde_json::Value::Array(values) => SmeltUnknown::Array(values.into_iter().map(smelt_unknown_from_json_value).collect()),",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3537"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "serde_json::Value::Bool(value) => SmeltUnknown::Bool(value),",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3534"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "serde_json::Value::Null => SmeltUnknown::Null,",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3533"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "serde_json::Value::Number(value) => SmeltUnknown::Number(value.as_fN().unwrap_or_default()),",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3535"
+    },
+    {
+      "category": "runtime-prelude",
+      "shape": "serde_json::Value::Object(values) => SmeltUnknown::Object(SmeltObject::new(values.into_iter().map(|(key, value)| (key, smelt_unknown_from_json_value(value))).collect())),",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3538"
+    },
+    {
+      "category": "runtime-prelude",
       "shape": "serde_json::Value::String(value) => SmeltUnknown::String(value),",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3522"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3536"
     },
     {
       "category": "runtime-prelude",
       "shape": "should_retry: None::<::std::rc::Rc<dyn Fn(SmeltUnknown, fN) -> bool>>,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4266"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4280"
     },
     {
       "category": "runtime-prelude",
       "shape": "should_retry: Option<::std::rc::Rc<dyn Fn(SmeltUnknown, fN) -> bool>>,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4258"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4272"
     },
     {
       "category": "runtime-prelude",
       "shape": "signal: None::<SmeltUnknown>,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4265"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:4279"
     },
     {
       "category": "runtime-prelude",
       "shape": "state: ::std::rc::Rc<::std::cell::RefCell<Option<Result<SmeltUnknown, String>>>>,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2665"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2666"
     },
     {
       "category": "runtime-prelude",
       "shape": "static SMELT_ERASED_FUNCTION_VALUES: ::std::cell::RefCell<::std::collections::HashMap<usize, ::std::rc::Weak<dyn Fn(Vec<SmeltUnknown>) -> Result<SmeltUnknown, Box<dyn std::error::Error>>>>> = ::std::cell::RefCell::new(::std::collections::HashMap::new());",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2844"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2845"
     },
     {
       "category": "runtime-prelude",
       "shape": "trait SmeltUnknownArrayExt {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3450"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:3464"
     },
     {
       "category": "runtime-prelude",
       "shape": "type SmeltPromiseFuture = ::std::pin::Pin<Box<dyn ::std::future::Future<Output = Result<SmeltUnknown, Box<dyn std::error::Error>>>>>;",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2660"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2661"
     },
     {
       "category": "runtime-prelude",
       "shape": "values: ::std::rc::Rc<::std::cell::RefCell<::std::collections::HashMap<String, SmeltUnknown>>>,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2581"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2582"
     },
     {
       "category": "runtime-prelude",
       "shape": "values: Vec<SmeltUnknown>,",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2638"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2639"
     },
     {
       "category": "runtime-prelude",
       "shape": "while let SmeltUnknown::Promise(promise) = current {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2701"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:2702"
     },
     {
       "category": "legitimate-boundary",
       "shape": "SMELT_FN_VALUE.with(|cell| cell.get_or_init(|| SmeltUnknown::Function({ let smelt_callback = ::std::rc::Rc::new(|closure_arg_N: Option<String>| {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5496"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5510"
     },
     {
       "category": "legitimate-boundary",
       "shape": "SMELT_FN_VALUE.with(|cell| cell.get_or_init(|| SmeltUnknown::Function({ let smelt_callback = ::std::rc::Rc::new(|closure_arg_N: String, closure_arg_N: Option<String>| {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5528"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5542"
     },
     {
       "category": "legitimate-boundary",
       "shape": "SMELT_FN_VALUE.with(|cell| cell.get_or_init(|| SmeltUnknown::Function({ let smelt_callback = ::std::rc::Rc::new(|closure_arg_N: fN, closure_arg_N: fN| {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5520"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5534"
     },
     {
       "category": "legitimate-boundary",
       "shape": "SMELT_FN_VALUE.with(|cell| cell.get_or_init(|| SmeltUnknown::Function({ let smelt_callback = ::std::rc::Rc::new(|| {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5472"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5486"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "_smelt_tmp_N = <SmeltJsSet<SmeltUnknown> as SmeltFromUnknown>::smelt_from_unknown((_smelt_tmp_N).into_smelt_unknown());",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_1.rs:327"
     },
     {
       "category": "legitimate-boundary",
@@ -26661,7 +26738,7 @@
       "shape": "impl<T: Clone + Default + IntoSmeltUnknown + SmeltFromUnknown + 'C'",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5664"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5678"
     },
     {
       "category": "legitimate-boundary",
@@ -27110,6 +27187,13 @@
       "occurrences": 1,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/invertBy.rs:31"
+    },
+    {
+      "category": "legitimate-boundary",
+      "shape": "let _smelt_tmp_N: bool = is_set_match(target.clone(), <SmeltJsSet<SmeltUnknown> as SmeltFromUnknown>::smelt_from_unknown((source.clone()).into_smelt_unknown()), &*compare, stack.clone());",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:181"
     },
     {
       "category": "legitimate-boundary",
@@ -27571,7 +27655,7 @@
       "shape": "_smelt_tmp_N = Into::<SmeltList<_>>::into(source.clone().iter().filter(|(key, _)| !matches!(key, SmeltUnknown::Symbol(_))).collect::<Vec<_>>());",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:998"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1004"
     },
     {
       "category": "avoidable-erasure",
@@ -27732,7 +27816,7 @@
       "shape": "_smelt_tmp_N = _smelt_tmp_N.clone().map_or(SmeltUnknown::Undefined, |value| value);",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:179"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:180"
     },
     {
       "category": "avoidable-erasure",
@@ -27848,20 +27932,6 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = matches!(a.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:43"
-    },
-    {
-      "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = matches!(b.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEqualWith.rs:45"
-    },
-    {
-      "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = matches!(closure_arg_N.clone(), SmeltUnknown::String(_));",
       "occurrences": 1,
       "files": 1,
@@ -27893,14 +27963,14 @@
       "shape": "_smelt_tmp_N = matches!(descriptor.clone(), SmeltUnknown::Null);",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:675"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:696"
     },
     {
       "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = matches!(descriptor.clone(), SmeltUnknown::Undefined);",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:676"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:697"
     },
     {
       "category": "avoidable-erasure",
@@ -27963,7 +28033,7 @@
       "shape": "_smelt_tmp_N = matches!(obj.clone(), SmeltUnknown::Array(_));",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:62"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone.rs:63"
     },
     {
       "category": "avoidable-erasure",
@@ -27995,13 +28065,6 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = matches!(source.clone().clone(), SmeltUnknown::Object(value) if value.contains_key(\"S\"));",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:173"
-    },
-    {
-      "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = matches!(tag.clone(), SmeltUnknown::Null);",
       "occurrences": 1,
       "files": 1,
@@ -28019,7 +28082,7 @@
       "shape": "_smelt_tmp_N = matches!(target.clone(), SmeltUnknown::Array(_));",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1056"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1062"
     },
     {
       "category": "avoidable-erasure",
@@ -28061,7 +28124,7 @@
       "shape": "_smelt_tmp_N = matches!(value_to_clone.clone(), SmeltUnknown::Array(_));",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:182"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:183"
     },
     {
       "category": "avoidable-erasure",
@@ -28261,13 +28324,6 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "_smelt_tmp_N = { let smelt_list_id = smelt_list_identity(&(result_N) as *const _ as *const () as usize); let mut values = result_N.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(SmeltArray::with_id(smelt_list_id, values)) };",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/clone_1.rs:341"
-    },
-    {
-      "category": "avoidable-erasure",
       "shape": "_smelt_tmp_N = { let smelt_push_item = provided_args.get({ let len = provided_args.len() as iN; let index = __smelt_update_tmp_N.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone(); args.push(smelt_push_item); args.len() as fN };",
       "occurrences": 1,
       "files": 1,
@@ -28460,70 +28516,70 @@
       "shape": "fn delete(&self, key: SmeltUnknown) -> Option<bool> {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5650"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5664"
     },
     {
       "category": "avoidable-erasure",
       "shape": "fn get(&self, key: SmeltUnknown) -> Option<String> {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5638"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5652"
     },
     {
       "category": "avoidable-erasure",
       "shape": "fn get_a(&self) -> SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5743"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5757"
     },
     {
       "category": "avoidable-erasure",
       "shape": "fn get_b(&self) -> SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5746"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5760"
     },
     {
       "category": "avoidable-erasure",
       "shape": "fn get_this(&self) -> SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5749"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5763"
     },
     {
       "category": "avoidable-erasure",
       "shape": "fn get_value(&self) -> SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5724"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5738"
     },
     {
       "category": "avoidable-erasure",
       "shape": "fn greet(&self) -> SmeltUnknown {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5704"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5718"
     },
     {
       "category": "avoidable-erasure",
       "shape": "fn has(&self, key: SmeltUnknown) -> bool {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5646"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5660"
     },
     {
       "category": "avoidable-erasure",
       "shape": "fn new(inner_error: SmeltUnknown) -> Self {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5765"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5779"
     },
     {
       "category": "avoidable-erasure",
       "shape": "fn set(&self, key: SmeltUnknown, value: String) -> () {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5642"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5656"
     },
     {
       "category": "avoidable-erasure",
@@ -28803,7 +28859,7 @@
       "shape": "let _smelt_tmp_N: Option<SmeltUnknown> = clone_value.clone().clone().map(|smelt_function| (smelt_function)(value_to_clone.clone(), key_to_clone.clone(), object_to_clone.clone(), stack.clone()));",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:164"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:165"
     },
     {
       "category": "avoidable-erasure",
@@ -28873,14 +28929,14 @@
       "shape": "let _smelt_tmp_N: SmeltJsMap<SmeltUnknown, String> = SmeltJsMap::from([]);",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5634"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5648"
     },
     {
       "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: SmeltJsMap<SmeltUnknown, String> = { self.N.borrow_mut().__data__.insert(key.clone(), value.clone()); self.N.borrow_mut().__data__.clone() };",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5643"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5657"
     },
     {
       "category": "avoidable-erasure",
@@ -29538,7 +29594,7 @@
       "shape": "let _smelt_tmp_N: SmeltUnknown = clone_deep_with_impl(match value_to_clone.clone() {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:296"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:316"
     },
     {
       "category": "avoidable-erasure",
@@ -29664,7 +29720,7 @@
       "shape": "let _smelt_tmp_N: SmeltUnknown = object_to_clone.clone().map_or_else(|| target.clone(), |value| value);",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:653"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:674"
     },
     {
       "category": "avoidable-erasure",
@@ -29839,7 +29895,7 @@
       "shape": "let _smelt_tmp_N: bool = is_array_match(SmeltUnknown::Array(_smelt_tmp_N.into()), _smelt_tmp_N, &*compare, stack.clone());",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1140"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1148"
     },
     {
       "category": "avoidable-erasure",
@@ -30004,13 +30060,6 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = is_empty_object({ let mut values = _smelt_tmp_N.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) });",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isEmptyObject_spec.rs:115"
-    },
-    {
-      "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: bool = is_equal_with_impl(a_prop, b_prop, Some(SmeltUnknown::String(prop_key)), a.clone(), b.clone(), Some(_smelt_tmp_N), &*are_values_equal);",
       "occurrences": 1,
       "files": 1,
@@ -30085,13 +30134,6 @@
       "occurrences": 1,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/isError_spec.rs:159"
-    },
-    {
-      "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = is_error_N({ let mut values = _smelt_tmp_N.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) });",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isError_spec.rs:116"
     },
     {
       "category": "avoidable-erasure",
@@ -30368,13 +30410,6 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = is_map_N({ let mut values = _smelt_tmp_N.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) });",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMap_spec.rs:66"
-    },
-    {
-      "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: bool = is_match_with_internal(target.clone(), SmeltUnknown::Object(SmeltObject::from_unknown_record((_smelt_tmp_N).clone())), &*compare, stack.clone(), is_root.clone());",
       "occurrences": 1,
       "files": 1,
@@ -30592,13 +30627,6 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = is_plain_object_N({ let mut values = _smelt_tmp_N.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) });",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isPlainObject_spec.rs:377"
-    },
-    {
-      "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: bool = is_primitive(SmeltUnknown::Bool(false));",
       "occurrences": 1,
       "files": 1,
@@ -30655,13 +30683,6 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = is_primitive({ let mut values = _smelt_tmp_N.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) });",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isPrimitive_spec.rs:97"
-    },
-    {
-      "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: bool = is_promise(SmeltUnknown::Null);",
       "occurrences": 1,
       "files": 1,
@@ -30690,13 +30711,6 @@
     },
     {
       "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = is_promise({ let mut values = _smelt_tmp_N.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) });",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isPromise_spec.rs:78"
-    },
-    {
-      "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: bool = is_prototype(object.clone().clone().map_or(SmeltUnknown::Undefined, |value| value));",
       "occurrences": 1,
       "files": 1,
@@ -30722,13 +30736,6 @@
       "occurrences": 1,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/isRegExp.rs:8"
-    },
-    {
-      "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = is_reg_exp_N({ let mut values = _smelt_tmp_N.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) });",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isRegExp_spec.rs:125"
     },
     {
       "category": "avoidable-erasure",
@@ -30764,13 +30771,6 @@
       "occurrences": 1,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/isSet.rs:8"
-    },
-    {
-      "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = is_set_N({ let mut values = _smelt_tmp_N.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) });",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isSet_spec.rs:13"
     },
     {
       "category": "avoidable-erasure",
@@ -30862,13 +30862,6 @@
       "occurrences": 1,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/transform.rs:34"
-    },
-    {
-      "category": "avoidable-erasure",
-      "shape": "let _smelt_tmp_N: bool = is_typed_array_N({ let mut values = _smelt_tmp_N.clone().into_iter().map(|value| value).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) });",
-      "occurrences": 1,
-      "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isTypedArray_spec.rs:201"
     },
     {
       "category": "avoidable-erasure",
@@ -31050,14 +31043,14 @@
       "shape": "let _smelt_tmp_N: bool = matches!(source.clone(), SmeltUnknown::Null);",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:161"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:162"
     },
     {
       "category": "avoidable-erasure",
       "shape": "let _smelt_tmp_N: bool = matches!(source.clone(), SmeltUnknown::Undefined);",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:162"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:163"
     },
     {
       "category": "avoidable-erasure",
@@ -31190,7 +31183,7 @@
       "shape": "let _smelt_tmp_N: fN = { _smelt_tmp_N.push(::std::rc::Rc::new({ let _smelt_adapted_callback = closure_arg_N.clone(); move || { (_smelt_adapted_callback)(SmeltUnknown::Null); () } })); _smelt_tmp_N.len() as fN };",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5557"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5571"
     },
     {
       "category": "avoidable-erasure",
@@ -31372,7 +31365,7 @@
       "shape": "let cloned: Option<SmeltUnknown> = _smelt_tmp_N;",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:165"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:166"
     },
     {
       "category": "avoidable-erasure",
@@ -31666,7 +31659,7 @@
       "shape": "let mut _smelt_tmp_N: ::std::rc::Rc<dyn Fn(::std::rc::Rc<dyn Fn(SmeltUnknown) -> ()>) -> ()> = ::std::rc::Rc::new({",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5553"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5567"
     },
     {
       "category": "avoidable-erasure",
@@ -31869,7 +31862,7 @@
       "shape": "let mut descriptor: SmeltUnknown;",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:638"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:659"
     },
     {
       "category": "avoidable-erasure",
@@ -32240,7 +32233,7 @@
       "shape": "let mut source_item: SmeltUnknown;",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1028"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1034"
     },
     {
       "category": "avoidable-erasure",
@@ -32254,21 +32247,21 @@
       "shape": "let mut target_item: SmeltUnknown;",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1031"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1037"
     },
     {
       "category": "avoidable-erasure",
       "shape": "let mut this: Self = Bar { a: SmeltUnknown::Null };",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5790"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5804"
     },
     {
       "category": "avoidable-erasure",
       "shape": "let mut this: Self = Foo { a: SmeltUnknown::Null };",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5782"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5796"
     },
     {
       "category": "avoidable-erasure",
@@ -32408,7 +32401,7 @@
       "shape": "let object_to_clone_N: SmeltUnknown = _smelt_tmp_N;",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:654"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:675"
     },
     {
       "category": "avoidable-erasure",
@@ -32835,7 +32828,7 @@
       "shape": "move |closure_arg_N: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ()>| {",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5555"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5569"
     },
     {
       "category": "avoidable-erasure",
@@ -33773,7 +33766,7 @@
       "shape": "result = SmeltUnknown::Array(_smelt_tmp_N.into());",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:185"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:186"
     },
     {
       "category": "avoidable-erasure",
@@ -33829,14 +33822,14 @@
       "shape": "return SmeltUnknown::Number(self.b.clone() as fN);",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5747"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5761"
     },
     {
       "category": "avoidable-erasure",
       "shape": "return SmeltUnknown::Number(self.value.clone() as fN);",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5725"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5739"
     },
     {
       "category": "avoidable-erasure",
@@ -33913,7 +33906,7 @@
       "shape": "source_item = source.get({ let len = source.len() as iN; let index = i.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone();",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1068"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1074"
     },
     {
       "category": "avoidable-erasure",
@@ -33934,14 +33927,14 @@
       "shape": "target_item = _smelt_tmp_N.get({ let len = _smelt_tmp_N.len() as iN; let index = j.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone();",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1083"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/isMatchWith.rs:1089"
     },
     {
       "category": "avoidable-erasure",
       "shape": "this.name = SmeltUnknown::String(\"S\".to_owned());",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5758"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/main.rs:5772"
     },
     {
       "category": "avoidable-erasure",
@@ -33984,6 +33977,13 @@
       "occurrences": 1,
       "files": 1,
       "example": "target/compat-repos/es-toolkit/dist-smelt/src/invert_1.rs:23"
+    },
+    {
+      "category": "avoidable-erasure",
+      "shape": "value_N = _smelt_tmp_N.get({ let len = _smelt_tmp_N.len() as iN; let index = _smelt_tmp_N.clone() as iN; let normalized = if index < N { len + index } else { index }; usize::try_from(normalized).expect(\"S\") }).cloned().unwrap_or(SmeltUnknown::Undefined).clone();",
+      "occurrences": 1,
+      "files": 1,
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:291"
     },
     {
       "category": "avoidable-erasure",
@@ -34102,7 +34102,7 @@
       "shape": "}.clone(), Some(SmeltUnknown::Number(i_N.clone() as fN)), object_to_clone.clone(), stack.clone(), clone_value.clone())?;",
       "occurrences": 1,
       "files": 1,
-      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:311"
+      "example": "target/compat-repos/es-toolkit/dist-smelt/src/cloneDeepWith_1.rs:331"
     }
   ]
 }

--- a/crates/smelt-codegen-rust/src/emitter/call.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call.rs
@@ -1780,6 +1780,30 @@ impl FunctionEmitter<'_> {
             // Any other concrete operand carries no Map identity.
             return Ok("false".to_owned());
         }
+        if class_name == "Set" {
+            // A concrete source `Set` is unconditionally `instanceof Set`. An
+            // erased operand recovers Set identity through the `__smelt_set`
+            // marker its erasure stamps. Mirrors the `Map` arm above.
+            if matches!(self.mir.types.get(value_ty), Some(Type::Set(_))) {
+                return Ok("true".to_owned());
+            }
+            if matches!(
+                self.mir.types.get(value_ty),
+                Some(Type::Unknown | Type::TypeParam { .. } | Type::Union(_) | Type::Optional(_))
+            ) {
+                let value_text = self.operand_text(value)?;
+                if matches!(self.mir.types.get(value_ty), Some(Type::Optional(_))) {
+                    return Ok(format!(
+                        "matches!({value_text}.clone(), Some(SmeltUnknown::Object(value)) if value.contains_key(\"__smelt_set\"))"
+                    ));
+                }
+                return Ok(format!(
+                    "matches!({value_text}.clone(), SmeltUnknown::Object(value) if value.contains_key(\"__smelt_set\"))"
+                ));
+            }
+            // Any other concrete operand carries no Set identity.
+            return Ok("false".to_owned());
+        }
         if class_name == "ArrayBuffer"
             && matches!(
                 self.mir.types.get(value_ty),

--- a/crates/smelt-codegen-rust/src/emitter/coercion.rs
+++ b/crates/smelt-codegen-rust/src/emitter/coercion.rs
@@ -1021,6 +1021,17 @@ impl FunctionEmitter<'_> {
                 self.class_unknown_object_text(&text, self.operand_ty(operand)?)
             }
             Some(Type::Set(item)) => {
+                // A `SmeltJsSet`-backed Set carries JS identity: erase through the
+                // single `IntoSmeltUnknown` adapter, which stamps the `__smelt_set`
+                // marker (and preserves the set's stable object id) so
+                // `isSet`/`instanceof Set`/`Object.prototype.toString` recognize the
+                // erased value and `SmeltFromUnknown` round-trips it. Mirrors the
+                // `SmeltJsMap` erasure. A `HashSet`-backed Set (value-equality
+                // primitives) has no such adapter, so it keeps the bare-array
+                // projection below.
+                if !self.type_is_hash_set_key_safe(*item) {
+                    return Ok(format!("({text}).clone().into_smelt_unknown()"));
+                }
                 let value_wrap = self.erase_value_text("value", *item)?;
                 // A Set erases to an array; like list bindings, the SAME source
                 // Set binding erased twice must compare `===` equal (arrays
@@ -1382,6 +1393,15 @@ impl FunctionEmitter<'_> {
             Some(Type::Class { .. }) if self.is_erased_class_type(ty) => Ok(value_text.to_owned()),
             Some(Type::Class { .. }) => self.class_unknown_object_text(value_text, ty),
             Some(Type::Set(item)) => {
+                // See the sibling `Type::Set` arm above: a `SmeltJsSet`-backed Set
+                // erases through the `__smelt_set` marker adapter; only a
+                // `HashSet`-backed primitive Set falls through to a bare array.
+                if !self.type_is_hash_set_key_safe(*item) {
+                    return Ok(format!(
+                        "({}).clone().into_smelt_unknown()",
+                        value.parenthesized_if_needed()
+                    ));
+                }
                 let value_wrap = self.erase_value_text("value", *item)?;
                 Ok(format!(
                     "{{ let mut values = {}.clone().into_iter().map(|value| {value_wrap}).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) }}",
@@ -1964,18 +1984,18 @@ impl FunctionEmitter<'_> {
             // unaffected.
             Some(Type::List(item)) if self.mir.types.get(*item) == Some(&Type::Unknown) => {
                 Ok(format!(
-                    "{{ let smelt_src = ({text}).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src {{ value.id }} else {{ smelt_next_object_id() }}; SmeltList::with_id(smelt_id, match smelt_src {{ SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"__smelt_symbol_iterator\") {{ Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) {{ SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"unknown iterator did not return iterable\") }}, _ => panic!(\"unknown is not iterable\") }}, _ => panic!(\"unknown is not iterable\") }}) }}"
+                    "{{ let smelt_src = ({text}).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src {{ value.id }} else {{ smelt_next_object_id() }}; SmeltList::with_id(smelt_id, match smelt_src {{ SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(value) => value.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"__smelt_set\") {{ members.into_vec() }} else {{ match value.get(\"__smelt_symbol_iterator\") {{ Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) {{ SmeltUnknown::Array(values) => values.into_vec(), SmeltUnknown::String(value) => value.chars().map(|ch| SmeltUnknown::String(ch.to_string())).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"unknown iterator did not return iterable\") }}, _ => panic!(\"unknown is not iterable\") }} }}, _ => panic!(\"unknown is not iterable\") }}) }}"
                 ))
             }
             Some(Type::List(item)) if self.mir.types.get(*item) == Some(&Type::String) => {
                 Ok(format!(
-                    "{{ let smelt_src = ({text}).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src {{ value.id }} else {{ smelt_next_object_id() }}; SmeltList::with_id(smelt_id, match smelt_src {{ SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value {{ value }} else {{ value.to_string() }}).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"__smelt_symbol_iterator\") {{ Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) {{ SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value {{ value }} else {{ value.to_string() }}).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"unknown iterator did not return iterable\") }}, _ => panic!(\"unknown is not iterable\") }}, _ => panic!(\"unknown is not iterable\") }}) }}"
+                    "{{ let smelt_src = ({text}).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src {{ value.id }} else {{ smelt_next_object_id() }}; SmeltList::with_id(smelt_id, match smelt_src {{ SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value {{ value }} else {{ value.to_string() }}).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"__smelt_set\") {{ members.into_vec().into_iter().map(|value| if let SmeltUnknown::String(value) = value {{ value }} else {{ value.to_string() }}).collect::<Vec<_>>() }} else {{ match value.get(\"__smelt_symbol_iterator\") {{ Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) {{ SmeltUnknown::Array(values) => values.into_iter().map(|value| if let SmeltUnknown::String(value) = value {{ value }} else {{ value.to_string() }}).collect::<Vec<_>>(), SmeltUnknown::String(value) => value.chars().map(|ch| ch.to_string()).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"unknown iterator did not return iterable\") }}, _ => panic!(\"unknown is not iterable\") }} }}, _ => panic!(\"unknown is not iterable\") }}) }}"
                 ))
             }
             Some(Type::List(item)) => {
                 let item_text = self.extract_value_text("value", *item)?;
                 Ok(format!(
-                    "{{ let smelt_src = ({text}).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src {{ value.id }} else {{ smelt_next_object_id() }}; SmeltList::with_id(smelt_id, match smelt_src {{ SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| {item_text}).collect::<Vec<_>>(), SmeltUnknown::Object(value) => match value.get(\"__smelt_symbol_iterator\") {{ Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) {{ SmeltUnknown::Array(values) => values.into_iter().map(|value| {item_text}).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"unknown iterator did not return array\") }}, _ => panic!(\"unknown is not array\") }}, _ => panic!(\"unknown is not array\") }}) }}"
+                    "{{ let smelt_src = ({text}).clone().into_smelt_unknown(); let smelt_id = if let SmeltUnknown::Array(value) = &smelt_src {{ value.id }} else {{ smelt_next_object_id() }}; SmeltList::with_id(smelt_id, match smelt_src {{ SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), SmeltUnknown::Array(values) => values.into_iter().map(|value| {item_text}).collect::<Vec<_>>(), SmeltUnknown::Object(value) => if let Some(SmeltUnknown::Array(members)) = value.get(\"__smelt_set\") {{ members.into_vec().into_iter().map(|value| {item_text}).collect::<Vec<_>>() }} else {{ match value.get(\"__smelt_symbol_iterator\") {{ Some(SmeltUnknown::Function(iterator)) => match iterator(vec![]).unwrap_or(SmeltUnknown::Null) {{ SmeltUnknown::Array(values) => values.into_iter().map(|value| {item_text}).collect::<Vec<_>>(), SmeltUnknown::Null | SmeltUnknown::Undefined => Vec::new(), _ => panic!(\"unknown iterator did not return array\") }}, _ => panic!(\"unknown is not array\") }} }}, _ => panic!(\"unknown is not array\") }}) }}"
                 ))
             }
             Some(Type::Dict(key, item))
@@ -2119,6 +2139,20 @@ impl FunctionEmitter<'_> {
                     ));
                 }
                 Ok("Default::default()".to_owned())
+            }
+            // A source `Set` recovers through `SmeltJsSet`'s `SmeltFromUnknown`
+            // impl, which round-trips the `__smelt_set` marker (rebuilding members
+            // and the stable id) and tolerantly accepts a bare array. This is the
+            // inverse of the `SmeltJsSet` erasure adapter, so an `unknown -> Set`
+            // cast (e.g. `data as unknown as Set` in a deep-equality walk) recovers
+            // the real members instead of an empty set. Only `SmeltJsSet`-backed
+            // sets have this impl; a `HashSet`-backed primitive set keeps the
+            // `Default::default()` fallback below.
+            Some(Type::Set(item)) if !self.type_is_hash_set_key_safe(*item) => {
+                let target_text = self.type_text_with_impl_trait(target, false)?;
+                Ok(format!(
+                    "<{target_text} as SmeltFromUnknown>::smelt_from_unknown(({text}).into_smelt_unknown())"
+                ))
             }
             Some(Type::Set(_) | Type::Dict(_, _) | Type::Class { .. }) => {
                 Ok("Default::default()".to_owned())

--- a/crates/smelt-codegen-rust/src/emitter/map.rs
+++ b/crates/smelt-codegen-rust/src/emitter/map.rs
@@ -35,12 +35,13 @@ impl FunctionEmitter<'_> {
                     }
                     _ => return Ok("false".to_owned()),
                 };
-                // An erased `Map` (`{ __smelt_map: [...] }`) exposes `size`
-                // through `Map.prototype`, so `"size" in map` is true even though
-                // the marker object has no own `size` field. Mirror the virtual
-                // `.size` synthesized in `smelt_get_object_field`.
+                // An erased `Map` (`{ __smelt_map: [...] }`) or `Set`
+                // (`{ __smelt_set: [...] }`) exposes `size` through its prototype,
+                // so `"size" in value` is true even though the marker object has no
+                // own `size` field. Mirror the virtual `.size` synthesized in
+                // `smelt_get_object_field`.
                 return Ok(format!(
-                    "{{ let smelt_key = {key_value}; match {dict_text}.clone() {{ SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || (values.contains_key(\"__smelt_map\") && smelt_key == \"size\"), SmeltUnknown::Array(values) => smelt_key == \"length\" || smelt_key == \"__smelt_symbol_iterator\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"length\" || smelt_key == \"__smelt_symbol_iterator\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false }} }}"
+                    "{{ let smelt_key = {key_value}; match {dict_text}.clone() {{ SmeltUnknown::Object(values) => values.contains_key(&smelt_key) || ((values.contains_key(\"__smelt_map\") || values.contains_key(\"__smelt_set\")) && smelt_key == \"size\"), SmeltUnknown::Array(values) => smelt_key == \"length\" || smelt_key == \"__smelt_symbol_iterator\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < values.len()), SmeltUnknown::String(value) => smelt_key == \"length\" || smelt_key == \"__smelt_symbol_iterator\" || smelt_key.parse::<usize>().ok().is_some_and(|index| index < value.chars().count()), _ => false }} }}"
                 ));
             }
             return Ok("false".to_owned());

--- a/crates/smelt-codegen-rust/src/lib.rs
+++ b/crates/smelt-codegen-rust/src/lib.rs
@@ -834,13 +834,24 @@ fn emit_source_with_free_function_router(
         // JS-correct container work for every element type that can be erased.
         // Elements are stored in a `Vec` so iteration preserves insertion order
         // like a real JS `Set`.
+        // Carries a stable object `id` — exactly like `SmeltJsMap` — so the
+        // identity a `Set` value has in JavaScript survives the erasure
+        // round-trip: when the set crosses a dynamic boundary
+        // (`IntoSmeltUnknown`) it becomes a marker-bearing `SmeltUnknown::Object`
+        // stamped with `__smelt_set` and its `id`, and un-erasing
+        // (`SmeltFromUnknown`) restores that same `id`. The marker is what lets
+        // `smelt_object_to_string_tag` report `[object Set]` and the
+        // `isSet`/`isEqualWith` runtime probes recognize the value once it is
+        // erased — a plain `SmeltUnknown::Array` cannot carry Set identity, which
+        // is why the marker boundary exists.
         writer.line("#[derive(Clone, Debug)]");
         writer.line("pub struct SmeltJsSet<T> {");
+        writer.line("    id: usize,");
         writer.line("    entries: Vec<T>,");
         writer.line("}");
         writer.blank_line();
         writer.line("impl<T> SmeltJsSet<T> {");
-        writer.line("    fn new() -> Self { Self { entries: Vec::new() } }");
+        writer.line("    fn new() -> Self { Self { id: smelt_next_object_id(), entries: Vec::new() } }");
         writer.line("    fn clear(&mut self) { self.entries.clear(); }");
         writer.line("}");
         writer.blank_line();
@@ -869,7 +880,18 @@ fn emit_source_with_free_function_router(
         writer.line("impl<T> IntoIterator for SmeltJsSet<T> { type Item = T; type IntoIter = ::std::vec::IntoIter<T>; fn into_iter(self) -> Self::IntoIter { self.entries.into_iter() } }");
         writer.line("impl<'smelt_set, T> IntoIterator for &'smelt_set SmeltJsSet<T> { type Item = &'smelt_set T; type IntoIter = ::std::slice::Iter<'smelt_set, T>; fn into_iter(self) -> Self::IntoIter { self.entries.iter() } }");
         writer.line("impl<T: Clone + IntoSmeltUnknown> PartialEq for SmeltJsSet<T> { fn eq(&self, other: &Self) -> bool { self.entries.len() == other.entries.len() && self.entries.iter().all(|value| other.contains(value)) } }");
-        writer.line("impl<T: IntoSmeltUnknown> IntoSmeltUnknown for SmeltJsSet<T> { fn into_smelt_unknown(self) -> SmeltUnknown { let mut values = self.entries.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) } }");
+        // Erase a `Set` to a marker-bearing object: `{ __smelt_set: [members...] }`
+        // stamped with the set's stable `id`. This is the dynamic boundary adapter
+        // — the only place a typed `SmeltJsSet` becomes a shapeless `SmeltUnknown`
+        // — and it preserves both the members and the object identity so
+        // `isSet`/`isEqualWith`/`Object.prototype.toString` work on the erased
+        // value and `SmeltFromUnknown` can restore it losslessly. Mirrors the
+        // `SmeltJsMap` `__smelt_map` adapter. Members are sorted by their stable
+        // erased-hash key — as the pre-marker bare-array erasure did — so that
+        // spreading / iterating an erased Set yields a deterministic order and
+        // structural equality over two sets with the same members (but different
+        // insertion order) still compares equal.
+        writer.line("impl<T: IntoSmeltUnknown + Clone> IntoSmeltUnknown for SmeltJsSet<T> { fn into_smelt_unknown(self) -> SmeltUnknown { let id = self.id; let mut members = self.entries.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>(); members.sort_by_key(smelt_unknown_stable_hash_key); let mut object = ::std::collections::HashMap::new(); object.insert(\"__smelt_set\".to_owned(), SmeltUnknown::Array(SmeltArray::with_id(smelt_next_object_id(), members))); SmeltUnknown::Object(SmeltObject::with_id(id, object)) } }");
         writer.blank_line();
         writer.line("pub trait SmeltJsKeyEq {");
         writer.line("    fn same_js_key(&self, other: &Self) -> bool;");
@@ -1369,6 +1391,30 @@ fn emit_source_with_free_function_router(
         // `unknown`-typed code that probes `value.size` (e.g. `isEmptyish`)
         // correct without materializing the typed `SmeltJsMap`.
         writer.line("    if field == \"size\" && let Some(SmeltUnknown::Array(pairs)) = map.get(\"__smelt_map\") { return SmeltUnknown::Number(pairs.len() as f64); }");
+        // Same synthesis for an erased `Set` (`{ __smelt_set: [members...] }`):
+        // real Sets expose `.size` through `Set.prototype`, absent from the marker
+        // object's own fields, so derive it from the member count.
+        writer.line("    if field == \"size\" && let Some(SmeltUnknown::Array(members)) = map.get(\"__smelt_set\") { return SmeltUnknown::Number(members.len() as f64); }");
+        // Erased `Set` prototype methods. A real Set exposes
+        // `values`/`keys`/`entries`/`has`/`forEach` through `Set.prototype`, which
+        // the `{ __smelt_set: [...] }` marker object does not store as own fields.
+        // Synthesize them so generic `unknown`-typed code that iterates or probes
+        // an erased Set (e.g. `es-toolkit` `isEqualWith`'s `Array.from(a.values())`
+        // membership walk) sees the members instead of `undefined`. Each returns a
+        // fresh closure over a clone of the member array. `values`/`keys` yield the
+        // member array (Set keys equal values); `entries` yields `[value, value]`
+        // pairs; `has` applies SameValueZero (`same_js_key`); `forEach` invokes the
+        // callback with `(value, value, set)` per JS semantics.
+        writer.line("    if let Some(SmeltUnknown::Array(members)) = map.get(\"__smelt_set\") {");
+        writer.line("        let members = members.into_vec();");
+        writer.line("        match field {");
+        writer.line("            \"values\" | \"keys\" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |_args: Vec<SmeltUnknown>| Ok(SmeltUnknown::Array(members.clone().into())))); }");
+        writer.line("            \"entries\" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |_args: Vec<SmeltUnknown>| Ok(SmeltUnknown::Array(members.clone().into_iter().map(|value| SmeltUnknown::Array(vec![value.clone(), value].into())).collect::<Vec<_>>().into())))); }");
+        writer.line("            \"has\" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { let needle = args.into_iter().next().unwrap_or(SmeltUnknown::Undefined); Ok(SmeltUnknown::Bool(members.iter().any(|member| member.same_js_key(&needle)))) })); }");
+        writer.line("            \"forEach\" => { let members = members.clone(); let receiver = SmeltUnknown::Object(map.clone()); return SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { if let Some(SmeltUnknown::Function(callback)) = args.into_iter().next() { for member in members.clone() { callback(vec![member.clone(), member.clone(), receiver.clone()])?; } } Ok(SmeltUnknown::Undefined) })); }");
+        writer.line("            _ => {}");
+        writer.line("        }");
+        writer.line("    }");
         writer.line("    // A missing property reads as JS `undefined`, distinct from an");
         writer.line("    // explicit `null` value (`obj.missing === undefined`, `!== null`).");
         writer.line("    match map.get(field).unwrap_or(SmeltUnknown::Undefined) {");
@@ -2058,6 +2104,15 @@ fn emit_source_with_free_function_router(
         // decodes as string-keyed entries — the "Map and Record share Dict
         // internally" tolerance — and any other value yields an empty map.
         writer.line("impl<K: SmeltFromUnknown + SmeltJsKeyEq + Clone, V: SmeltFromUnknown + Clone> SmeltFromUnknown for SmeltJsMap<K, V> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Object(object) => { if let Some(SmeltUnknown::Array(pairs)) = object.get(\"__smelt_map\") { let mut map = SmeltJsMap { id: object.id, entries: Vec::new() }; for pair in pairs.into_vec() { if let SmeltUnknown::Array(entry) = pair { let mut entry = entry.into_vec().into_iter(); if let (Some(key), Some(value)) = (entry.next(), entry.next()) { map.insert(K::smelt_from_unknown(key), V::smelt_from_unknown(value)); } } } map } else { object.iter().map(|(key, value)| (K::smelt_from_unknown(SmeltUnknown::String(key)), V::smelt_from_unknown(value))).collect() } }, _ => SmeltJsMap::default() } } }");
+        writer.blank_line();
+        // Un-erase a `Set`. A `__smelt_set` marker object restores the original
+        // members (from the members array) and the source `id`, so the erasure
+        // round-trip preserves JS identity — mirrors the `SmeltJsMap` decode. The
+        // bare-`Array` arm is the tolerant back-compat boundary: an erased value
+        // that is a plain array (e.g. produced outside this stage's marker path,
+        // or a genuine dynamic-interop array coerced to a `Set`) still decodes as
+        // set members via SameValueZero insert. Any other value yields an empty set.
+        writer.line("impl<T: SmeltFromUnknown + Clone + IntoSmeltUnknown> SmeltFromUnknown for SmeltJsSet<T> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Object(object) => { if let Some(SmeltUnknown::Array(members)) = object.get(\"__smelt_set\") { let mut set = SmeltJsSet { id: object.id, entries: Vec::new() }; for member in members.into_vec() { set.insert(T::smelt_from_unknown(member)); } set } else { SmeltJsSet::default() } }, SmeltUnknown::Array(members) => { let mut set = SmeltJsSet::new(); for member in members.into_vec() { set.insert(T::smelt_from_unknown(member)); } set }, _ => SmeltJsSet::default() } } }");
         writer.blank_line();
         writer.block("trait SmeltIntoF64", |trait_writer| {
             trait_writer.line("fn smelt_into_f64(self) -> f64;");

--- a/crates/smelt-frontend-ts/src/lowering/guards.rs
+++ b/crates/smelt-frontend-ts/src/lowering/guards.rs
@@ -265,20 +265,16 @@ impl ModuleBuilder<'_> {
 
     /// Return true for builtin targets represented by non-class HIR values today.
     ///
-    /// `Map` is intentionally absent: a source `Map` erases to a marker object
-    /// (`{ __smelt_map: [...] }`), so `value instanceof Map` resolves through
-    /// that marker in `instance_of_text` rather than folding to a constant
-    /// `false`. `Set` stays here because a `Set` erases to a bare array with no
-    /// distinguishing marker, and `Date`/`RegExp` are timestamp/marker values
-    /// whose `instanceof` remains a deliberate `false` fold for erased operands.
+    /// `Map` and `Set` are intentionally absent: each source value erases to a
+    /// marker object (`{ __smelt_map: [...] }` / `{ __smelt_set: [...] }`), so
+    /// `value instanceof Map`/`instanceof Set` resolves through that marker in
+    /// `instance_of_text` rather than folding to a constant `false`. `Date`/`RegExp`
+    /// are timestamp/marker values whose `instanceof` remains a deliberate `false`
+    /// fold for erased operands.
     pub(super) fn instanceof_fold_false_builtin_target(target: &str) -> bool {
         matches!(
             smelt_stdlib::typescript_stdlib_class(target),
-            Some(
-                smelt_stdlib::StdlibClass::Date
-                    | smelt_stdlib::StdlibClass::RegExp
-                    | smelt_stdlib::StdlibClass::Set
-            )
+            Some(smelt_stdlib::StdlibClass::Date | smelt_stdlib::StdlibClass::RegExp)
         )
     }
 
@@ -373,9 +369,11 @@ impl ModuleBuilder<'_> {
                 // `InstanceOf` codegen to `false` instead of aborting the build
                 // (records are never instances of a user-declared class here).
                 // A source `Map` (`JsMap`) is likewise a supported operand: it is
-                // `instanceof Map` and `false` for any other class.
+                // `instanceof Map` and `false` for any other class. A source `Set`
+                // is analogously `instanceof Set` and `false` for any other class.
                 | Type::Dict(..)
-                | Type::JsMap(..),
+                | Type::JsMap(..)
+                | Type::Set(..),
             ) => true,
             Some(Type::Union(items)) => items
                 .iter()

--- a/examples/typescript/end-to-end/27_optional_chains/expected.rs
+++ b/examples/typescript/end-to-end/27_optional_chains/expected.rs
@@ -214,11 +214,12 @@ impl<K: IntoSmeltUnknown + Clone, V: IntoSmeltUnknown + Clone> IntoSmeltUnknown 
 
 #[derive(Clone, Debug)]
 pub struct SmeltJsSet<T> {
+    id: usize,
     entries: Vec<T>,
 }
 
 impl<T> SmeltJsSet<T> {
-    fn new() -> Self { Self { entries: Vec::new() } }
+    fn new() -> Self { Self { id: smelt_next_object_id(), entries: Vec::new() } }
     fn clear(&mut self) { self.entries.clear(); }
 }
 
@@ -247,7 +248,7 @@ impl<T: Clone + IntoSmeltUnknown> ::std::iter::FromIterator<T> for SmeltJsSet<T>
 impl<T> IntoIterator for SmeltJsSet<T> { type Item = T; type IntoIter = ::std::vec::IntoIter<T>; fn into_iter(self) -> Self::IntoIter { self.entries.into_iter() } }
 impl<'smelt_set, T> IntoIterator for &'smelt_set SmeltJsSet<T> { type Item = &'smelt_set T; type IntoIter = ::std::slice::Iter<'smelt_set, T>; fn into_iter(self) -> Self::IntoIter { self.entries.iter() } }
 impl<T: Clone + IntoSmeltUnknown> PartialEq for SmeltJsSet<T> { fn eq(&self, other: &Self) -> bool { self.entries.len() == other.entries.len() && self.entries.iter().all(|value| other.contains(value)) } }
-impl<T: IntoSmeltUnknown> IntoSmeltUnknown for SmeltJsSet<T> { fn into_smelt_unknown(self) -> SmeltUnknown { let mut values = self.entries.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) } }
+impl<T: IntoSmeltUnknown + Clone> IntoSmeltUnknown for SmeltJsSet<T> { fn into_smelt_unknown(self) -> SmeltUnknown { let id = self.id; let mut members = self.entries.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>(); members.sort_by_key(smelt_unknown_stable_hash_key); let mut object = ::std::collections::HashMap::new(); object.insert("__smelt_set".to_owned(), SmeltUnknown::Array(SmeltArray::with_id(smelt_next_object_id(), members))); SmeltUnknown::Object(SmeltObject::with_id(id, object)) } }
 
 pub trait SmeltJsKeyEq {
     fn same_js_key(&self, other: &Self) -> bool;
@@ -504,6 +505,17 @@ fn smelt_index_assign(target: &mut SmeltUnknown, key: String, value: SmeltUnknow
 
 fn smelt_get_object_field(map: &SmeltObject, field: &str) -> SmeltUnknown {
     if field == "size" && let Some(SmeltUnknown::Array(pairs)) = map.get("__smelt_map") { return SmeltUnknown::Number(pairs.len() as f64); }
+    if field == "size" && let Some(SmeltUnknown::Array(members)) = map.get("__smelt_set") { return SmeltUnknown::Number(members.len() as f64); }
+    if let Some(SmeltUnknown::Array(members)) = map.get("__smelt_set") {
+        let members = members.into_vec();
+        match field {
+            "values" | "keys" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |_args: Vec<SmeltUnknown>| Ok(SmeltUnknown::Array(members.clone().into())))); }
+            "entries" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |_args: Vec<SmeltUnknown>| Ok(SmeltUnknown::Array(members.clone().into_iter().map(|value| SmeltUnknown::Array(vec![value.clone(), value].into())).collect::<Vec<_>>().into())))); }
+            "has" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { let needle = args.into_iter().next().unwrap_or(SmeltUnknown::Undefined); Ok(SmeltUnknown::Bool(members.iter().any(|member| member.same_js_key(&needle)))) })); }
+            "forEach" => { let members = members.clone(); let receiver = SmeltUnknown::Object(map.clone()); return SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { if let Some(SmeltUnknown::Function(callback)) = args.into_iter().next() { for member in members.clone() { callback(vec![member.clone(), member.clone(), receiver.clone()])?; } } Ok(SmeltUnknown::Undefined) })); }
+            _ => {}
+        }
+    }
     // A missing property reads as JS `undefined`, distinct from an
     // explicit `null` value (`obj.missing === undefined`, `!== null`).
     match map.get(field).unwrap_or(SmeltUnknown::Undefined) {
@@ -873,6 +885,8 @@ impl<T: SmeltFromUnknown> SmeltFromUnknown for SmeltList<T> { fn smelt_from_unkn
 impl<K: SmeltFromUnknown + Eq + ::std::hash::Hash + Clone, V: SmeltFromUnknown + Clone> SmeltFromUnknown for SmeltRecord<K, V> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Object(object) => SmeltRecord::with_id_from_entries(object.id, object.iter().map(|(key, value)| (K::smelt_from_unknown(SmeltUnknown::String(key)), V::smelt_from_unknown(value)))), _ => SmeltRecord::with_id_from_entries(smelt_next_object_id(), ::std::iter::empty()) } } }
 
 impl<K: SmeltFromUnknown + SmeltJsKeyEq + Clone, V: SmeltFromUnknown + Clone> SmeltFromUnknown for SmeltJsMap<K, V> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Object(object) => { if let Some(SmeltUnknown::Array(pairs)) = object.get("__smelt_map") { let mut map = SmeltJsMap { id: object.id, entries: Vec::new() }; for pair in pairs.into_vec() { if let SmeltUnknown::Array(entry) = pair { let mut entry = entry.into_vec().into_iter(); if let (Some(key), Some(value)) = (entry.next(), entry.next()) { map.insert(K::smelt_from_unknown(key), V::smelt_from_unknown(value)); } } } map } else { object.iter().map(|(key, value)| (K::smelt_from_unknown(SmeltUnknown::String(key)), V::smelt_from_unknown(value))).collect() } }, _ => SmeltJsMap::default() } } }
+
+impl<T: SmeltFromUnknown + Clone + IntoSmeltUnknown> SmeltFromUnknown for SmeltJsSet<T> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Object(object) => { if let Some(SmeltUnknown::Array(members)) = object.get("__smelt_set") { let mut set = SmeltJsSet { id: object.id, entries: Vec::new() }; for member in members.into_vec() { set.insert(T::smelt_from_unknown(member)); } set } else { SmeltJsSet::default() } }, SmeltUnknown::Array(members) => { let mut set = SmeltJsSet::new(); for member in members.into_vec() { set.insert(T::smelt_from_unknown(member)); } set }, _ => SmeltJsSet::default() } } }
 
 trait SmeltIntoF64 {
     fn smelt_into_f64(self) -> f64;

--- a/examples/typescript/end-to-end/29_callable_object/expected.rs
+++ b/examples/typescript/end-to-end/29_callable_object/expected.rs
@@ -242,11 +242,12 @@ impl<K: IntoSmeltUnknown + Clone, V: IntoSmeltUnknown + Clone> IntoSmeltUnknown 
 
 #[derive(Clone, Debug)]
 pub struct SmeltJsSet<T> {
+    id: usize,
     entries: Vec<T>,
 }
 
 impl<T> SmeltJsSet<T> {
-    fn new() -> Self { Self { entries: Vec::new() } }
+    fn new() -> Self { Self { id: smelt_next_object_id(), entries: Vec::new() } }
     fn clear(&mut self) { self.entries.clear(); }
 }
 
@@ -275,7 +276,7 @@ impl<T: Clone + IntoSmeltUnknown> ::std::iter::FromIterator<T> for SmeltJsSet<T>
 impl<T> IntoIterator for SmeltJsSet<T> { type Item = T; type IntoIter = ::std::vec::IntoIter<T>; fn into_iter(self) -> Self::IntoIter { self.entries.into_iter() } }
 impl<'smelt_set, T> IntoIterator for &'smelt_set SmeltJsSet<T> { type Item = &'smelt_set T; type IntoIter = ::std::slice::Iter<'smelt_set, T>; fn into_iter(self) -> Self::IntoIter { self.entries.iter() } }
 impl<T: Clone + IntoSmeltUnknown> PartialEq for SmeltJsSet<T> { fn eq(&self, other: &Self) -> bool { self.entries.len() == other.entries.len() && self.entries.iter().all(|value| other.contains(value)) } }
-impl<T: IntoSmeltUnknown> IntoSmeltUnknown for SmeltJsSet<T> { fn into_smelt_unknown(self) -> SmeltUnknown { let mut values = self.entries.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>(); values.sort_by_key(smelt_unknown_stable_hash_key); SmeltUnknown::Array(values.into()) } }
+impl<T: IntoSmeltUnknown + Clone> IntoSmeltUnknown for SmeltJsSet<T> { fn into_smelt_unknown(self) -> SmeltUnknown { let id = self.id; let mut members = self.entries.into_iter().map(IntoSmeltUnknown::into_smelt_unknown).collect::<Vec<_>>(); members.sort_by_key(smelt_unknown_stable_hash_key); let mut object = ::std::collections::HashMap::new(); object.insert("__smelt_set".to_owned(), SmeltUnknown::Array(SmeltArray::with_id(smelt_next_object_id(), members))); SmeltUnknown::Object(SmeltObject::with_id(id, object)) } }
 
 pub trait SmeltJsKeyEq {
     fn same_js_key(&self, other: &Self) -> bool;
@@ -532,6 +533,17 @@ fn smelt_index_assign(target: &mut SmeltUnknown, key: String, value: SmeltUnknow
 
 fn smelt_get_object_field(map: &SmeltObject, field: &str) -> SmeltUnknown {
     if field == "size" && let Some(SmeltUnknown::Array(pairs)) = map.get("__smelt_map") { return SmeltUnknown::Number(pairs.len() as f64); }
+    if field == "size" && let Some(SmeltUnknown::Array(members)) = map.get("__smelt_set") { return SmeltUnknown::Number(members.len() as f64); }
+    if let Some(SmeltUnknown::Array(members)) = map.get("__smelt_set") {
+        let members = members.into_vec();
+        match field {
+            "values" | "keys" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |_args: Vec<SmeltUnknown>| Ok(SmeltUnknown::Array(members.clone().into())))); }
+            "entries" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |_args: Vec<SmeltUnknown>| Ok(SmeltUnknown::Array(members.clone().into_iter().map(|value| SmeltUnknown::Array(vec![value.clone(), value].into())).collect::<Vec<_>>().into())))); }
+            "has" => { let members = members.clone(); return SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { let needle = args.into_iter().next().unwrap_or(SmeltUnknown::Undefined); Ok(SmeltUnknown::Bool(members.iter().any(|member| member.same_js_key(&needle)))) })); }
+            "forEach" => { let members = members.clone(); let receiver = SmeltUnknown::Object(map.clone()); return SmeltUnknown::Function(::std::rc::Rc::new(move |args: Vec<SmeltUnknown>| { if let Some(SmeltUnknown::Function(callback)) = args.into_iter().next() { for member in members.clone() { callback(vec![member.clone(), member.clone(), receiver.clone()])?; } } Ok(SmeltUnknown::Undefined) })); }
+            _ => {}
+        }
+    }
     // A missing property reads as JS `undefined`, distinct from an
     // explicit `null` value (`obj.missing === undefined`, `!== null`).
     match map.get(field).unwrap_or(SmeltUnknown::Undefined) {
@@ -901,6 +913,8 @@ impl<T: SmeltFromUnknown> SmeltFromUnknown for SmeltList<T> { fn smelt_from_unkn
 impl<K: SmeltFromUnknown + Eq + ::std::hash::Hash + Clone, V: SmeltFromUnknown + Clone> SmeltFromUnknown for SmeltRecord<K, V> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Object(object) => SmeltRecord::with_id_from_entries(object.id, object.iter().map(|(key, value)| (K::smelt_from_unknown(SmeltUnknown::String(key)), V::smelt_from_unknown(value)))), _ => SmeltRecord::with_id_from_entries(smelt_next_object_id(), ::std::iter::empty()) } } }
 
 impl<K: SmeltFromUnknown + SmeltJsKeyEq + Clone, V: SmeltFromUnknown + Clone> SmeltFromUnknown for SmeltJsMap<K, V> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Object(object) => { if let Some(SmeltUnknown::Array(pairs)) = object.get("__smelt_map") { let mut map = SmeltJsMap { id: object.id, entries: Vec::new() }; for pair in pairs.into_vec() { if let SmeltUnknown::Array(entry) = pair { let mut entry = entry.into_vec().into_iter(); if let (Some(key), Some(value)) = (entry.next(), entry.next()) { map.insert(K::smelt_from_unknown(key), V::smelt_from_unknown(value)); } } } map } else { object.iter().map(|(key, value)| (K::smelt_from_unknown(SmeltUnknown::String(key)), V::smelt_from_unknown(value))).collect() } }, _ => SmeltJsMap::default() } } }
+
+impl<T: SmeltFromUnknown + Clone + IntoSmeltUnknown> SmeltFromUnknown for SmeltJsSet<T> { fn smelt_from_unknown(value: SmeltUnknown) -> Self { match value { SmeltUnknown::Object(object) => { if let Some(SmeltUnknown::Array(members)) = object.get("__smelt_set") { let mut set = SmeltJsSet { id: object.id, entries: Vec::new() }; for member in members.into_vec() { set.insert(T::smelt_from_unknown(member)); } set } else { SmeltJsSet::default() } }, SmeltUnknown::Array(members) => { let mut set = SmeltJsSet::new(); for member in members.into_vec() { set.insert(T::smelt_from_unknown(member)); } set }, _ => SmeltJsSet::default() } } }
 
 trait SmeltIntoF64 {
     fn smelt_into_f64(self) -> f64;


### PR DESCRIPTION
Final stage of the Map/Set erased-identity feature (stages 1–2 in PRs #170/#172).

`SmeltJsSet` gains a stable id and now erases to a `{__smelt_set: [members]}` marker object instead of a bare array; `SmeltFromUnknown` restores it (tolerating bare arrays at genuine dynamic boundaries); erased Sets get virtual `.size` plus synthesized `values`/`keys`/`entries`/`has`/`forEach`; `instanceof Set` resolves concretely and via the marker; spread/`Array.from` templates iterate the members; `"size" in` works.

The flip was the flagged riskiest change — three consumer regressions surfaced during regen (isEqual setTag reading empty values, remeda `isDeepEqualSets` getting empty data, remeda `isEmptyish` `"size" in`) and were root-caused and fixed; remeda held **1789/1789**.

Results: `isSet` 1/2 → **2/2** (isMap 2/2 and isEqual baselines unregressed); SmeltUnknown avoidable **−48** (re-snapshotted, exit 0); es-toolkit compiles 0 errors; goldens 9/9 re-blessed; corpus green; zero new clippy findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)