### PR TITLE
feat(frontend-ts): lower String.prototype.includes inside callback bodies

### DIFF
--- a/crates/smelt-frontend-ts/src/lowering/callbacks/closures.rs
+++ b/crates/smelt-frontend-ts/src/lowering/callbacks/closures.rs
@@ -862,6 +862,51 @@ impl ModuleBuilder<'_> {
                     span,
                 }))
             }
+            "includes" if (1..=2).contains(&args.len())
+                && matches!(
+                    self.ctx.krate.types.get(receiver_ty),
+                    Some(Type::String | Type::Unknown | Type::TypeParam { .. })
+                ) =>
+            {
+                // `String.prototype.includes(needle, position?)` inside a callback
+                // body mirrors the direct `string_includes` lowering. The list
+                // receiver arm above already claimed real arrays, so a `String`,
+                // erased (`Unknown`), or type-param receiver here is unambiguously
+                // a string: coerce the receiver and needle to `String` (matching
+                // `callback_coerce_to_string`) and thread the optional numeric
+                // `position` through as `from_index`.
+                let string_ty = self.ctx.krate.types.intern(Type::String);
+                let haystack = Self::callback_coerce_to_string(receiver, string_ty, body, span);
+                let needle = *args.first().ok_or_else(|| {
+                    SmeltError::unsupported(span, "callback string includes requires a needle")
+                })?;
+                let needle = Self::callback_coerce_to_string(needle, string_ty, body, span);
+                let from_index = args.get(1).copied();
+                // `StringContains` always yields a concrete `bool`, so the node
+                // must be typed `Bool` for the emitter to produce a real boolean.
+                // If the surrounding callback body expects an erased/other type
+                // (`ty`), box it back up with a `TypeAssert`, exactly as the
+                // `push`/`slice` arms above do for their concrete results.
+                let bool_ty = self.ctx.krate.types.intern(Type::Bool);
+                let value = body.push_expr(Expr {
+                    kind: ExprKind::StringContains {
+                        haystack,
+                        needle,
+                        from_index,
+                    },
+                    ty: bool_ty,
+                    span,
+                });
+                if ty == bool_ty {
+                    Ok(value)
+                } else {
+                    Ok(body.push_expr(Expr {
+                        kind: ExprKind::TypeAssert { value },
+                        ty,
+                        span,
+                    }))
+                }
+            }
             "indexOf" | "index_of" | "lastIndexOf" | "last_index_of"
                 if args.len() == 1
                     && self.callback_method_receiver_is_list_like(receiver_ty) =>

--- a/crates/smelt-frontend-ts/src/tests/part04_tests.rs
+++ b/crates/smelt-frontend-ts/src/tests/part04_tests.rs
@@ -8282,6 +8282,65 @@ export function scaleAll(xs: number[]): number[] {
 }
 
 #[test]
+fn lowers_string_includes_inside_filter_callback_body() -> Result<(), String> {
+    // `s.includes(sub)` called inside a `.filter()` callback body is a
+    // statically-typed `String.prototype.includes` that the compact callback IR
+    // did not model: only the array-receiver `includes` arm existed, so a string
+    // (or erased) receiver surfaced "callback method `includes` is not lowered
+    // into closure bodies yet". The closure-body path now mirrors the direct
+    // `string_includes` lowering, emitting a `StringContains`. This is the
+    // dominant callback blocker across the quicktype/knip probes.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function withNeedle(words: string[], needle: string): string[] {
+  return words.filter((w) => w.includes(needle));
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate.bodies.iter().any(|body| {
+            body.exprs
+                .iter()
+                .any(|expr| matches!(&expr.kind, ExprKind::StringContains { .. }))
+        }),
+        "string .includes() inside a filter callback body did not lower to StringContains"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
+fn lowers_string_includes_with_position_inside_map_callback_body() -> Result<(), String> {
+    // The optional numeric `position` argument of `String.prototype.includes`
+    // must thread through the callback-body lowering as `from_index`, matching
+    // the direct lowering's second-argument handling.
+    let mut ctx = HirCtx::new();
+    let module_id = lower_ok(
+        ts!(r#"
+export function hasFromOne(words: string[]): boolean[] {
+  return words.map((w) => w.includes("a", 1));
+}
+"#),
+        &mut ctx,
+    )?;
+    let _module = module(&ctx, module_id)?;
+    ensure!(
+        ctx.krate.bodies.iter().any(|body| {
+            body.exprs.iter().any(|expr| matches!(
+                &expr.kind,
+                ExprKind::StringContains { from_index: Some(_), .. }
+            ))
+        }),
+        "string .includes(needle, position) inside a callback body did not carry from_index"
+    );
+    ensure!(smelt_hir::validate(&ctx.krate).is_empty());
+    Ok(())
+}
+
+#[test]
 fn lowers_callback_ternary_with_differing_list_branches() -> Result<(), String> {
     // A `.map` callback ternary whose branches are arrays of different element
     // types (`string[]` vs `number[]`) must reconcile to a single list type


### PR DESCRIPTION
## What

Lowers `String.prototype.includes` when called on the receiver **inside a callback closure body** (e.g. `words.filter(w => w.includes(needle))`).

Until now the callback dispatcher in `closures.rs` only handled `includes` for **array** receivers (via `list_surface_type`). A string, erased (`unknown`), or type-param receiver fell through to the callable-field path and produced:

> callback method \`includes\` is not lowered into closure bodies yet

## Why this one

While checking transpile coverage for quicktype / knip / rxjs (context: #166), this exact blocker was the **single dominant callback-lowering gap** — 14 occurrences, all `includes`, vs. the next-most method at 2:

| Library | `includes` callback blockers |
| --- | ---: |
| knip | 11 |
| quicktype | 3 |
| rxjs | 0 |

The remaining `callback method X` blockers are user-defined class methods (`find_member`, `add_issue`, …) — a separate cross-module-resolution problem, deliberately left out of scope.

## The fix

A new `includes` arm mirroring the direct `string_includes` lowering (`assignability.rs`) and the sibling `startsWith`/`endsWith` callback arm:

- coerces receiver + needle to `String` (the list arm above already claimed real arrays, so a String/`unknown`/type-param receiver here is unambiguously a string);
- threads the optional numeric `position` through as `from_index`;
- emits `StringContains`, **typed `Bool`** (its true result type) and boxed back up with a `TypeAssert` when the surrounding erased callback body expects another type — matching the `push`/`slice` arms. Without the explicit `Bool`+assert, the emitter assigns a Rust `bool` to a `SmeltUnknown` binding and the generated crate fails to compile (caught during end-to-end verification).

## Verification

- `cargo test -p smelt-frontend-ts` — 926 pass, 0 fail (incl. 2 new regression tests: string receiver + optional-position `from_index`).
- End-to-end: the generated Rust crate for a `filter(w => w.includes(x))` repro (concrete string, erased receiver, and 2-arg position forms) **compiles clean** with `cargo check`.
- Blocker re-scan across the three source trees: `includes` callback blocker **14 → 0**; files lowering clean in isolation: quicktype 163→166, knip 421→423.

## Scope notes

- No net `SmeltUnknown` change — `StringContains` yields a concrete `bool`; the pre-existing erased-callback boxing is unchanged.
- `cargo clippy --lib` reports 5 pre-existing nursery-lint errors in `new_expr.rs`/`stdlib.rs`/`closures.rs:1296` that also fail on `main` (verified by stashing) — none in the added code; left untouched.