### PR TITLE
fix(codegen): preserve rejected Error message in Promise executor

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/call.rs
+++ b/crates/smelt-codegen-rust/src/emitter/call.rs
@@ -229,8 +229,18 @@ impl FunctionEmitter<'_> {
                 let resolve_input_text = self.type_text(resolve_input_ty)?;
                 let resolve_value =
                     self.value_at_type_text("value", resolve_input_ty, output_ty)?;
+                // The rejection channel stores a plain `String` message (the
+                // future settles to `Result<_, Box<dyn Error>>`, whose error only
+                // survives as its `to_string()`). `reject(new Error("late"))`
+                // erases the argument to a `SmeltUnknown::Object` Error record, so
+                // a bare `format!("{}", error)` would render Display's
+                // "[object Object]" and a downstream `catch (e) { e.message }`
+                // would observe that instead of "late". Extract the object's
+                // `message` field (present on erased `Error` values) before
+                // falling back to string coercion, mirroring how `throw`/`catch`
+                // lowering reconstructs the message field.
                 Ok(format!(
-                    "{{ let smelt_promise_result: ::std::rc::Rc<::std::cell::RefCell<Option<Result<{output_text}, Box<dyn std::error::Error>>>>> = ::std::rc::Rc::new(::std::cell::RefCell::new(None)); let smelt_resolve_result = smelt_promise_result.clone(); let smelt_reject_result = smelt_promise_result.clone(); let smelt_resolve: ::std::rc::Rc<dyn Fn({resolve_input_text}) -> ()> = ::std::rc::Rc::new(move |value: {resolve_input_text}| {{ *smelt_resolve_result.borrow_mut() = Some(Ok({resolve_value})); }}); let smelt_reject: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ()> = ::std::rc::Rc::new(move |error: SmeltUnknown| {{ *smelt_reject_result.borrow_mut() = Some(Err(std::io::Error::new(std::io::ErrorKind::Other, format!(\"{{}}\", error)).into())); }}); {executor_call} SmeltFuture::from_future(Box::pin(async move {{ loop {{ if let Some(result) = smelt_promise_result.borrow_mut().take() {{ break result; }} tokio::task::yield_now().await; {sleep_ms}(0.0).await; }} }})) }}",
+                    "{{ let smelt_promise_result: ::std::rc::Rc<::std::cell::RefCell<Option<Result<{output_text}, Box<dyn std::error::Error>>>>> = ::std::rc::Rc::new(::std::cell::RefCell::new(None)); let smelt_resolve_result = smelt_promise_result.clone(); let smelt_reject_result = smelt_promise_result.clone(); let smelt_resolve: ::std::rc::Rc<dyn Fn({resolve_input_text}) -> ()> = ::std::rc::Rc::new(move |value: {resolve_input_text}| {{ *smelt_resolve_result.borrow_mut() = Some(Ok({resolve_value})); }}); let smelt_reject: ::std::rc::Rc<dyn Fn(SmeltUnknown) -> ()> = ::std::rc::Rc::new(move |error: SmeltUnknown| {{ let smelt_reject_message = if let SmeltUnknown::Object(smelt_error_object) = &error {{ match smelt_error_object.get(\"message\") {{ Some(SmeltUnknown::String(smelt_message)) => smelt_message, _ => format!(\"{{}}\", error) }} }} else {{ format!(\"{{}}\", error) }}; *smelt_reject_result.borrow_mut() = Some(Err(std::io::Error::new(std::io::ErrorKind::Other, smelt_reject_message).into())); }}); {executor_call} SmeltFuture::from_future(Box::pin(async move {{ loop {{ if let Some(result) = smelt_promise_result.borrow_mut().take() {{ break result; }} tokio::task::yield_now().await; {sleep_ms}(0.0).await; }} }})) }}",
                     sleep_ms = smelt_stdlib::runtime_symbols::timers::SLEEP_MS,
                 ))
             }

--- a/crates/smelt-codegen-rust/tests/timer_runtime.rs
+++ b/crates/smelt-codegen-rust/tests/timer_runtime.rs
@@ -193,3 +193,29 @@ test("setInterval forwards typed args and clears", async () => {{
     );
     run_timer_fixture(&source, "smelt_timer_runtime_interval");
 }
+
+#[test]
+#[ignore = "slow: emits and runs a generated test crate; run in CI via --ignored"]
+fn promise_executor_reject_preserves_error_message() {
+    // Regression: `reject(new Error("late"))` from a `new Promise` executor must
+    // surface the Error's real `message` to a downstream `catch`, not Display's
+    // "[object Object]". The rejection value erases to a `SmeltUnknown::Object`
+    // Error record; the executor reject path extracts its `message` field before
+    // storing the settled error, so `(e as Error).message` observes "late".
+    let source = r#"
+import { test, expect } from "vitest";
+test("rejected Error message survives to catch", async () => {
+  const promise = new Promise<number>((_resolve, reject) => {
+    reject(new Error("late"));
+  });
+  let message = "";
+  try {
+    await promise;
+  } catch (e: any) {
+    message = e.message;
+  }
+  expect(message).toBe("late");
+});
+"#;
+    run_timer_fixture(source, "smelt_timer_runtime_reject_error_message");
+}


### PR DESCRIPTION
## Problem

The `new Promise((_, reject) => …)` executor's reject path stored `format!("{}", error)` as the rejection message. When rejected with an Error object (`reject(new Error("late"))`), the argument erases to a `SmeltUnknown::Object` Error record whose `Display` renders `"[object Object]"`, so a downstream `catch (e) { e.message }` observed `"[object Object]"` instead of the real message.

## Fix

The reject closure now extracts the object's `message` field before falling back to string coercion, mirroring how `throw`/`catch` lowering carries the message field through the `Box<dyn Error>` round-trip.

## Verification

- Added a runtime regression test `promise_executor_reject_preserves_error_message` in `timer_runtime.rs` that rejects with `new Error("late")` and asserts the caught `e.message` is `"late"`. It passes end-to-end (real emit → `cargo test` on the generated crate).
- `cargo check --lib` / `cargo clippy --lib` clean for the change.
- No golden/snapshot tests capture the executor emission, so no re-blessing needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)