### PR TITLE
fix(codegen): borrow shared-capture arrays immutably on index read

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/place.rs
+++ b/crates/smelt-codegen-rust/src/emitter/place.rs
@@ -303,7 +303,19 @@ impl FunctionEmitter<'_> {
                 }
                 match self.mir.types.get(base_ty) {
                     Some(Type::List(item_ty)) => {
-                        let base_text = self.local_mut_value_text(*base)?;
+                        // A list index READ only ever calls `.get(..).cloned()`
+                        // and `.len()` — both take `&self`, so the receiver must
+                        // borrow the backing `Vec` immutably. Using the mutable
+                        // form here (`borrow_mut()`) is not just unnecessary: when
+                        // `base` is a shared closure capture (`Rc<RefCell<Vec<_>>>`)
+                        // the `.len()` inside the normalized-index argument expands
+                        // to a SECOND `borrow_mut()` of the same cell, so the single
+                        // `arr.get({ ... arr.len() ... })` expression holds two
+                        // simultaneous mutable borrows and panics at runtime with
+                        // "already borrowed". Two simultaneous shared `borrow()`s
+                        // are allowed, matching the sibling string/optional-list
+                        // read arms below.
+                        let base_text = self.local_value_text(*base)?;
                         let index_text =
                             self.normalized_index_text(&format!("{base_text}.len()"), index)?;
                         // JS out-of-bounds element access is `undefined`, not

--- a/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
@@ -225,6 +225,52 @@ function run(): number {
     );
 }
 
+/// A list index READ on a shared-capture array must borrow the backing `Vec`
+/// immutably. The read lowers to `arr.get({ ... arr.len() ... }).cloned()`, so
+/// if the receiver used `borrow_mut()` the `.len()` inside the normalized-index
+/// argument would take a SECOND `borrow_mut()` of the same `Rc<RefCell<Vec<_>>>`
+/// cell within one expression — two simultaneous mutable borrows that panic at
+/// runtime with "already borrowed". Two shared `borrow()`s coexist fine. Here
+/// `order` is forced into a shared capture cell because the nested `record`
+/// closure mutates it while the outer scope reads `order[0]`.
+#[test]
+fn shared_capture_list_index_read_borrows_immutably() {
+    let source = source_for(
+        r"
+function run(): number {
+  let order: number[] = [];
+  function record(): void {
+    order.push(1);
+  }
+  record();
+  return order[0];
+}
+",
+    );
+
+    // `order` is shared through an `Rc<RefCell<Vec<_>>>` capture cell.
+    assert!(
+        source
+            .contains("let smelt_capture_order = ::std::rc::Rc::new(::std::cell::RefCell::new("),
+        "order should be a shared capture cell: {source}"
+    );
+    // The index read must not place two `borrow_mut()` of the same cell in one
+    // expression: the `.get(...)` receiver and the `.len()` argument both read,
+    // so both use `borrow()`.
+    let read_line = source
+        .lines()
+        .find(|line| line.contains(".get(") && line.contains("smelt_capture_order"))
+        .unwrap_or_else(|| panic!("no order index-read line\n{source}"));
+    assert!(
+        !read_line.contains(".borrow_mut()"),
+        "list index read must borrow immutably, not borrow_mut: {read_line}\n{source}"
+    );
+    assert!(
+        read_line.contains("(*smelt_capture_order.borrow())"),
+        "list index read should use borrow(): {read_line}\n{source}"
+    );
+}
+
 #[test]
 fn emits_function_array_some_without_cloning_callbacks() {
     let source = source_for(


### PR DESCRIPTION
## Problem

Indexing a closure-captured array (an `Rc<RefCell<Vec<_>>>` shared capture) generated code that panicked at runtime with `RefCell already borrowed`.

A list index read lowers to `arr.get({ ... arr.len() ... }).cloned()`. The `Type::List` read arm used `local_mut_value_text` for the receiver, so a shared capture expanded to `(*cap.borrow_mut())` for **both** the `.get()` receiver and the `.len()` inside the negative-index normalization argument:

```rust
(*order.borrow_mut()).get({ let len = (*order.borrow_mut()).len() as i64; ... }).cloned()...
```

Two simultaneous `borrow_mut()` of the same cell in one expression → panic.

## Fix

A list index **read** only ever calls `.get(..).cloned()` and `.len()` — both `&self` — so switch the receiver to `local_value_text` (`borrow()`), matching the sibling string-read and optional-list-read arms. Two shared `borrow()`s coexist fine.

## Test

New regression test `shared_capture_list_index_read_borrows_immutably` forces `order` into a shared capture cell (nested closure mutates it, outer reads `order[0]`) and asserts the read line uses `(*smelt_capture_order.borrow())` with no `borrow_mut()`.

- `cargo check --lib --no-default-features` / `cargo clippy --lib --no-default-features`: clean (no new warnings)
- Full codegen suite: **693 passed, 0 failed**

## Follow-up (not in this PR)

The indexed-**write** path (`assignment_place_text`) has the same double-`borrow_mut()` shape for captured-array writes (`order[0] = x`). It genuinely needs `IndexMut`, so it requires computing the length into a temp before the mutable borrow — left as a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)