### PR TITLE
fix(codegen): borrow shared-capture arrays immutably on index write

### DIFF
--- a/crates/smelt-codegen-rust/src/emitter/control_flow.rs
+++ b/crates/smelt-codegen-rust/src/emitter/control_flow.rs
@@ -408,12 +408,25 @@ impl FunctionEmitter<'_> {
                     }
                     Some(Type::List(item)) => {
                         let rendered_value = self.rvalue_text_for_dest(value, *item)?;
-                        let base_text = self.local_mut_value_text(*base)?;
+                        // The receiver is grown and written through `resize` /
+                        // `IndexMut`, which need a mutable borrow, but the two
+                        // length reads (normalizing the index and bounds-checking
+                        // the resize) only need `&self`. Rendering the length
+                        // through the mutable form put two `borrow_mut()` of the
+                        // same shared-capture `RefCell` on the resize line. The
+                        // index is bound to `smelt_assign_index` first, so each
+                        // read borrow drops at its statement boundary before the
+                        // mutable write; splitting the read borrow keeps every
+                        // emitted statement to at most one `borrow_mut()` of the
+                        // cell, avoiding the "already borrowed" panic. Write-path
+                        // twin of the list index READ arm in `place.rs`.
+                        let base_mut = self.local_mut_value_text(*base)?;
+                        let base_read = self.local_value_text(*base)?;
                         let index_text =
-                            self.normalized_index_text(&format!("{base_text}.len()"), index)?;
+                            self.normalized_index_text(&format!("{base_read}.len()"), index)?;
                         let default_value = self.default_value(*item)?;
                         out.push_str(&format!(
-                            "    {{ let smelt_assign_index = {index_text}; if smelt_assign_index >= {base_text}.len() {{ {base_text}.resize(smelt_assign_index.saturating_add(1), {default_value}); }} {base_text}[smelt_assign_index] = {rendered_value}; }}\n"
+                            "    {{ let smelt_assign_index = {index_text}; if smelt_assign_index >= {base_read}.len() {{ {base_mut}.resize(smelt_assign_index.saturating_add(1), {default_value}); }} {base_mut}[smelt_assign_index] = {rendered_value}; }}\n"
                         ));
                         return Ok(());
                     }

--- a/crates/smelt-codegen-rust/src/emitter/place.rs
+++ b/crates/smelt-codegen-rust/src/emitter/place.rs
@@ -650,10 +650,20 @@ impl FunctionEmitter<'_> {
                 let base_ty = self.local_decl(*base)?.ty;
                 match self.mir.types.get(base_ty) {
                     Some(Type::List(_)) => {
-                        let base_text = self.local_mut_value_text(*base)?;
+                        // The indexed lvalue is written through `IndexMut`, which
+                        // needs a mutable borrow, but the length used to normalize
+                        // the index only needs `&self`. Reading the length through
+                        // the mutable form put two `borrow_mut()` of the same
+                        // shared-capture `RefCell` in one expression. The primary
+                        // list-index write (`emit_assign_place_statement`) never
+                        // reaches this arm — it binds the index to a temp first;
+                        // this lvalue is only consumed directly by block-wrapped
+                        // callers such as `collection_clear_text`.
+                        let base_mut = self.local_mut_value_text(*base)?;
+                        let base_read = self.local_value_text(*base)?;
                         let index_text =
-                            self.normalized_index_text(&format!("{base_text}.len()"), index)?;
-                        Ok(format!("{base_text}[{index_text}]"))
+                            self.normalized_index_text(&format!("{base_read}.len()"), index)?;
+                        Ok(format!("{base_mut}[{index_text}]"))
                     }
                     Some(Type::Dict(key_ty, _)) => {
                         let key_text = if self.mir.types.get(*key_ty) == Some(&Type::String) {

--- a/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
+++ b/crates/smelt-codegen-rust/src/tests/part_1_tests.rs
@@ -271,6 +271,60 @@ function run(): number {
     );
 }
 
+/// The write-path twin of [`shared_capture_list_index_read_borrows_immutably`].
+///
+/// `order[i] = v` on a shared-capture array grows and writes the backing `Vec`
+/// through `resize`/`IndexMut` (which need `borrow_mut()`), but the length
+/// reads that normalize and bounds-check the index need only `&self`. The index
+/// is bound to `smelt_assign_index` in its own statement BEFORE the mutable
+/// borrow, and the length reads borrow immutably, so the receiver's
+/// `borrow_mut()` never coexists with a second borrow of the same `RefCell` in
+/// one statement. The regressed form
+/// `(*cap.borrow_mut())[{ ... (*cap.borrow_mut()).len() ... }]` — an inline
+/// index that reborrows the receiver — panics at runtime with "already
+/// borrowed". Here `order` is a shared capture because the nested `put` closure
+/// writes it by index.
+#[test]
+fn shared_capture_list_index_write_precomputes_index_before_borrow_mut() {
+    let source = source_for(
+        r"
+function run(k: number, v: number): number[] {
+  const order: number[] = [0, 0, 0];
+  function put(i: number, value: number): void {
+    order[i] = value;
+  }
+  put(k, v);
+  return order;
+}
+",
+    );
+
+    // `order` is shared through an `Rc<RefCell<Vec<_>>>` capture cell.
+    assert!(
+        source
+            .contains("let smelt_capture_order = ::std::rc::Rc::new(::std::cell::RefCell::new("),
+        "order should be a shared capture cell: {source}"
+    );
+    // The index is precomputed into a temp, so the indexed write borrows the
+    // receiver mutably exactly once with a plain temp subscript.
+    assert!(
+        source.contains("(*smelt_capture_order.borrow_mut())[smelt_assign_index] ="),
+        "list index write must subscript with a precomputed index temp: {source}"
+    );
+    // The length reads that normalize/bounds-check the index borrow immutably.
+    assert!(
+        source.contains("(*smelt_capture_order.borrow()).len()"),
+        "index-length reads must borrow the shared capture immutably: {source}"
+    );
+    // The regressed double-`borrow_mut` signature is an inline index block right
+    // after a mutable borrow: `borrow_mut())[{`. It must not appear anywhere.
+    assert!(
+        !source.contains("borrow_mut())[{"),
+        "list index write must not inline a reborrowing index into the mutable \
+         receiver (two simultaneous borrow_mut of one cell): {source}"
+    );
+}
+
 #[test]
 fn emits_function_array_some_without_cloning_callbacks() {
     let source = source_for(


### PR DESCRIPTION
## Summary

Write-path twin of #181 (`b3617eaa`, the list index **read** fix).

A list index write `order[i] = v` on a shared closure capture (`Rc<RefCell<Vec<_>>>`) grows and writes the backing `Vec` through `resize`/`IndexMut` (which need `borrow_mut()`), but the length reads that normalize and bounds-check the index need only `&self`. Rendering those length reads through the mutable helper placed two `borrow_mut()` of the **same** cell in one statement → runtime panic `RefCell already borrowed`, a crash single-threaded JS never produces.

### Fix
- **`emit_assign_place_statement`** (main list-index write path): the index is already bound to `smelt_assign_index` in its own statement before the mutable write; the two length reads now use an immutable `borrow()`, so every emitted statement holds at most one `borrow_mut()` of the cell.
- **`assignment_place_text`** list-index arm (reached only by block-wrapped callers such as `collection_clear_text`): same immutable-length treatment, for consistency.

For non-shared locals the two helpers (`local_value_text` / `local_mut_value_text`) render identically, so output is byte-identical there — confirmed by unchanged snapshot tests.

## Verification
- `cargo test --lib --no-default-features -p smelt-codegen-rust` → **694 passed, 0 failed**.
- No new clippy warnings in the changed regions.
- End-to-end: compiled and ran a generated program doing a shared-capture read + two writes (one growing the `Vec`) → `[0.0, 5.0, 0.0, 0.0, 0.0, 9.0]`, no panic. The pre-fix inline-index form reproduced the `already borrowed` panic.
- Adds regression test `shared_capture_list_index_write_precomputes_index_before_borrow_mut` (twin of the landed read test).

## Known residual (out of scope)
`assignment_place_text`'s list-index arm still returns a single lvalue, so the exotic Python `matrix[i].clear()`-on-a-shared-capture path would still overlap the `borrow_mut()` receiver with the immutable index borrow. Fully fixing that needs `collection_clear_text` to precompute the index in its block wrapper — deferred as unrelated to the index read/write twin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)